### PR TITLE
reek matcher ignores configuration

### DIFF
--- a/lib/reek/spec/should_reek.rb
+++ b/lib/reek/spec/should_reek.rb
@@ -8,8 +8,11 @@ module Reek
     # An rspec matcher that matches when the +actual+ has code smells.
     #
     class ShouldReek        # :nodoc:
+      def initialize(config_files = [])
+        @config_files = config_files
+      end
       def matches?(actual)
-        @examiner = Examiner.new(actual)
+        @examiner = Examiner.new(actual, @config_files)
         @examiner.smelly?
       end
       def failure_message_for_should
@@ -25,7 +28,7 @@ module Reek
     # Returns +true+ if and only if the target source code contains smells.
     #
     def reek
-      ShouldReek.new
+      ShouldReek.new(Dir['config/*.reek'])
     end
   end
 end

--- a/spec/reek/spec/should_reek_spec.rb
+++ b/spec/reek/spec/should_reek_spec.rb
@@ -66,3 +66,21 @@ describe ShouldReek, 'checking code in a File' do
     @matcher.failure_message_for_should_not.should match('UncommunicativeName')
   end
 end
+
+describe ShouldReek, 'configuration' do
+  before :each do
+    @smelly_file = File.new('spec/samples/redcloth.rb')
+    @clean_file = File.new('spec/samples/three_clean_files/clean_one.rb')
+  end
+  it 'can handle array of config files in ctor' do
+    expect{matcher = ShouldReek.new(Dir['spec/samples/*.reek'])}.to_not raise_error
+  end
+  it 'does not alter result for clean file' do
+    matcher = ShouldReek.new(Dir['spec/samples/*.reek'])
+    matcher.matches?(@clean_file).should be_false
+  end
+  it 'ignores smells according to config' do
+    matcher = ShouldReek.new(Dir['spec/samples/*.reek'])
+    matcher.matches?('def hash() md5 = Digest::MD5.new; end').should be_false
+  end
+end


### PR DESCRIPTION
This will add all *.reek files in the config directory to the Examiner.
