### PR TITLE
Fix old links pointing to Kevin Rutherfords original github reek repository 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ reek [options] [dir_or_source_file]*
 ```
 
 For a full list of command-line options see the Reek
-wiki[http://wiki.github.com/kevinrutherford/reek/command-line-options]
+wiki[http://wiki.github.com/troessner/reek/command-line-options]
 or run
 
 ```bash
@@ -56,7 +56,7 @@ spec/samples/demo/demo.rb -- 6 warnings:
 Reek currently includes checks for some aspects of Control Couple,
 Data Clump, Feature Envy, Large Class, Long Method, Long Parameter List,
 Simulated Polymorphism, Uncommunicative Name and more.
-See the [Reek wiki](http://wiki.github.com/kevinrutherford/reek/code-smells)
+See the [Reek wiki](http://wiki.github.com/troessner/reek/code-smells)
 for up to date details of exactly what Reek will check in your code.
 
 ### Tool Integration
@@ -82,8 +82,8 @@ Learn More
 
 Find out more about Reek from any of the following sources:
 
-* Browse the Reek documentation at [http://wiki.github.com/kevinrutherford/reek](http://wiki.github.com/kevinrutherford/reek)
-* Browse the code or install the latest development version from [http://github.com/kevinrutherford/reek/tree](http://github.com/kevinrutherford/reek/tree)
-* Read the code API at [http://rdoc.info/projects/kevinrutherford/reek](http://rdoc.info/projects/kevinrutherford/reek)
+* Browse the Reek documentation at [http://wiki.github.com/troessner/reek](http://wiki.github.com/troessner/reek)
+* Browse the code or install the latest development version from [http://github.com/troessner/reek/tree](http://github.com/troessner/reek/tree)
+* Read the code API at [http://rdoc.info/projects/troessner/reek](http://rdoc.info/projects/troessner/reek)
 * Follow [@rubyreek](http://twitter.com/rubyreek) on twitter!
 

--- a/bin/reek
+++ b/bin/reek
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #
 # Reek examines Ruby source code for smells.
-# Visit http://wiki.github.com/kevinrutherford/reek for docs etc.
+# Visit http://wiki.github.com/troessner/reek for docs etc.
 #
 # Author: Kevin Rutherford
 #

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -28,7 +28,7 @@ Feature: Reek can be controlled using command-line options
       reek -q lib
       cat my_class.rb | reek
 
-      See http://wiki.github.com/kevinrutherford/reek for detailed help.
+      See http://wiki.github.com/troessner/reek for detailed help.
 
       Common options:
           -h, --help                       Show this message

--- a/lib/reek/cli/command_line.rb
+++ b/lib/reek/cli/command_line.rb
@@ -49,7 +49,7 @@ Examples:
 #{progname} -q lib
 cat my_class.rb | #{progname}
 
-See http://wiki.github.com/kevinrutherford/reek for detailed help.
+See http://wiki.github.com/troessner/reek for detailed help.
 
 EOB
       end

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -18,10 +18,10 @@ and reports any code smells it finds.
                 "Rakefile", "bin/reek", "config/defaults.reek",
                 "{features,lib,spec,tasks}/**/*",
                 "reek.gemspec" ] & `git ls-files -z`.split("\0")
-  s.homepage = %q{http://wiki.github.com/kevinrutherford/reek}
+  s.homepage = %q{http://wiki.github.com/troessner/reek}
   s.post_install_message = %q{
 Thank you for downloading Reek. For info:
-  - see the reek wiki http://wiki.github.com/kevinrutherford/reek
+  - see the reek wiki http://wiki.github.com/troessner/reek
   - follow @rubyreek on twitter
 }
   s.rdoc_options = ["--main", "README.md"]

--- a/tasks/deployment.rake
+++ b/tasks/deployment.rake
@@ -19,7 +19,7 @@ and reports any code smells it finds.
 EOS
   s.author = 'Kevin Rutherford'
   s.email = ['kevin@rutherford-software.com']
-  s.homepage = 'http://wiki.github.com/kevinrutherford/reek'
+  s.homepage = 'http://wiki.github.com/troessner/reek'
   s.rubyforge_project = PROJECT_NAME
   s.add_dependency('ruby_parser', '~> 2.0')
   s.add_dependency('ruby2ruby', '~> 1.2')
@@ -32,7 +32,7 @@ EOS
   s.extra_rdoc_files = s.files.grep(/(txt|rdoc)$/)
   s.post_install_message = '
 Thank you for downloading Reek. For info:
-  - see the reek wiki http://wiki.github.com/kevinrutherford/reek
+  - see the reek wiki http://wiki.github.com/troessner/reek
   - follow @rubyreek on twitter
 '
 end


### PR DESCRIPTION
Kevin Rutherord moved the reek project to Timo Rößner. There have been various links pointing the the old github repository. I fixed the links so that they are now pointing to http://github.com/troessner/reek.

I changed also the link to rdoc.info because there is also no reek project from Kevin Rutherford. This means a new project has to be setup at rdoc.info (actually it seems the page is down ...)
