### PR TITLE
Config deprecated, use RbConfig

### DIFF
--- a/lib/reek/rake/task.rb
+++ b/lib/reek/rake/task.rb
@@ -105,7 +105,7 @@ module Reek
       end
 
       def self.ruby_exe
-        File.join(Config::CONFIG['bindir'], Config::CONFIG['ruby_install_name'])
+        File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
       end
 
       def cmd_words


### PR DESCRIPTION
This fixes a deprecation warning:
`..gems/reek-1.2.12/lib/reek/rake/task.rb:108: Use RbConfig instead of obsolete and deprecated Config.`

RbConfig exists in 1.8.7, deprecation warning was added in 1.9.3.
