### PR TITLE
undefined method `chr' on an instance of String on Rubinius

### DIFF
--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -19,7 +19,7 @@ module Reek
 
       def all_ruby_source_files(paths)
         paths.map do |path|
-          if test 'd', path
+          if test ?d, path
             all_ruby_source_files(Dir["#{path}/**/*.rb"])
           else
             path
@@ -29,7 +29,7 @@ module Reek
 
       def valid_paths
         all_ruby_source_files(@paths).select do |path|
-          if test 'f', path
+          if test ?f, path
             true
           else
             $stderr.puts "Error: No such file - #{path}"


### PR DESCRIPTION
Hello,

I've been trying to use Reek with rubinius head although got:

```
NoMethodError in 'Reek::Spec::ShouldReek checking code in a Dir reports the smells when should_not fails'
undefined method `chr' on an instance of String.
kernel/delta/kernel.rb:81:in `chr (method_missing)'
kernel/common/kernel.rb:230:in `test'
/Users/petr/development/reek/lib/reek/source/source_locator.rb:22:in `all_ruby_source_files'
kernel/bootstrap/array18.rb:18:in `map'
/Users/petr/development/reek/lib/reek/source/source_locator.rb:21:in `all_ruby_source_files'
```

The tests were already failing, so just made a fix in code to get them green. Found the annotation here `http://www.ruby-doc.org/core-1.9.3/Kernel.html#method-i-test` and changed param to integer.

Tested on `rbx-head` and `ruby-1.9.3-p194`.
