### PR TITLE
Fix problem with IrresponsibleModule flagging the same module twice

### DIFF
--- a/lib/reek/smells/irresponsible_module.rb
+++ b/lib/reek/smells/irresponsible_module.rb
@@ -19,6 +19,10 @@ module Reek
         [:class]
       end
 
+      def self.descriptive   # :nodoc:
+        @descriptive ||= {}
+      end
+
       #
       # Checks the given class or module for a descriptive comment.
       #
@@ -26,7 +30,7 @@ module Reek
       #
       def examine_context(ctx)
         comment = Source::CodeComment.new(ctx.exp.comments)
-        return [] if comment.is_descriptive?
+        return [] if self.class.descriptive[ctx.full_name] ||= comment.is_descriptive?
         smell = SmellWarning.new(SMELL_CLASS, ctx.full_name, [ctx.exp.line],
           'has no descriptive comment',
           @source, SMELL_SUBCLASS, {MODULE_NAME_KEY => ctx.exp.text_name})


### PR DESCRIPTION
This branch fixes problems where if reek encounters the same module in two separate files, one documented, and the other not, it will still flag the second occurrence as being irresponsible. This is especially noticeable when you have:

``` ruby
# lib/my_class.rb

# This is an abstract class for my classes
class MyClass
end

# lib/my_class/subclass.rb
class MyClass

  # My subclass that does something neat
  class Subclass

  end
end
```

In the second file `MyClass` would be flagged as irresponsible, when in fact the first time it was encountered it had a proper description.
