### PR TITLE
Updated dependencies to use ruby2ruby 2.0.2 and ruby_parser 3.1.1

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -25,9 +25,9 @@ and reports any code smells it finds.
   s.rubygems_version = %q{1.3.6}
   s.summary = %q{Code smell detector for Ruby}
 
-  s.add_runtime_dependency(%q<ruby_parser>, ["~> 3.0.4"])
+  s.add_runtime_dependency(%q<ruby_parser>, ["~> 3.1.1"])
   s.add_runtime_dependency(%q<sexp_processor>)
-  s.add_runtime_dependency(%q<ruby2ruby>, ["~> 2.0.0"])
+  s.add_runtime_dependency(%q<ruby2ruby>, ["~> 2.0.2"])
 
   s.add_development_dependency(%q<bundler>, ["~> 1.1"])
   s.add_development_dependency(%q<rake>)


### PR DESCRIPTION
ruby2ruby v2.0.2 needs ruby_parser 3.1, which can cause a version conflict if users have 2.0.2 rather than 2.0.1 installed on their machine. Updated dependencies to resolve conflict (and move up to ruby_parser's newest minor version).
