### PR TITLE
Make UnusedParameters correctly handle super

### DIFF
--- a/features/samples.feature
+++ b/features/samples.feature
@@ -61,7 +61,7 @@ Feature: Basic smell detection
     Then the exit status indicates smells
     And it reports:
     """
-    spec/samples/optparse.rb -- 115 warnings:
+    spec/samples/optparse.rb -- 114 warnings:
       OptionParser has at least 42 methods (TooManyMethods)
       OptionParser has the variable name 'f' (UncommunicativeVariableName)
       OptionParser has the variable name 'k' (UncommunicativeVariableName)
@@ -123,7 +123,6 @@ Feature: Basic smell detection
       OptionParser#summarize has 4 parameters (LongParameterList)
       OptionParser#summarize has the variable name 'l' (UncommunicativeVariableName)
       OptionParser#ver has the variable name 'v' (UncommunicativeVariableName)
-      OptionParser::Arguable#initialize has unused parameter '*args' (UnusedParameters)
       OptionParser::CompletingHash#match contains iterators nested 2 deep (NestedIterators)
       OptionParser::Completion#complete calls candidates.size twice (DuplicateMethodCall)
       OptionParser::Completion#complete calls k.id2name twice (DuplicateMethodCall)

--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -21,6 +21,7 @@ module Reek
       #
       def examine_context(method_ctx)
         params = method_ctx.exp.arg_names || []
+        return [] if method_ctx.exp.body.find_node :zsuper
         params.select do |param|
           param = param.to_s.sub(/^\*/, '')
           !["", "_"].include?(param) &&

--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -43,5 +43,17 @@ describe UnusedParameters do
       'def simple(*); end'.should_not smell_of(UnusedParameters)
     end
 
+    it 'should report nothing when using super with implicit arguments' do
+      'def simple(*args); super; end'.should_not smell_of(UnusedParameters)
+    end
+
+    it 'should report something when using super explicitely passing no arguments' do
+      'def simple(*args); super(); end'.should smell_of(UnusedParameters)
+    end
+
+    it 'should report nothing when using super explicitely passing all arguments' do
+      'def simple(*args); super(*args); end'.should_not smell_of(UnusedParameters)
+    end
+
   end
 end


### PR DESCRIPTION
- Report no smell if super is called with implicit arguments
- Possibly report smell if super is called with explicit arguments

Fixes #135.
