### PR TITLE
Support marking unused parameters by prefixing them with _

### DIFF
--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -6,7 +6,7 @@ module Reek
 
     #
     # Methods should use their parameters.
-    # 
+    #
     class UnusedParameters < SmellDetector
 
       SMELL_CLASS = 'ControlCouple'
@@ -14,23 +14,71 @@ module Reek
 
       PARAMETER_KEY = 'parameter'
 
+      EMPTY_ARRAY  = [].freeze
+      EMPTY_STRING = ''.freeze
+      SPLAT_MATCH  = /^\*/.freeze
+      UNDERSCORE   = '_'.freeze
+
       #
       # Checks whether the given method has any unused parameters.
       #
       # @return [Array<SmellWarning>]
       #
       def examine_context(method_ctx)
-        params = method_ctx.exp.arg_names || []
-        return [] if method_ctx.exp.body.find_node :zsuper
-        params.select do |param|
-          param = param.to_s.sub(/^\*/, '')
-          !["", "_"].include?(param) &&
-            !method_ctx.local_nodes(:lvar).include?(Sexp.new(:lvar, param.to_sym))
-        end.map do |param|
-          SmellWarning.new(SMELL_CLASS, method_ctx.full_name, [method_ctx.exp.line],
-                           "has unused parameter '#{param.to_s}'",
-                           @source, SMELL_SUBCLASS, {PARAMETER_KEY => param.to_s})
+        return EMPTY_ARRAY if zsuper?(method_ctx)
+        unused_params(method_ctx).map do |param|
+          smell_warning(method_ctx, param)
         end
+      end
+
+      private
+
+      def unused_params(method_ctx)
+        params(method_ctx).select do |param|
+          param = sanitized_param(param)
+          next if skip?(param)
+          unused?(method_ctx, param)
+        end
+      end
+
+      def skip?(param)
+        anonymous_splat?(param) || marked_unused?(param)
+      end
+
+      def unused?(method_ctx, param)
+        !method_ctx.local_nodes(:lvar).include?(Sexp.new(:lvar, param.to_sym))
+      end
+
+      def params(method_ctx)
+        method_ctx.exp.arg_names || EMPTY_ARRAY
+      end
+
+      def sanitized_param(param)
+        param.to_s.sub(SPLAT_MATCH, EMPTY_STRING)
+      end
+
+      def marked_unused?(param)
+        param.start_with?(UNDERSCORE)
+      end
+
+      def anonymous_splat?(param)
+        param == EMPTY_STRING
+      end
+
+      def zsuper?(method_ctx)
+        method_ctx.exp.body.find_node :zsuper
+      end
+
+      def smell_warning(method_ctx, param)
+        SmellWarning.new(
+          SMELL_CLASS,
+          method_ctx.full_name,
+          [ method_ctx.exp.line ],
+          "has unused parameter '#{param.to_s}'",
+          @source,
+          SMELL_SUBCLASS,
+          { PARAMETER_KEY => param.to_s }
+        )
       end
 
     end

--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -39,6 +39,10 @@ describe UnusedParameters do
       'def simple(_); end'.should_not smell_of(UnusedParameters)
     end
 
+    it 'should report nothing for named parameters prefixed with _' do
+      'def simple(_name); end'.should_not smell_of(UnusedParameters)
+    end
+
     it 'should report nothing for unused anonymous splatted parameter' do
       'def simple(*); end'.should_not smell_of(UnusedParameters)
     end


### PR DESCRIPTION
The mbj/mutant gem also uses this convention, and
there simply are situations where you need to have
the variable named, but you know that it won't be
used.

This commit contains all commits done recently in
troessner/reek#141 squashed into one.
