### PR TITLE
Improve default config creation

### DIFF
--- a/lib/reek/smells/smell_detector.rb
+++ b/lib/reek/smells/smell_detector.rb
@@ -36,7 +36,7 @@ module Reek
         def default_config
           {
             Core::SmellConfiguration::ENABLED_KEY => true,
-            EXCLUDE_KEY => DEFAULT_EXCLUDE_SET
+            EXCLUDE_KEY => DEFAULT_EXCLUDE_SET.dup
           }
         end
       end

--- a/tasks/develop.rake
+++ b/tasks/develop.rake
@@ -12,7 +12,7 @@ directory CONFIG_DIR
 file CONFIG_FILE => [CONFIG_DIR] do
   config = {}
   Reek::Core::SmellRepository.smell_classes.each do |klass|
-    config[klass.name.split(/::/)[-1]] = klass.default_config.dup
+    config[klass.name.split(/::/)[-1]] = klass.default_config
   end
   $stderr.puts "Creating #{CONFIG_FILE}"
   File.open(CONFIG_FILE, 'w') { |f| YAML.dump(config, f) }


### PR DESCRIPTION
The previous solution still produced YAML references in the config file.
By duplicating the DEFAULT_EXCLUDE_SET in each configuration, this is
avoided.
