### PR TITLE
Improve NilCheck specs

### DIFF
--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -43,16 +43,3 @@ Feature: Reek can be controlled using command-line options
           -y, --yaml                       Report smells in YAML format
 
       """
-
-  Scenario: output proper line numbers for nil-check smells if -n flag is passed
-    When I run reek -n spec/samples/not_quite_masked/smelly.rb
-    Then the exit status indicates smells
-    And it should indicate the line numbers of those smells
-    And it reports:
-      """
-      spec/samples/not_quite_masked/smelly.rb -- 4 warnings:
-        [1]:f has the name 'f' (UncommunicativeMethodName)
-        [1]:f has the parameter name 'x' (UncommunicativeParameterName)
-        [1]:f has unused parameter 'x' (UnusedParameters)
-        [2]:f performs a nil-check. (NilCheck)
-      """

--- a/spec/reek/smells/nil_check_spec.rb
+++ b/spec/reek/smells/nil_check_spec.rb
@@ -9,19 +9,31 @@ describe NilCheck do
 
   context 'for methods' do
 
+    it 'reports the correct line number' do
+      src = <<-EOS
+      def nilcheck foo
+        foo.nil?
+      end
+      EOS
+      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      detector = NilCheck.new('source_name')
+      smells = detector.examine_context(ctx)
+      smells[0].lines.should eq [2]
+    end
+
     it 'should report nothing when scope includes no nil checks' do
       'def no_nils; end'.should_not smell_of(NilCheck)
     end
 
     it 'should report when scope uses multiple nil? methods' do
       src = <<-eos
-      def chk_multi_nil(para) 
-        para.nil? 
+      def chk_multi_nil(para)
+        para.nil?
         puts "Hello"
-        \"\".nil? 
+        \"\".nil?
       end
       eos
-      src.should smell_of(NilCheck, 
+      src.should smell_of(NilCheck,
                           {NilCheck => nil}, {NilCheck => nil})
     end
 
@@ -42,16 +54,16 @@ describe NilCheck do
 
     it 'should report when scope uses multiple case-clauses checking nil' do
       src = <<-eos
-      def caseNil 
-        case @inst_var 
-        when nil then puts "Nil" 
+      def case_nil
+        case @inst_var
+        when nil then puts "Nil"
         end
         puts "Hello"
         case @inst_var2
         when 1 then puts 1
         when nil then puts nil.inspect
         end
-      end 
+      end
       eos
       src.should smell_of(NilCheck,
                           {NilCheck => nil}, {NilCheck => nil})


### PR DESCRIPTION
- Move test for correct line number info from cukes to specs
- Clean up trailing spaces and tested method naming
