### PR TITLE
Allow duplicate calls to variable-like methods

### DIFF
--- a/features/samples.feature
+++ b/features/samples.feature
@@ -10,7 +10,7 @@ Feature: Basic smell detection
     Then the exit status indicates smells
     And it reports:
     """
-    spec/samples/inline.rb -- 42 warnings:
+    spec/samples/inline.rb -- 40 warnings:
       File has no descriptive comment (IrresponsibleModule)
       Inline declares the class variable @@directory (ClassVariable)
       Inline declares the class variable @@rootdir (ClassVariable)
@@ -28,7 +28,6 @@ Feature: Basic smell detection
       Inline::C#build calls io.puts 6 times (DuplicateMethodCall)
       Inline::C#build calls io.puts("#endif") twice (DuplicateMethodCall)
       Inline::C#build calls io.puts("#ifdef __cplusplus") twice (DuplicateMethodCall)
-      Inline::C#build calls module_name twice (DuplicateMethodCall)
       Inline::C#build calls warn("Output:\n#{result}") twice (DuplicateMethodCall)
       Inline::C#build contains iterators nested 2 deep (NestedIterators)
       Inline::C#build has approx 60 statements (TooManyStatements)
@@ -41,7 +40,6 @@ Feature: Basic smell detection
       Inline::C#generate calls signature["args"].map twice (DuplicateMethodCall)
       Inline::C#generate has approx 32 statements (TooManyStatements)
       Inline::C#initialize calls stack.empty? twice (DuplicateMethodCall)
-      Inline::C#load calls so_name twice (DuplicateMethodCall)
       Inline::C#module_name has the variable name 'm' (UncommunicativeVariableName)
       Inline::C#module_name has the variable name 'x' (UncommunicativeVariableName)
       Inline::C#parse_signature has approx 15 statements (TooManyStatements)
@@ -61,7 +59,7 @@ Feature: Basic smell detection
     Then the exit status indicates smells
     And it reports:
     """
-    spec/samples/optparse.rb -- 112 warnings:
+    spec/samples/optparse.rb -- 109 warnings:
       OptionParser has at least 42 methods (TooManyMethods)
       OptionParser has the variable name 'f' (UncommunicativeVariableName)
       OptionParser has the variable name 'k' (UncommunicativeVariableName)
@@ -145,9 +143,7 @@ Feature: Basic smell detection
       OptionParser::List#update is controlled by argument sopts (ControlParameter)
       OptionParser::ParseError#set_option is controlled by argument eq (ControlParameter)
       OptionParser::Switch#add_banner has the variable name 's' (UncommunicativeVariableName)
-      OptionParser::Switch#conv_arg calls conv twice (DuplicateMethodCall)
       OptionParser::Switch#initialize has 7 parameters (LongParameterList)
-      OptionParser::Switch#parse_arg calls pattern twice (DuplicateMethodCall)
       OptionParser::Switch#parse_arg calls s.length twice (DuplicateMethodCall)
       OptionParser::Switch#parse_arg has approx 11 statements (TooManyStatements)
       OptionParser::Switch#parse_arg has the variable name 'm' (UncommunicativeVariableName)
@@ -155,7 +151,6 @@ Feature: Basic smell detection
       OptionParser::Switch#self.guess has the variable name 't' (UncommunicativeVariableName)
       OptionParser::Switch#self.incompatible_argument_styles has the parameter name 't' (UncommunicativeParameterName)
       OptionParser::Switch#summarize calls (indent + l) twice (DuplicateMethodCall)
-      OptionParser::Switch#summarize calls arg 4 times (DuplicateMethodCall)
       OptionParser::Switch#summarize calls left.collect twice (DuplicateMethodCall)
       OptionParser::Switch#summarize calls left.collect { |s| s.length }.max twice (DuplicateMethodCall)
       OptionParser::Switch#summarize calls left.collect { |s| s.length }.max.to_i twice (DuplicateMethodCall)

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -73,6 +73,7 @@ module Reek
         result = Hash.new {|hash,key| hash[key] = []}
         method_ctx.local_nodes(:call) do |call_node|
           next if call_node.method_name == :new
+          next if call_node.receiver.nil? && call_node.args.empty?
           result[call_node].push(call_node)
         end
         method_ctx.local_nodes(:attrasgn) do |asgn_node|

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -61,6 +61,22 @@ EOS
     end
   end
 
+  context "with repeated simple method calls" do
+    it 'reports no smell' do
+      src = <<-EOS
+        def foo
+          case bar
+          when :baz
+            :qux
+          else
+            bar
+          end
+        end
+      EOS
+      src.should_not smell_of(DuplicateMethodCall)
+    end
+  end
+
   context 'with repeated attribute assignment' do
     it 'reports repeated assignment' do
       src = 'def double_thing(thing) @other[thing] = true; @other[thing] = true; end'


### PR DESCRIPTION
It is common and recommended to create accessor methods and to extract code into accessor-like methods. The existing implementation of DuplicateMethodCall would force the result of these calls to be assigned to a local variable, if it was needed several times in a method. The resulting code would not be clearer.

This pull request remedies this.

With it, the following code:

``` ruby
  attr_reader :bar

  def foo
    the_bar = bar
    case the_bar
    when :qux
      :baz
    else
      the_bar
    end
  end
```

can be written as:

``` ruby
  attr_reader :bar

  def foo
    case bar
    when :qux
      :baz
    else
      bar
    end
  end
```
