### PR TITLE
Loosen ruby_parser version dependency

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -26,7 +26,7 @@ and reports any code smells it finds.
   s.rubygems_version = %q{1.3.6}
   s.summary = %q{Code smell detector for Ruby}
 
-  s.add_runtime_dependency(%q<ruby_parser>, ["~> 3.1.1"])
+  s.add_runtime_dependency(%q<ruby_parser>, [">= 3.1.1", "~> 3.1"])
   s.add_runtime_dependency(%q<sexp_processor>)
   s.add_runtime_dependency(%q<ruby2ruby>, ["~> 2.0.2"])
 


### PR DESCRIPTION
This PR specifies all 3.x versions of ruby_parser greater that 3.1.1

All the metric_fu dependencies the require ruby_parser are on 3.x, but because reek specifies ~> 3.1.1, it prohibits install of any libraries (such as [roodi](https://rubygems.org/gems/roodi)), that require 3.2 or above.
