### PR TITLE
Added feature to remove extra slash from source path to prevent doubling...

### DIFF
--- a/features/reports/reports.feature
+++ b/features/reports/reports.feature
@@ -81,3 +81,30 @@ Feature: Correctly formatted reports
       | --line-number |
       | -n -q         |
       | -q -n         |
+
+  Scenario Outline: Extra slashes aren't added to directory names
+    When I run reek <args>
+    Then the exit status indicates smells
+    And it reports:
+      """
+      spec/samples/two_smelly_files/dirty_one.rb -- 6 warnings:
+        Dirty has the variable name '@s' (UncommunicativeVariableName)
+        Dirty#a calls @s.title twice (DuplicateMethodCall)
+        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        Dirty#a contains iterators nested 2 deep (NestedIterators)
+        Dirty#a has the name 'a' (UncommunicativeMethodName)
+        Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+      spec/samples/two_smelly_files/dirty_two.rb -- 6 warnings:
+        Dirty has the variable name '@s' (UncommunicativeVariableName)
+        Dirty#a calls @s.title twice (DuplicateMethodCall)
+        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        Dirty#a contains iterators nested 2 deep (NestedIterators)
+        Dirty#a has the name 'a' (UncommunicativeMethodName)
+        Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+      12 total warnings
+      """
+
+    Examples:
+      | args |
+      | spec/samples/two_smelly_files/ |
+      | spec/samples/two_smelly_files  |

--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -8,7 +8,7 @@ module Reek
     #
     class SourceLocator
       def initialize(paths)
-        @paths = paths
+        @paths = paths.map {|path| path.chomp('/') }
       end
 
       def all_sources


### PR DESCRIPTION
... of slash character in report output.

I chose to do a simple chomp rather than removing all `/` with a regex because the chomp is clearer to read and understand and while people may put an extra slash at the end of the path likewise: `reek lib/` if they put `reek lib///` (which is still valid) they probably have made a typing error.

Resolves issue #176.
