### PR TITLE
Added line numbers by default when you run the reek command

### DIFF
--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -39,7 +39,7 @@ Feature: Reek can be controlled using command-line options
 
       Report formatting:
           -q, --[no-]quiet                 Suppress headings for smell-free source files
-          -n, --line-number                Prefix the output with the line number(s).
+          -n, --line-number                Suppress line number(s) from the output.
           -y, --yaml                       Report smells in YAML format
 
       """

--- a/features/command_line_interface/smells_count.feature
+++ b/features/command_line_interface/smells_count.feature
@@ -9,11 +9,11 @@ Feature: Reports total number of code smells
         And it reports:
         """
         spec/samples/not_quite_masked/dirty.rb -- 5 warnings:
-          Dirty has the variable name '@s' (UncommunicativeVariableName)
-          Dirty#a calls @s.title twice (DuplicateMethodCall)
-          Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-          Dirty#a contains iterators nested 2 deep (NestedIterators)
-          Dirty#a has the name 'a' (UncommunicativeMethodName)
+          [7]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+          [6, 8]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+          [6, 8]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+          [7]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+          [5]:Dirty#a has the name 'a' (UncommunicativeMethodName)
         """
 
     Scenario: Output total number of smells when inspecting multiple files
@@ -22,19 +22,19 @@ Feature: Reports total number of code smells
         And it reports:
         """
         spec/samples/two_smelly_files/dirty_one.rb -- 6 warnings:
-          Dirty has the variable name '@s' (UncommunicativeVariableName)
-          Dirty#a calls @s.title twice (DuplicateMethodCall)
-          Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-          Dirty#a contains iterators nested 2 deep (NestedIterators)
-          Dirty#a has the name 'a' (UncommunicativeMethodName)
-          Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+          [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+          [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+          [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+          [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+          [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+          [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
         spec/samples/two_smelly_files/dirty_two.rb -- 6 warnings:
-          Dirty has the variable name '@s' (UncommunicativeVariableName)
-          Dirty#a calls @s.title twice (DuplicateMethodCall)
-          Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-          Dirty#a contains iterators nested 2 deep (NestedIterators)
-          Dirty#a has the name 'a' (UncommunicativeMethodName)
-          Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+          [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+          [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+          [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+          [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+          [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+          [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
         12 total warnings
         """
 

--- a/features/command_line_interface/stdin.feature
+++ b/features/command_line_interface/stdin.feature
@@ -33,9 +33,9 @@ Feature: Reek reads from $stdin when no files are given
     And it reports:
       """
       $stdin -- 3 warnings:
-        Turn has no descriptive comment (IrresponsibleModule)
-        Turn has the variable name '@x' (UncommunicativeVariableName)
-        Turn#y has the name 'y' (UncommunicativeMethodName)
+        [1]:Turn has no descriptive comment (IrresponsibleModule)
+        [1]:Turn has the variable name '@x' (UncommunicativeVariableName)
+        [1]:Turn#y has the name 'y' (UncommunicativeMethodName)
 
       """
 

--- a/features/configuration_files/masking_smells.feature
+++ b/features/configuration_files/masking_smells.feature
@@ -10,12 +10,12 @@ Feature: Masking smells using config files
     And it reports:
       """
       spec/samples/empty_config_file/dirty.rb -- 6 warnings:
-        Dirty has the variable name '@s' (UncommunicativeVariableName)
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
-        Dirty#a has the name 'a' (UncommunicativeMethodName)
-        Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+        [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
       """
 
   Scenario: corrupt config file prevents normal output
@@ -24,13 +24,13 @@ Feature: Masking smells using config files
     And it reports:
       """
       spec/samples/corrupt_config_file/dirty.rb -- 7 warnings:
-        Dirty has no descriptive comment (IrresponsibleModule)
-        Dirty has the variable name '@s' (UncommunicativeVariableName)
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
-        Dirty#a has the name 'a' (UncommunicativeMethodName)
-        Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+        [1]:Dirty has no descriptive comment (IrresponsibleModule)
+        [4]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+        [3, 5]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [3, 5]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [4]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [2]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [4]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
       """
     And it reports an error
 
@@ -40,9 +40,9 @@ Feature: Masking smells using config files
     And it reports:
       """
       spec/samples/masked/dirty.rb -- 3 warnings:
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
       """
     And it reports the error "Error: No such file - no_such_file.rb"
 
@@ -52,9 +52,9 @@ Feature: Masking smells using config files
     And it reports:
       """
       spec/samples/masked/dirty.rb -- 3 warnings:
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
       """
 
   Scenario: non-masked smells are only counted once
@@ -63,11 +63,11 @@ Feature: Masking smells using config files
     And it reports:
       """
       spec/samples/not_quite_masked/dirty.rb -- 5 warnings:
-        Dirty has the variable name '@s' (UncommunicativeVariableName)
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
-        Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [7]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+        [6, 8]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [6, 8]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [7]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [5]:Dirty#a has the name 'a' (UncommunicativeMethodName)
       """
 
   @overrides
@@ -77,8 +77,8 @@ Feature: Masking smells using config files
     And it reports:
       """
       spec/samples/overrides/masked/dirty.rb -- 2 warnings:
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
       """
 
   Scenario: allow masking some calls for duplication smell
@@ -87,8 +87,8 @@ Feature: Masking smells using config files
     And it reports:
       """
       spec/samples/mask_some/dirty.rb -- 2 warnings:
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
       """
 
   @comments
@@ -98,7 +98,7 @@ Feature: Masking smells using config files
     And it reports:
       """
       spec/samples/inline_config/dirty.rb -- 1 warning:
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [5, 7]:Dirty#a calls @s.title twice (DuplicateMethodCall)
       """
 
   Scenario: supports a config file
@@ -107,7 +107,7 @@ Feature: Masking smells using config files
     And it reports:
       """
       spec/samples/masked/dirty.rb -- 1 warning:
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
       """
 
   Scenario: supports multiple config files

--- a/features/rake_task/rake_task.feature
+++ b/features/rake_task/rake_task.feature
@@ -14,9 +14,9 @@ Feature: Reek can be driven through its Task
     And it reports:
       """
       spec/samples/masked/dirty.rb -- 3 warnings:
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
       """
 
   Scenario: name changes the task name
@@ -30,9 +30,9 @@ Feature: Reek can be driven through its Task
     And it reports:
       """
       spec/samples/masked/dirty.rb -- 3 warnings:
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
       """
 
   Scenario: verbose prints the reek command
@@ -58,12 +58,12 @@ Feature: Reek can be driven through its Task
     And it reports:
       """
       spec/samples/empty_config_file/dirty.rb -- 6 warnings:
-        Dirty has the variable name '@s' (UncommunicativeVariableName)
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
-        Dirty#a has the name 'a' (UncommunicativeMethodName)
-        Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+        [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
       """
 
   Scenario: can be configured with config_files

--- a/features/reports/reports.feature
+++ b/features/reports/reports.feature
@@ -10,19 +10,19 @@ Feature: Correctly formatted reports
     And it reports:
       """
       spec/samples/two_smelly_files/dirty_one.rb -- 6 warnings:
-        Dirty has the variable name '@s' (UncommunicativeVariableName)
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
-        Dirty#a has the name 'a' (UncommunicativeMethodName)
-        Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+        [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
       spec/samples/two_smelly_files/dirty_two.rb -- 6 warnings:
-        Dirty has the variable name '@s' (UncommunicativeVariableName)
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
-        Dirty#a has the name 'a' (UncommunicativeMethodName)
-        Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+        [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
       12 total warnings
       """
 
@@ -50,7 +50,7 @@ Feature: Correctly formatted reports
   Scenario Outline: --quiet turns off headers for fragrant files
     When I run reek <option> spec/samples/three_clean_files/*.rb
     Then it succeeds
-    And it reports: 
+    And it reports:
     """
     0 total warnings
     """
@@ -62,17 +62,17 @@ Feature: Correctly formatted reports
       | -n -q   |
       | -q -n   |
 
-  Scenario Outline: --line-number turns on line numbers
+  Scenario Outline: --line-number turns off line numbers
     When I run reek <option> spec/samples/not_quite_masked/dirty.rb
     Then the exit status indicates smells
     And it reports:
       """
       spec/samples/not_quite_masked/dirty.rb -- 5 warnings:
-        [7]:Dirty has the variable name '@s' (UncommunicativeVariableName)
-        [6, 8]:Dirty#a calls @s.title twice (DuplicateMethodCall)
-        [6, 8]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        [7]:Dirty#a contains iterators nested 2 deep (NestedIterators)
-        [5]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        Dirty has the variable name '@s' (UncommunicativeVariableName)
+        Dirty#a calls @s.title twice (DuplicateMethodCall)
+        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        Dirty#a contains iterators nested 2 deep (NestedIterators)
+        Dirty#a has the name 'a' (UncommunicativeMethodName)
       """
 
     Examples:
@@ -88,19 +88,19 @@ Feature: Correctly formatted reports
     And it reports:
       """
       spec/samples/two_smelly_files/dirty_one.rb -- 6 warnings:
-        Dirty has the variable name '@s' (UncommunicativeVariableName)
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
-        Dirty#a has the name 'a' (UncommunicativeMethodName)
-        Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+        [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
       spec/samples/two_smelly_files/dirty_two.rb -- 6 warnings:
-        Dirty has the variable name '@s' (UncommunicativeVariableName)
-        Dirty#a calls @s.title twice (DuplicateMethodCall)
-        Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-        Dirty#a contains iterators nested 2 deep (NestedIterators)
-        Dirty#a has the name 'a' (UncommunicativeMethodName)
-        Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+        [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+        [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+        [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+        [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+        [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
       12 total warnings
       """
 

--- a/features/ruby_api/api.feature
+++ b/features/ruby_api/api.feature
@@ -10,14 +10,14 @@ Feature: The Reek API maintains backwards compatibility
     And it reports:
       """
       spec/samples/demo/demo.rb -- 10 warnings:
-        Dirty has no descriptive comment (IrresponsibleModule)
-        Dirty#awful has 4 parameters (LongParameterList)
-        Dirty#awful has boolean parameter 'log' (BooleanParameter)
-        Dirty#awful has the parameter name 'x' (UncommunicativeParameterName)
-        Dirty#awful has the parameter name 'y' (UncommunicativeParameterName)
-        Dirty#awful has the variable name 'w' (UncommunicativeVariableName)
-        Dirty#awful has unused parameter 'log' (UnusedParameters)
-        Dirty#awful has unused parameter 'offset' (UnusedParameters)
-        Dirty#awful has unused parameter 'x' (UnusedParameters)
-        Dirty#awful has unused parameter 'y' (UnusedParameters)
+        [1]:Dirty has no descriptive comment (IrresponsibleModule)
+        [3]:Dirty#awful has 4 parameters (LongParameterList)
+        [3]:Dirty#awful has boolean parameter 'log' (BooleanParameter)
+        [3]:Dirty#awful has the parameter name 'x' (UncommunicativeParameterName)
+        [3]:Dirty#awful has the parameter name 'y' (UncommunicativeParameterName)
+        [5]:Dirty#awful has the variable name 'w' (UncommunicativeVariableName)
+        [3]:Dirty#awful has unused parameter 'log' (UnusedParameters)
+        [3]:Dirty#awful has unused parameter 'offset' (UnusedParameters)
+        [3]:Dirty#awful has unused parameter 'x' (UnusedParameters)
+        [3]:Dirty#awful has unused parameter 'y' (UnusedParameters)
       """

--- a/features/samples.feature
+++ b/features/samples.feature
@@ -6,7 +6,7 @@ Feature: Basic smell detection
 
   @inline
   Scenario: Correct smells from inline.rb
-    When I run reek spec/samples/inline.rb
+    When I run reek -n spec/samples/inline.rb
     Then the exit status indicates smells
     And it reports:
     """
@@ -54,7 +54,7 @@ Feature: Basic smell detection
     """
 
   Scenario: Correct smells from optparse.rb
-    When I run reek spec/samples/optparse.rb
+    When I run reek -n spec/samples/optparse.rb
     Then the exit status indicates smells
     And it reports:
     """
@@ -171,7 +171,7 @@ Feature: Basic smell detection
     """
 
   Scenario: Correct smells from redcloth.rb
-    When I run reek spec/samples/redcloth.rb
+    When I run reek -n spec/samples/redcloth.rb
     Then the exit status indicates smells
     And it reports:
     """
@@ -285,6 +285,6 @@ Feature: Basic smell detection
     And it reports:
     """
     spec/samples/ruby20_syntax.rb -- 2 warnings:
-      SomeClass has no descriptive comment (IrresponsibleModule)
-      SomeClass#method_with_keyword_arguments has unused parameter 'foo' (UnusedParameters)
+      [1]:SomeClass has no descriptive comment (IrresponsibleModule)
+      [2]:SomeClass#method_with_keyword_arguments has unused parameter 'foo' (UnusedParameters)
     """

--- a/lib/reek/cli/command_line.rb
+++ b/lib/reek/cli/command_line.rb
@@ -18,7 +18,7 @@ module Reek
         @argv = argv
         @parser = OptionParser.new
         @report_class = VerboseReport
-        @warning_formatter = SimpleWarningFormatter
+        @warning_formatter = WarningFormatterWithLineNumbers
         @command_class = ReekCommand
         @config_files = []
         set_options
@@ -75,8 +75,8 @@ EOB
         @parser.on("-q", "--[no-]quiet", "Suppress headings for smell-free source files") do |opt|
           @report_class = opt ? QuietReport : VerboseReport
         end
-        @parser.on("-n", "--line-number", "Prefix the output with the line number(s).") do 
-          @warning_formatter = WarningFormatterWithLineNumbers
+        @parser.on("-n", "--line-number", "Suppress line number(s) from the output.") do 
+          @warning_formatter = SimpleWarningFormatter
         end
         @parser.on("-y", "--yaml", "Report smells in YAML format") do
           @command_class = YamlCommand


### PR DESCRIPTION
This is my proposed fix for issue #170. 

Line numbers are shown by default. The message for the -n --line-number switch has been changed. The cucumber tests have been changed as well and finally this has been achieved by changing the warning formatter in command_line.rb to WarningFormatterWithLineNumbers.
