### PR TITLE
Allow config files to override default config values

### DIFF
--- a/features/configuration_files/overrides_defaults.feature
+++ b/features/configuration_files/overrides_defaults.feature
@@ -1,0 +1,14 @@
+@overrides_defaults
+Feature: Overriding current rules by specifying new configuration values
+  In order to customize Reek to suit my needs
+  As a developer
+  I want to be able to override the default configuration values
+
+  Scenario: List of configuration values is overridden by a lower config file
+    When I run reek spec/samples/overrides_defaults/camel_case.rb
+    Then the exit status indicates smells
+    And it reports:
+      """
+      spec/samples/overrides_defaults/camel_case.rb -- 1 warning:
+        [9]:CamelCase#initialize has the variable name 'x1' (UncommunicativeVariableName)
+      """

--- a/lib/reek/core/smell_configuration.rb
+++ b/lib/reek/core/smell_configuration.rb
@@ -18,8 +18,8 @@ module Reek
         @options = hash
       end
 
-      def adopt!(options)
-        @options.adopt!(options)
+      def merge!(options)
+        @options.merge!(options)
       end
 
       #

--- a/lib/reek/smells/smell_detector.rb
+++ b/lib/reek/smells/smell_detector.rb
@@ -57,7 +57,7 @@ module Reek
       end
 
       def configure_with(config)
-        @config.adopt!(config)
+        @config.merge!(config)
       end
 
       def examine(context)

--- a/spec/reek/core/smell_configuration_spec.rb
+++ b/spec/reek/core/smell_configuration_spec.rb
@@ -8,4 +8,40 @@ describe SmellConfiguration do
     cf = SmellConfiguration.new({})
     cf.value('fred', nil, 27).should == 27
   end
+
+  context 'when overriding default configs' do
+    before(:each) do
+      @base_config = {"enabled"=>true, "exclude"=>[],
+                      "reject"=>[/^.$/, /[0-9]$/, /[A-Z]/],
+                      "accept"=>["_"]}
+      @smell_config = SmellConfiguration.new(@base_config)
+    end
+
+    it { @smell_config.merge!({}).should == @base_config }
+    it { @smell_config.merge!({"enabled"=>true}).should == @base_config }
+    it { @smell_config.merge!({"exclude"=>[]}).should == @base_config }
+    it { @smell_config.merge!({"accept"=>["_"]}).should == @base_config }
+    it { @smell_config.merge!({"reject"=>[/^.$/, /[0-9]$/, /[A-Z]/]}).should == @base_config }
+    it { @smell_config.merge!({"enabled"=>true, "accept"=>["_"]}).should == @base_config }
+
+    it 'should override single values' do
+      @smell_config.merge!({"enabled"=>false}).should == {"enabled"=>false, "exclude"=>[],
+                                                          "reject"=>[/^.$/, /[0-9]$/, /[A-Z]/],
+                                                          "accept"=>["_"]}
+    end
+
+    it 'should override arrays of values' do
+      @smell_config.merge!({"reject"=>[/^.$/, /[3-9]$/]}).should == {"enabled"=>true,
+                                                          "exclude"=>[],
+                                                          "reject"=>[/^.$/, /[3-9]$/],
+                                                          "accept"=>["_"]}
+    end
+
+    it 'should override multiple values' do
+      @smell_config.merge!({"enabled"=>false, "accept"=>[/[A-Z]$/]}).should ==
+                           {"enabled"=>false, "exclude"=>[],
+                            "reject"=>[/^.$/, /[0-9]$/, /[A-Z]/],
+                            "accept"=>[/[A-Z]$/]}
+    end
+  end
 end

--- a/spec/samples/overrides_defaults/camel_case.rb
+++ b/spec/samples/overrides_defaults/camel_case.rb
@@ -1,0 +1,14 @@
+# Class containing camelCase variable which would normally smell
+class CamelCase
+  def initialize
+    # These next two would normally smell if it weren't for overridden config values
+    camelCaseVariable = []
+    anotherOne = 1
+
+    # this next one should still smell
+    x1 = 0
+
+    # this next one should not smell
+    should_not_smell = true
+  end
+end

--- a/spec/samples/overrides_defaults/config.reek
+++ b/spec/samples/overrides_defaults/config.reek
@@ -1,0 +1,6 @@
+---
+UncommunicativeVariableName:
+  enabled: true
+  reject:
+  - !ruby/regexp /^.$/
+  - !ruby/regexp /[0-9]$/


### PR DESCRIPTION
This fixes #154. 

I added a feature file. This test the new sample class camel_case which contains two variables that would normally reek but has been redefined not to. Another variable that should still smell under the new config values and finally a third variable that should not smell (it's a default but it has been overridden to default value).

The only code change was in smell_configuration where I used merge! from the Ruby API. I did not delete the adopt! method in hash_extensions because it was still used elsewhere. 

I also added specs tests to check nothing was broken with the new change.
