### PR TITLE
Issue 204: Improve exception handling - Show a full backtrace unless we are dealing with an invalid options problem.

### DIFF
--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -25,6 +25,7 @@ module Reek
           cmd.execute(self)
         rescue Exception => error
           $stderr.puts "Error: #{error}"
+          $stderr.puts error.backtrace.join("\n") unless OptionParser::InvalidOption == error.class
           @status = STATUS_ERROR
         end
         return @status


### PR DESCRIPTION
Given: https://github.com/troessner/reek/issues/201

this will give the following output:

> >   ( $ (master)) reek /tmp/omg 
> > Error: can't convert Fixnum into String
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:88:in `initialize'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:88:in`new'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:88:in `deserialize'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:104:in`visit_Psych_Nodes_Scalar'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:15:in `visit'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:5:in`accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:20:in `accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:134:in`block in visit_Psych_Nodes_Sequence'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:134:in `each'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:134:in`visit_Psych_Nodes_Sequence'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:15:in `visit'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:5:in`accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:20:in `accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:159:in`block in visit_Psych_Nodes_Mapping'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:159:in `map'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:159:in`visit_Psych_Nodes_Mapping'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:15:in `visit'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:5:in`accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:20:in `accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:134:in`block in visit_Psych_Nodes_Sequence'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:134:in `each'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:134:in`visit_Psych_Nodes_Sequence'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:15:in `visit'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:5:in`accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:20:in `accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:159:in`block in visit_Psych_Nodes_Mapping'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:159:in `map'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:159:in`visit_Psych_Nodes_Mapping'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:15:in `visit'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:5:in`accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:20:in `accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:238:in`visit_Psych_Nodes_Document'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:15:in `visit'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/visitor.rb:5:in`accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/visitors/to_ruby.rb:20:in `accept'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych/nodes/node.rb:35:in`to_ruby'
> > /home/troessner/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/1.9.1/psych.rb:128:in `load'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/source/tree_dresser.rb:56:in`deep_copy'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/source/tree_dresser.rb:53:in `format_ruby'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/smells/duplicate_method_call.rb:82:in`block in calls'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/smells/duplicate_method_call.rb:82:in `each'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/smells/duplicate_method_call.rb:82:in`sort_by'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/smells/duplicate_method_call.rb:82:in `calls'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/smells/duplicate_method_call.rb:56:in`examine_context'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/smells/smell_detector.rb:66:in `examine'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/core/smell_repository.rb:53:in`block in examine'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/core/smell_repository.rb:52:in `each'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/core/smell_repository.rb:52:in`examine'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/core/sniffer.rb:32:in `examine'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/core/code_parser.rb:155:in`check_smells'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/core/code_parser.rb:149:in `block in handle_context'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/core/code_parser.rb:161:in`push'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/core/code_parser.rb:146:in `handle_context'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/core/code_parser.rb:46:in`process_defn'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/core/code_parser.rb:23:in `process'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/core/sniffer.rb:27:in`report_on'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/examiner.rb:34:in `block in initialize'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/source/source_repository.rb:29:in`each'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/source/source_repository.rb:29:in `each'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/examiner.rb:34:in`initialize'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/cli/reek_command.rb:24:in `new'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/cli/reek_command.rb:24:in`block in execute'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/cli/reek_command.rb:23:in `each'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/cli/reek_command.rb:23:in`execute'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/lib/reek/cli/application.rb:25:in `execute'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/gems/reek-1.3.3/bin/reek:11:in`<top (required)>'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/bin/reek:19:in `load'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/bin/reek:19:in`<main>'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/bin/ruby_noexec_wrapper:14:in `eval'
> > /home/troessner/.rvm/gems/ruby-1.9.3-p392@apd/bin/ruby_noexec_wrapper:14:in`<main>'
