### PR TITLE
Force ruby2ruby update.

### DIFF
--- a/features/samples.feature
+++ b/features/samples.feature
@@ -23,7 +23,7 @@ Feature: Basic smell detection
       Inline::C tests $DEBUG at least 7 times (RepeatedConditional)
       Inline::C tests $TESTING at least 4 times (RepeatedConditional)
       Inline::C tests @@type_map.has_key?(type) at least 3 times (RepeatedConditional)
-      Inline::C#build calls $?.!=(0) twice (DuplicateMethodCall)
+      Inline::C#build calls ($? != 0) twice (DuplicateMethodCall)
       Inline::C#build calls Inline.directory 5 times (DuplicateMethodCall)
       Inline::C#build calls io.puts 6 times (DuplicateMethodCall)
       Inline::C#build calls io.puts("#endif") twice (DuplicateMethodCall)

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -28,7 +28,7 @@ and reports any code smells it finds.
 
   s.add_runtime_dependency(%q<ruby_parser>, ["~> 3.2"])
   s.add_runtime_dependency(%q<sexp_processor>)
-  s.add_runtime_dependency(%q<ruby2ruby>, ["~> 2.0.2"])
+  s.add_runtime_dependency(%q<ruby2ruby>, ["~> 2.0.7"])
 
   s.add_development_dependency(%q<bundler>, ["~> 1.1"])
   s.add_development_dependency(%q<rake>)


### PR DESCRIPTION
The maintainers of ruby2ruby updated the gem: https://github.com/seattlerb/ruby2ruby/issues/23

This update fixes 

https://github.com/troessner/reek/issues/213

and

https://github.com/troessner/reek/issues/184
