### PR TITLE
Allow sorting by issue count.

### DIFF
--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -41,6 +41,7 @@ Feature: Reek can be controlled using command-line options
           -q, --[no-]quiet                 Suppress headings for smell-free source files
           -n, --line-number                Suppress line number(s) from the output.
           -s, --single-line                Show IDE-compatible single-line-per-warning
+          -S, --sort-by-issue-count        Sort by "issue-count", listing the "smelliest" files first
           -y, --yaml                       Report smells in YAML format
 
       """

--- a/features/reports/reports.feature
+++ b/features/reports/reports.feature
@@ -31,6 +31,51 @@ Feature: Correctly formatted reports
       | spec/samples/two_smelly_files/*.rb |
       | spec/samples/two_smelly_files      |
 
+  Scenario: Do not sort by default (which means report each file as it is read in)
+    When I run reek spec/samples/three_smelly_files/*.rb
+    Then the exit status indicates smells
+    And it reports:
+      """
+      spec/samples/three_smelly_files/dirty_one.rb -- 2 warnings:
+        [1]:Dirty has no descriptive comment (IrresponsibleModule)
+        [2]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+      spec/samples/three_smelly_files/dirty_three.rb -- 4 warnings:
+        [1]:Dirty has no descriptive comment (IrresponsibleModule)
+        [2]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [3]:Dirty#b has the name 'b' (UncommunicativeMethodName)
+        [4]:Dirty#c has the name 'c' (UncommunicativeMethodName)
+      spec/samples/three_smelly_files/dirty_two.rb -- 3 warnings:
+        [1]:Dirty has no descriptive comment (IrresponsibleModule)
+        [2]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [3]:Dirty#b has the name 'b' (UncommunicativeMethodName)
+      9 total warnings
+      """
+
+  Scenario Outline: Sort by issue count
+    When I run reek <option> spec/samples/three_smelly_files/*.rb
+    Then the exit status indicates smells
+    And it reports:
+      """
+      spec/samples/three_smelly_files/dirty_three.rb -- 4 warnings:
+        [1]:Dirty has no descriptive comment (IrresponsibleModule)
+        [2]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [3]:Dirty#b has the name 'b' (UncommunicativeMethodName)
+        [4]:Dirty#c has the name 'c' (UncommunicativeMethodName)
+      spec/samples/three_smelly_files/dirty_two.rb -- 3 warnings:
+        [1]:Dirty has no descriptive comment (IrresponsibleModule)
+        [2]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+        [3]:Dirty#b has the name 'b' (UncommunicativeMethodName)
+      spec/samples/three_smelly_files/dirty_one.rb -- 2 warnings:
+        [1]:Dirty has no descriptive comment (IrresponsibleModule)
+        [2]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+      9 total warnings
+      """
+
+    Examples:
+      | option                |
+      | -S                    |
+      | --sort-by-issue-count |
+
   Scenario Outline: good files show headers consecutively
     When I run reek <args>
     Then it succeeds

--- a/lib/reek/cli/command_line.rb
+++ b/lib/reek/cli/command_line.rb
@@ -21,6 +21,7 @@ module Reek
         @warning_formatter = WarningFormatterWithLineNumbers
         @command_class = ReekCommand
         @config_files = []
+        @sort_by_issue_count = false
         set_options
       end
 
@@ -81,6 +82,9 @@ EOB
         @parser.on("-s", "--single-line", "Show IDE-compatible single-line-per-warning") do 
           @warning_formatter = SingleLineWarningFormatter
         end        
+        @parser.on("-S", "--sort-by-issue-count", 'Sort by "issue-count", listing the "smelliest" files first') do
+          @sort_by_issue_count = true
+        end
         @parser.on("-y", "--yaml", "Report smells in YAML format") do
           @command_class = YamlCommand
           # SMELL: the args passed to the command should be tested, because it may
@@ -100,7 +104,7 @@ EOB
           if @command_class == YamlCommand
             YamlCommand.create(sources, @config_files)
           else
-            reporter = @report_class.new(@warning_formatter)
+            reporter = @report_class.new(@warning_formatter, ReportFormatter, @sort_by_issue_count)
             ReekCommand.create(sources, reporter, @config_files)
           end
         end

--- a/lib/reek/cli/report.rb
+++ b/lib/reek/cli/report.rb
@@ -34,11 +34,12 @@ module Reek
     end
 
     class Report
-      def initialize(warning_formatter = SimpleWarningFormatter, report_formatter = ReportFormatter)
-        @warning_formatter  = warning_formatter
-        @report_formatter   = report_formatter
-        @examiners          = []
-        @total_smell_count  = 0
+      def initialize(warning_formatter = SimpleWarningFormatter, report_formatter = ReportFormatter, sort_by_issue_count = false)
+        @warning_formatter   = warning_formatter
+        @report_formatter    = report_formatter
+        @examiners           = []
+        @total_smell_count   = 0
+        @sort_by_issue_count = sort_by_issue_count
       end
 
       def add_examiner(examiner)
@@ -48,11 +49,9 @@ module Reek
       end
 
       def show
-        print gather_results.reject(&:empty?).join("\n")
-        if @examiners.size > 1
-          print "\n"
-          print total_smell_count_message
-        end
+        sort_examiners
+        display_summary
+        display_total_smell_count
       end
 
       def has_smells?
@@ -60,6 +59,21 @@ module Reek
       end
 
     private
+
+      def sort_examiners
+        @examiners.sort! {|a, b| b.smells_count <=> a.smells_count } if @sort_by_issue_count
+      end
+
+      def display_summary
+        print gather_results.reject(&:empty?).join("\n")
+      end
+
+      def display_total_smell_count
+        if @examiners.size > 1
+          print "\n"
+          print total_smell_count_message
+        end
+      end
 
       def total_smell_count_message
         "#{@total_smell_count} total warning#{'s' unless @total_smell_count == 1 }\n"

--- a/spec/samples/three_smelly_files/dirty_one.rb
+++ b/spec/samples/three_smelly_files/dirty_one.rb
@@ -1,0 +1,3 @@
+class Dirty
+  def a; end
+end

--- a/spec/samples/three_smelly_files/dirty_three.rb
+++ b/spec/samples/three_smelly_files/dirty_three.rb
@@ -1,0 +1,5 @@
+class Dirty
+  def a; end
+  def b; end
+  def c; end
+end

--- a/spec/samples/three_smelly_files/dirty_two.rb
+++ b/spec/samples/three_smelly_files/dirty_two.rb
@@ -1,0 +1,4 @@
+class Dirty
+  def a; end
+  def b; end
+end


### PR DESCRIPTION
This implements https://github.com/troessner/reek/issues/207

I chose deliberately to start out with the most simple solution at hand.
Which means NOT to support different sorting options ( a la "--sort OPTION), but only one specific option because otherwise this would be a premature optimization par excellence for me - who knows when or if  we offer other options at all?
