### PR TITLE
Separate test dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+language: ruby
+bundler_args: --without local_development
+script: bundle exec rake
 rvm:
   - 1.9.2
   - 1.9.3
@@ -8,4 +11,3 @@ notifications:
     - matijs@matijs.net
     - emil.rehnberg@gmail.com
   irc: "irc.freenode.org#reek"
-

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # The gem's dependencies are specified in the gemspec
 gemspec
+
+group :local_development do
+  gem 'debugger', platforms: [:ruby]
+end

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -36,5 +36,4 @@ and reports any code smells it finds.
   s.add_development_dependency(%q<rspec>, ["~> 2.12"])
   s.add_development_dependency(%q<flay>)
   s.add_development_dependency(%q<yard>)
-  s.add_development_dependency(%q<debugger>)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,11 @@ require 'reek/spec'
 require 'reek/source/tree_dresser'
 
 require 'matchers/smell_of_matcher'
-require 'debugger'
+begin
+  require 'debugger'
+rescue LoadError
+  # Swallow error. Not required to run tests
+end
 
 SAMPLES_DIR = 'spec/samples'
 


### PR DESCRIPTION
Remove from gemspec development deps not required to run tests

per discussion in https://github.com/troessner/reek/pull/226

The gems moved into the Gemfile group :local_development may be
    used while developing the gem, but are not required for running tests.

Now, one can run the tests without installing all the development gems with

``` sh
      bundle --without local_development
      bundle exec rake
```

The choice of `local_development` has to do with how Bundler brings
    evaulates the gemspec development dependencies as both development
    and test dependencies.
