### PR TITLE
Improve line numbers CLI options

### DIFF
--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -39,7 +39,8 @@ Feature: Reek can be controlled using command-line options
 
       Report formatting:
           -q, --[no-]quiet                 Suppress headings for smell-free source files
-          -n, --line-number                Suppress line number(s) from the output.
+          -n, --no-line-numbers            Suppress line numbers from the output
+              --line-numbers               Show line numbers in the output (this is the default)
           -s, --single-line                Show IDE-compatible single-line-per-warning
           -S, --sort-by-issue-count        Sort by "issue-count", listing the "smelliest" files first
           -y, --yaml                       Report smells in YAML format

--- a/features/reports/reports.feature
+++ b/features/reports/reports.feature
@@ -122,11 +122,11 @@ Feature: Correctly formatted reports
       """
 
     Examples:
-      | option        |
-      | -n            |
-      | --line-number |
-      | -n -q         |
-      | -q -n         |
+      | option            |
+      | -n                |
+      | --no-line-numbers |
+      | -n -q             |
+      | -q -n             |
 
   Scenario Outline: --single-line shows filename and one line number
     When I run reek <option> spec/samples/not_quite_masked/dirty.rb

--- a/lib/reek/cli/command_line.rb
+++ b/lib/reek/cli/command_line.rb
@@ -76,8 +76,11 @@ EOB
         @parser.on("-q", "--[no-]quiet", "Suppress headings for smell-free source files") do |opt|
           @report_class = opt ? QuietReport : VerboseReport
         end
-        @parser.on("-n", "--line-number", "Suppress line number(s) from the output.") do 
+        @parser.on("-n", "--no-line-numbers", "Suppress line numbers from the output") do 
           @warning_formatter = SimpleWarningFormatter
+        end
+        @parser.on("--line-numbers", "Show line numbers in the output (this is the default)") do 
+          @warning_formatter = WarningFormatterWithLineNumbers
         end
         @parser.on("-s", "--single-line", "Show IDE-compatible single-line-per-warning") do 
           @warning_formatter = SingleLineWarningFormatter


### PR DESCRIPTION
Alternative to #236.
- Make the long form have the meaning suggested by its name
- Add negative of the long form
- Add a trailing s to the long form, which makes more sense
