### PR TITLE
Improve line numbers CLI options

### DIFF
--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -39,7 +39,7 @@ Feature: Reek can be controlled using command-line options
 
       Report formatting:
           -q, --[no-]quiet                 Suppress headings for smell-free source files
-          -n, --line-number                Suppress line number(s) from the output.
+          -n, --[no-]line-numbers          Show line numbers in the output (this is the default)
           -s, --single-line                Show IDE-compatible single-line-per-warning
           -S, --sort-by-issue-count        Sort by "issue-count", listing the "smelliest" files first
           -y, --yaml                       Report smells in YAML format

--- a/features/reports/reports.feature
+++ b/features/reports/reports.feature
@@ -108,7 +108,7 @@ Feature: Correctly formatted reports
       | -n -q   |
       | -q -n   |
 
-  Scenario Outline: --line-number turns off line numbers
+  Scenario Outline: --no-line-numbers turns off line numbers
     When I run reek <option> spec/samples/not_quite_masked/dirty.rb
     Then the exit status indicates smells
     And it reports:
@@ -122,11 +122,10 @@ Feature: Correctly formatted reports
       """
 
     Examples:
-      | option        |
-      | -n            |
-      | --line-number |
-      | -n -q         |
-      | -q -n         |
+      | option               |
+      | --no-line-numbers    |
+      | --no-line-numbers -q |
+      | -q --no-line-numbers |
 
   Scenario Outline: --single-line shows filename and one line number
     When I run reek <option> spec/samples/not_quite_masked/dirty.rb

--- a/features/samples.feature
+++ b/features/samples.feature
@@ -6,7 +6,7 @@ Feature: Basic smell detection
 
   @inline
   Scenario: Correct smells from inline.rb
-    When I run reek -n spec/samples/inline.rb
+    When I run reek --no-line-numbers spec/samples/inline.rb
     Then the exit status indicates smells
     And it reports:
     """
@@ -53,7 +53,7 @@ Feature: Basic smell detection
     """
 
   Scenario: Correct smells from optparse.rb
-    When I run reek -n spec/samples/optparse.rb
+    When I run reek --no-line-numbers spec/samples/optparse.rb
     Then the exit status indicates smells
     And it reports:
     """
@@ -164,7 +164,7 @@ Feature: Basic smell detection
     """
 
   Scenario: Correct smells from redcloth.rb
-    When I run reek -n spec/samples/redcloth.rb
+    When I run reek --no-line-numbers spec/samples/redcloth.rb
     Then the exit status indicates smells
     And it reports:
     """

--- a/lib/reek/cli/command_line.rb
+++ b/lib/reek/cli/command_line.rb
@@ -76,8 +76,8 @@ EOB
         @parser.on("-q", "--[no-]quiet", "Suppress headings for smell-free source files") do |opt|
           @report_class = opt ? QuietReport : VerboseReport
         end
-        @parser.on("-n", "--line-number", "Suppress line number(s) from the output.") do 
-          @warning_formatter = SimpleWarningFormatter
+        @parser.on("-n", "--[no-]line-numbers", "Show line numbers in the output (this is the default)") do |opt|
+          @warning_formatter = opt ? WarningFormatterWithLineNumbers : SimpleWarningFormatter
         end
         @parser.on("-s", "--single-line", "Show IDE-compatible single-line-per-warning") do 
           @warning_formatter = SingleLineWarningFormatter


### PR DESCRIPTION
Alternative to #235.
- Make the short form have the positive meaning
- Make the long form have the meaning suggested by its name
- Add negative of the long form
- Add a trailing s to the long form, which makes more sense

This means the short form usually does nothing. On the positive side, it has the
meaning it had from the beginning. Also, once command line arguments can be set
in config files, it can be used to override those. We can add a new short option
to be the short version of --no-line-numbers.
