### PR TITLE
Don’t mark kwargs as unused

### DIFF
--- a/features/samples.feature
+++ b/features/samples.feature
@@ -269,12 +269,12 @@ Feature: Basic smell detection
       RedCloth#to_html has approx 24 statements (TooManyStatements)
     """
 
+  @ruby20
   Scenario: Correct smells from a source file with Ruby 2.0 specific syntax
     When I run reek spec/samples/ruby20_syntax.rb
     Then the exit status indicates smells
     And it reports:
     """
-    spec/samples/ruby20_syntax.rb -- 2 warnings:
+    spec/samples/ruby20_syntax.rb -- 1 warning:
       [1]:SomeClass has no descriptive comment (IrresponsibleModule)
-      [2]:SomeClass#method_with_keyword_arguments has unused parameter 'foo' (UnusedParameters)
     """

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -26,7 +26,7 @@ and reports any code smells it finds.
   s.rubygems_version = %q{1.3.6}
   s.summary = %q{Code smell detector for Ruby}
 
-  s.add_runtime_dependency(%q<ruby_parser>, ["~> 3.2"])
+  s.add_runtime_dependency(%q<ruby_parser>, ["~> 3.3"])
   s.add_runtime_dependency(%q<sexp_processor>)
   s.add_runtime_dependency(%q<ruby2ruby>, ["~> 2.0.7"])
 

--- a/spec/samples/ruby20_syntax.rb
+++ b/spec/samples/ruby20_syntax.rb
@@ -1,10 +1,6 @@
 class SomeClass
   def method_with_keyword_arguments(foo: '123')
-    if foo == '123'
-      bar
-    else
-      baz
-    end
+    puts foo
   end
 
   def make_symbol_list


### PR DESCRIPTION
Currently Ruby 2.0’s keyword arguments are always marked as `UnusedParameters`. This is an attempt to fix this. :)
