### PR TITLE
Issue quiet by default

### DIFF
--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -38,7 +38,8 @@ Feature: Reek can be controlled using command-line options
           -c, --config FILE                Read configuration options from FILE
 
       Report formatting:
-          -q, --[no-]quiet                 Suppress headings for smell-free source files
+          -q, --quiet                      Suppress headings for smell-free source files (this is the default)
+          -V, --no-quiet, --verbose        Show headings for smell-free source files
           -n, --no-line-numbers            Suppress line numbers from the output
               --line-numbers               Show line numbers in the output (this is the default)
           -s, --single-line                Show IDE-compatible single-line-per-warning

--- a/features/command_line_interface/smells_count.feature
+++ b/features/command_line_interface/smells_count.feature
@@ -1,50 +1,48 @@
 @smells_count
 Feature: Reports total number of code smells
-    In order to monitor the total number of smells
-    Reek outputs the total number of smells among all files inspected.
+  In order to monitor the total number of smells
+  Reek outputs the total number of smells among all files inspected.
 
-    Scenario: Does not output total number of smells when inspecting single file
-        When I run reek spec/samples/not_quite_masked/dirty.rb
-        Then the exit status indicates smells
-        And it reports:
-        """
-        spec/samples/not_quite_masked/dirty.rb -- 5 warnings:
-          [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
-          [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
-          [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-          [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
-          [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
-        """
+  Scenario: Does not output total number of smells when inspecting single file
+    When I run reek spec/samples/not_quite_masked/dirty.rb
+    Then the exit status indicates smells
+    And it reports:
+    """
+    spec/samples/not_quite_masked/dirty.rb -- 5 warnings:
+      [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+      [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+      [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+      [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+      [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+    """
 
-    Scenario: Output total number of smells when inspecting multiple files
-        When I run reek spec/samples/two_smelly_files
-        Then the exit status indicates smells
-        And it reports:
-        """
-        spec/samples/two_smelly_files/dirty_one.rb -- 6 warnings:
-          [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
-          [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
-          [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-          [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
-          [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
-          [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
-        spec/samples/two_smelly_files/dirty_two.rb -- 6 warnings:
-          [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
-          [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
-          [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
-          [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
-          [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
-          [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
-        12 total warnings
-        """
+  Scenario: Output total number of smells when inspecting multiple files
+    When I run reek spec/samples/two_smelly_files
+    Then the exit status indicates smells
+    And it reports:
+    """
+    spec/samples/two_smelly_files/dirty_one.rb -- 6 warnings:
+      [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+      [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+      [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+      [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+      [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+      [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+    spec/samples/two_smelly_files/dirty_two.rb -- 6 warnings:
+      [5]:Dirty has the variable name '@s' (UncommunicativeVariableName)
+      [4, 6]:Dirty#a calls @s.title twice (DuplicateMethodCall)
+      [4, 6]:Dirty#a calls puts(@s.title) twice (DuplicateMethodCall)
+      [5]:Dirty#a contains iterators nested 2 deep (NestedIterators)
+      [3]:Dirty#a has the name 'a' (UncommunicativeMethodName)
+      [5]:Dirty#a has the variable name 'x' (UncommunicativeVariableName)
+    12 total warnings
+    """
 
-    Scenario: Output total number of smells even if total equals 0
-        When I run reek spec/samples/three_clean_files
-        Then it succeeds
-        And it reports:
-        """
-        spec/samples/three_clean_files/clean_one.rb -- 0 warnings
-        spec/samples/three_clean_files/clean_three.rb -- 0 warnings
-        spec/samples/three_clean_files/clean_two.rb -- 0 warnings
-        0 total warnings
-        """
+  Scenario: Output total number of smells even if total equals 0
+    When I run reek spec/samples/three_clean_files
+    Then it succeeds
+    And it reports:
+    """
+
+    0 total warnings
+    """

--- a/features/command_line_interface/stdin.feature
+++ b/features/command_line_interface/stdin.feature
@@ -9,23 +9,21 @@ Feature: Reek reads from $stdin when no files are given
     Then it succeeds
     And it reports:
       """
-      $stdin -- 0 warnings
-
       """
 
-  Scenario: outputs header only on empty stdin
-    When I pass "" to reek
+  Scenario: outputs nothing on empty stdin
+    When I pass "" to reek --quiet
+    Then it succeeds
+    And stdout equals ""
+
+  Scenario: outputs header only on empty stdin in verbose mode
+    When I pass "" to reek -V
     Then it succeeds
     And it reports:
       """
       $stdin -- 0 warnings
 
       """
-
-  Scenario: outputs nothing on empty stdin in quiet mode
-    When I pass "" to reek --quiet
-    Then it succeeds
-    And stdout equals ""
 
   Scenario: return non-zero status when there are smells
     When I pass "class Turn; def y() @x = 3; end end" to reek
@@ -44,9 +42,5 @@ Feature: Reek reads from $stdin when no files are given
     When I pass "def incomplete" to reek
     Then it reports a parsing error
     Then it succeeds
-    And it reports:
-      """
-      $stdin -- 0 warnings
-
-      """
+    And stdout equals ""
 

--- a/features/configuration_files/masking_smells.feature
+++ b/features/configuration_files/masking_smells.feature
@@ -108,5 +108,4 @@ Feature: Masking smells using config files
     Then it succeeds
     And it reports:
       """
-      spec/samples/masked/dirty.rb -- 0 warnings
       """

--- a/features/rake_task/rake_task.feature
+++ b/features/rake_task/rake_task.feature
@@ -78,5 +78,4 @@ Feature: Reek can be driven through its Task
     Then it succeeds
     And it reports:
       """
-      spec/samples/masked/dirty.rb -- 0 warnings
       """

--- a/features/reports/reports.feature
+++ b/features/reports/reports.feature
@@ -76,8 +76,22 @@ Feature: Correctly formatted reports
       | -S                    |
       | --sort-by-issue-count |
 
-  Scenario Outline: good files show headers consecutively
+  Scenario Outline: good files show no headers by default
     When I run reek <args>
+    Then it succeeds
+    And it reports:
+      """
+
+      0 total warnings
+      """
+
+    Examples:
+      | args |
+      | spec/samples/three_clean_files/*.rb |
+      | spec/samples/three_clean_files      |
+
+  Scenario Outline: --verbose and --no-quiet turn on headers for fragrant files
+    When I run reek <option> spec/samples/three_clean_files/*.rb
     Then it succeeds
     And it reports:
       """
@@ -88,9 +102,10 @@ Feature: Correctly formatted reports
       """
 
     Examples:
-      | args |
-      | spec/samples/three_clean_files/*.rb |
-      | spec/samples/three_clean_files      |
+      | option     |
+      | --verbose  |
+      | -V         |
+      | --no-quiet |
 
   Scenario Outline: --quiet turns off headers for fragrant files
     When I run reek <option> spec/samples/three_clean_files/*.rb
@@ -102,11 +117,9 @@ Feature: Correctly formatted reports
     """
 
     Examples:
-      | option  |
-      | -q      |
-      | --quiet |
-      | -n -q   |
-      | -q -n   |
+      | option        |
+      | -V -q         |
+      | -V --quiet    |
 
   Scenario Outline: --line-number turns off line numbers
     When I run reek <option> spec/samples/not_quite_masked/dirty.rb
@@ -125,8 +138,8 @@ Feature: Correctly formatted reports
       | option            |
       | -n                |
       | --no-line-numbers |
-      | -n -q             |
-      | -q -n             |
+      | -n -V             |
+      | -V -n             |
 
   Scenario Outline: --single-line shows filename and one line number
     When I run reek <option> spec/samples/not_quite_masked/dirty.rb
@@ -145,8 +158,8 @@ Feature: Correctly formatted reports
       | option        |
       | -s            |
       | --single-line |
-      | -s -q         |
-      | -q -s         |
+      | -s -V         |
+      | -V -s         |
 
   Scenario Outline: Extra slashes aren't added to directory names
     When I run reek <args>

--- a/lib/reek/cli/command_line.rb
+++ b/lib/reek/cli/command_line.rb
@@ -17,7 +17,7 @@ module Reek
       def initialize(argv)
         @argv = argv
         @parser = OptionParser.new
-        @report_class = VerboseReport
+        @report_class = QuietReport
         @warning_formatter = WarningFormatterWithLineNumbers
         @command_class = ReekCommand
         @config_files = []
@@ -73,8 +73,11 @@ EOB
         end
 
         @parser.separator "\nReport formatting:"
-        @parser.on("-q", "--[no-]quiet", "Suppress headings for smell-free source files") do |opt|
-          @report_class = opt ? QuietReport : VerboseReport
+        @parser.on("-q", "--quiet", "Suppress headings for smell-free source files (this is the default)") do |opt|
+          @report_class = QuietReport
+        end
+        @parser.on("-V", "--no-quiet", "--verbose", "Show headings for smell-free source files") do |opt|
+          @report_class = VerboseReport
         end
         @parser.on("-n", "--no-line-numbers", "Suppress line numbers from the output") do 
           @warning_formatter = SimpleWarningFormatter


### PR DESCRIPTION
Fix for #169. I have decided not to always show the warning count like I mentioned in #169, because there were some odd edge cases there. If reek's silence when run on a single fragrant file becomes annoying, we can always do something about that.
