### PR TITLE
Only mark parameters uncommunicative if used

### DIFF
--- a/config/defaults.reek
+++ b/config/defaults.reek
@@ -89,6 +89,7 @@ UncommunicativeParameterName:
   - !ruby/regexp /^.$/
   - !ruby/regexp /[0-9]$/
   - !ruby/regexp /[A-Z]/
+  - !ruby/regexp /^_/
   accept: []
 UncommunicativeVariableName:
   enabled: true

--- a/features/ruby_api/api.feature
+++ b/features/ruby_api/api.feature
@@ -9,12 +9,10 @@ Feature: The Reek API maintains backwards compatibility
     Then the exit status indicates smells
     And it reports:
       """
-      spec/samples/demo/demo.rb -- 10 warnings:
+      spec/samples/demo/demo.rb -- 8 warnings:
         [1]:Dirty has no descriptive comment (IrresponsibleModule)
         [3]:Dirty#awful has 4 parameters (LongParameterList)
         [3]:Dirty#awful has boolean parameter 'log' (BooleanParameter)
-        [3]:Dirty#awful has the parameter name 'x' (UncommunicativeParameterName)
-        [3]:Dirty#awful has the parameter name 'y' (UncommunicativeParameterName)
         [5]:Dirty#awful has the variable name 'w' (UncommunicativeVariableName)
         [3]:Dirty#awful has unused parameter 'log' (UnusedParameters)
         [3]:Dirty#awful has unused parameter 'offset' (UnusedParameters)

--- a/lib/reek/core/method_context.rb
+++ b/lib/reek/core/method_context.rb
@@ -57,6 +57,10 @@ module Reek
         return [] if @refs.self_is_max?
         @refs.max_keys
       end
+
+      def uses_param?(param)
+        local_nodes(:lvar).include?(Sexp.new(:lvar, param.to_sym))
+      end
     end
   end
 end

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -27,7 +27,7 @@ module Reek
       # smelly names to be reported.
       REJECT_KEY = 'reject'
 
-      DEFAULT_REJECT_SET = [/^.$/, /[0-9]$/, /[A-Z]/]
+      DEFAULT_REJECT_SET = [/^.$/, /[0-9]$/, /[A-Z]/, /^_/]
 
       # The name of the config field that lists the specific names that are
       # to be treated as exceptions; these names will not be reported as
@@ -56,7 +56,7 @@ module Reek
         @reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
         @accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
         ctx.exp.parameter_names.select do |name|
-          is_bad_name?(name, ctx)
+          is_bad_name?(name) && ctx.uses_param?(name)
         end.map do |name|
           smell = SmellWarning.new(SMELL_CLASS, ctx.full_name, [ctx.exp.line],
                                    "has the parameter name '#{name}'",
@@ -65,7 +65,7 @@ module Reek
         end
       end
 
-      def is_bad_name?(name, ctx)
+      def is_bad_name?(name)
         var = name.to_s.gsub(/^[@\*\&]*/, '')
         return false if var == '*' or @accept_names.include?(var)
         @reject_names.detect {|patt| patt === var}

--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -37,16 +37,12 @@ module Reek
         params(method_ctx).select do |param|
           param = sanitized_param(param)
           next if skip?(param)
-          unused?(method_ctx, param)
+          !method_ctx.uses_param?(param)
         end
       end
 
       def skip?(param)
         anonymous_splat?(param) || marked_unused?(param)
-      end
-
-      def unused?(method_ctx, param)
-        !method_ctx.local_nodes(:lvar).include?(Sexp.new(:lvar, param.to_sym))
       end
 
       def params(method_ctx)

--- a/spec/reek/core/module_context_spec.rb
+++ b/spec/reek/core/module_context_spec.rb
@@ -6,7 +6,7 @@ include Reek::Core
 
 describe ModuleContext do
   it 'should report module name for smell in method' do
-    'module Fred; def simple(x) true; end; end'.should reek_of(:UncommunicativeParameterName, /x/, /simple/)
+    'module Fred; def simple(x) x + 1; end; end'.should reek_of(:UncommunicativeParameterName, /x/, /simple/)
   end
 
   it 'should not report module with empty class' do


### PR DESCRIPTION
UncommunicativeParameterName and UnusedParameter now collaborate as follows to
ensure correct parameters:
- If the parameter is unused, it will be flagged by UnusedParameter, unless it
  is explicitely marked as unused.
- If the parameter is used, UncommunicativeParameterName will ensure it has a
  communicative name. This includes not being marked as unused.

This means UncommunicativeParameterName only flags parameters that are actually
used, and its default reject set includes a new regexp that matches parameters
marked as unused.

The logic for checking whether a method uses a given parameter is moved to
MethodContext#uses_param?
