### PR TITLE
Ignore unused parameters if method calls super in nested context

### DIFF
--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -62,7 +62,7 @@ module Reek
       end
 
       def zsuper?(method_ctx)
-        method_ctx.exp.body.find_node :zsuper
+        method_ctx.exp.body.has_nested_node? :zsuper
       end
 
       def smell_warning(method_ctx, param)

--- a/lib/reek/source/sexp_node.rb
+++ b/lib/reek/source/sexp_node.rb
@@ -43,13 +43,16 @@ module Reek
       # every Sexp of type +target_type+. The traversal ignores any node
       # whose type is listed in the Array +ignoring+.
       #
-      def look_for(target_type, ignoring, &blk)
-        each do |elem|
-          if Sexp === elem then
-            elem.look_for(target_type, ignoring, &blk) unless ignoring.include?(elem.first)
-          end
+      def look_for(target_type, ignoring = [], &blk)
+        each_sexp do |elem|
+          elem.look_for(target_type, ignoring, &blk) unless ignoring.include?(elem.first)
         end
         blk.call(self) if first == target_type
+      end
+
+      def has_nested_node?(target_type)
+        look_for(target_type) { |elem| return true }
+        false
       end
 
       def format_ruby

--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -9,54 +9,58 @@ describe UnusedParameters do
 
   context 'for methods' do
 
-    it 'should report nothing for no parameters' do
+    it 'reports nothing for no parameters' do
       'def simple; true end'.should_not smell_of(UnusedParameters)
     end
 
-    it 'should report nothing for used parameter' do
+    it 'reports nothing for used parameter' do
       'def simple(sum); sum end'.should_not smell_of(UnusedParameters)
     end
 
-    it 'should report for 1 used and 2 unused parameter' do
+    it 'reports for 1 used and 2 unused parameter' do
       src = 'def simple(num,sum,denum); sum end'
       src.should smell_of(UnusedParameters,
                           {UnusedParameters::PARAMETER_KEY => 'num'},
                           {UnusedParameters::PARAMETER_KEY => 'denum'})
     end
 
-    it 'should report for 3 used and 1 unused parameter' do
+    it 'reports for 3 used and 1 unused parameter' do
       src = 'def simple(num,sum,denum,quotient); num + denum + sum end'
       src.should smell_of(UnusedParameters,
                           {UnusedParameters::PARAMETER_KEY => 'quotient'})
     end
 
-    it 'should report nothing for used splatted parameter' do
+    it 'reports nothing for used splatted parameter' do
       'def simple(*sum); sum end'.should_not smell_of(UnusedParameters)
     end
 
-    it 'should report nothing for unused anonymous parameter' do
+    it 'reports nothing for unused anonymous parameter' do
       'def simple(_); end'.should_not smell_of(UnusedParameters)
     end
 
-    it 'should report nothing for named parameters prefixed with _' do
+    it 'reports nothing for named parameters prefixed with _' do
       'def simple(_name); end'.should_not smell_of(UnusedParameters)
     end
 
-    it 'should report nothing for unused anonymous splatted parameter' do
+    it 'reports nothing for unused anonymous splatted parameter' do
       'def simple(*); end'.should_not smell_of(UnusedParameters)
     end
 
-    it 'should report nothing when using super with implicit arguments' do
+    it 'reports nothing when using super with implicit arguments' do
       'def simple(*args); super; end'.should_not smell_of(UnusedParameters)
     end
 
-    it 'should report something when using super explicitely passing no arguments' do
+    it 'reports something when using super explicitely passing no arguments' do
       'def simple(*args); super(); end'.should smell_of(UnusedParameters)
     end
 
-    it 'should report nothing when using super explicitely passing all arguments' do
+    it 'reports nothing when using super explicitely passing all arguments' do
       'def simple(*args); super(*args); end'.should_not smell_of(UnusedParameters)
     end
 
+    it 'reports nothing when using super in a nested context' do
+      'def simple(*args); call_other("something", super); end'.
+        should_not smell_of(UnusedParameters)
+    end
   end
 end

--- a/spec/reek/source/sexp_node_spec.rb
+++ b/spec/reek/source/sexp_node_spec.rb
@@ -25,4 +25,3 @@ describe SexpNode do
     end
   end
 end
-


### PR DESCRIPTION
This handles the case where super without arguments is called in a nested
context in the method. Sexp#find_node does not find those cases, so a new method
SexpNode#has_nested_node? is introduced.

Includes some rewording of spec descriptions, and a small refactoring of
SexpNode#look_for.
