### PR TITLE
Loosen ruby2ruby dependency

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -28,7 +28,7 @@ and reports any code smells it finds.
 
   s.add_runtime_dependency(%q<ruby_parser>, ["~> 3.3"])
   s.add_runtime_dependency(%q<sexp_processor>)
-  s.add_runtime_dependency(%q<ruby2ruby>, ["~> 2.0.8"])
+  s.add_runtime_dependency(%q<ruby2ruby>, [">= 2.0.8", "< 3.0"])
   s.add_runtime_dependency(%q<rainbow>, [">= 1.99", "< 3.0"])
 
   s.add_development_dependency(%q<bundler>, ["~> 1.1"])


### PR DESCRIPTION
Since ruby2ruby is semantically versioned, we can safely allow any 2.x
version equal to or above 2.0.8.

Fix for #263.
