### PR TITLE
Use byebug on MRI 2.0 and up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 group :local_development do
-  gem 'debugger', platforms: [:ruby]
+  gem 'debugger', :platforms => :mri_19
+  gem 'byebug', :platforms => [:mri_20, :mri_21]
   gem 'pry'
   gem 'pry_debug'
 end


### PR DESCRIPTION
Debugger is not supported on 2.x. See https://github.com/cldwalker/debugger/issues/125.

Another option is debugger2.
