### PR TITLE
Corrects UnusedParameter with keyword arguments with splat

### DIFF
--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -16,7 +16,7 @@ module Reek
 
       EMPTY_ARRAY  = [].freeze
       EMPTY_STRING = ''.freeze
-      SPLAT_MATCH  = /^\*/.freeze
+      SPLAT_MATCH  = /^\*{1,2}/.freeze
       UNDERSCORE   = '_'.freeze
 
       #

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -26,7 +26,7 @@ and reports any code smells it finds.
   s.rubygems_version = %q{1.3.6}
   s.summary = %q{Code smell detector for Ruby}
 
-  s.add_runtime_dependency(%q<ruby_parser>, ["~> 3.3"])
+  s.add_runtime_dependency(%q<ruby_parser>, [">= 3.5.0", "< 4.0"])
   s.add_runtime_dependency(%q<sexp_processor>)
   s.add_runtime_dependency(%q<ruby2ruby>, [">= 2.0.8", "< 3.0"])
   s.add_runtime_dependency(%q<rainbow>, [">= 1.99", "< 3.0"])

--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -62,5 +62,15 @@ describe UnusedParameters do
       expect('def simple(*args); call_other("something", super); end').
         not_to smell_of(UnusedParameters)
     end
+
+    it 'reports something when not using a keyword argument with splat' do
+      expect('def simple(var, kw: :val, **args); @var, @kw = var, kw; end').
+        to smell_of(UnusedParameters)
+    end
+
+    it 'reports nothing when using a keyword argument with splat' do
+      expect('def simple(var, kw: :val, **args); @var, @kw, @args = var, kw, args; end').
+        not_to smell_of(UnusedParameters)
+    end
   end
 end


### PR DESCRIPTION
Corrects an error where the UnusedParameter smell was flaged when it
should not have been when the method parameters included a keyword
argument with a splat.

Fixes #262
