### PR TITLE
Consider block parameter for DuplicateMethodCall

### DIFF
--- a/features/samples.feature
+++ b/features/samples.feature
@@ -59,7 +59,7 @@ Feature: Basic smell detection
     Then the exit status indicates smells
     And it reports:
     """
-    spec/samples/optparse.rb -- 108 warnings:
+    spec/samples/optparse.rb -- 109 warnings:
       OptionParser has at least 42 methods (TooManyMethods)
       OptionParser has the variable name 'f' (UncommunicativeVariableName)
       OptionParser has the variable name 'k' (UncommunicativeVariableName)
@@ -154,6 +154,7 @@ Feature: Basic smell detection
       OptionParser::Switch#self.incompatible_argument_styles has the parameter name 't' (UncommunicativeParameterName)
       OptionParser::Switch#summarize calls (indent + l) twice (DuplicateMethodCall)
       OptionParser::Switch#summarize calls left.collect twice (DuplicateMethodCall)
+      OptionParser::Switch#summarize calls left.collect { |s| s.length } twice (DuplicateMethodCall)
       OptionParser::Switch#summarize calls left.collect { |s| s.length }.max twice (DuplicateMethodCall)
       OptionParser::Switch#summarize calls left.collect { |s| s.length }.max.to_i twice (DuplicateMethodCall)
       OptionParser::Switch#summarize calls left.shift twice (DuplicateMethodCall)

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -8,11 +8,11 @@ module Reek
     # Duplication occurs when two fragments of code look nearly identical,
     # or when two fragments of code have nearly identical effects
     # at some conceptual level.
-    # 
+    #
     # +DuplicateMethodCall+ checks for repeated identical method calls
     # within any one method definition. For example, the following method
     # will report a warning:
-    # 
+    #
     #   def double_thing()
     #     @other.thing + @other.thing
     #   end
@@ -123,6 +123,9 @@ module Reek
           context.local_nodes(:call) do |call_node|
             next if call_node.method_name == :new
             next if !call_node.receiver && call_node.args.empty?
+            result[call_node].record(call_node)
+          end
+          context.local_nodes(:iter) do |call_node|
             result[call_node].record(call_node)
           end
         end

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -77,6 +77,50 @@ EOS
     end
   end
 
+  context "with repeated simple method calls with blocks" do
+    it 'reports a smell if the blocks are identical' do
+      src = <<-EOS
+        def foo
+          bar { baz }
+          bar { baz }
+        end
+      EOS
+      expect(src).to smell_of(DuplicateMethodCall)
+    end
+
+    it 'reports no smell if the blocks are different' do
+      src = <<-EOS
+        def foo
+          bar { baz }
+          bar { qux }
+        end
+      EOS
+      expect(src).not_to smell_of(DuplicateMethodCall)
+    end
+  end
+
+  context "with repeated method calls with receivers with blocks" do
+    it 'reports a smell if the blocks are identical' do
+      src = <<-EOS
+        def foo
+          bar.qux { baz }
+          bar.qux { baz }
+        end
+      EOS
+      expect(src).to smell_of(DuplicateMethodCall)
+    end
+
+    it 'reports a smell if the blocks are different' do
+      src = <<-EOS
+        def foo
+          bar.qux { baz }
+          bar.qux { qux }
+        end
+      EOS
+      expect(src).to smell_of(DuplicateMethodCall)
+    end
+  end
+
   context 'with repeated attribute assignment' do
     it 'reports repeated assignment' do
       src = 'def double_thing(thing) @other[thing] = true; @other[thing] = true; end'


### PR DESCRIPTION
This catches cases like the following:

```
foo {|a| a.bar}
foo {|a| a.bar}
```

In addition, the following cases become extra smelly since the whole iterator is considered smelly, in additon to `foo.bar`:

```
foo.bar {|a| a.baz}
foo.bar {|a| a.baz}
```

One consideration is whether the following case should still be considered smelly:

```
foo.bar {|a| a.baz}
foo.bar {|a| a.qux}
```

With the present change, this case stays smelly as it was before.
