### PR TITLE
Refactor Cli::Options

### DIFF
--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -1,4 +1,4 @@
-require 'reek/cli/command_line'
+require 'reek/cli/options'
 
 module Reek
   module Cli

--- a/lib/reek/cli/command.rb
+++ b/lib/reek/cli/command.rb
@@ -1,0 +1,14 @@
+module Reek
+  module Cli
+
+    #
+    # Base class for all commands
+    #
+    class Command
+      def initialize(parser)
+        @parser = parser
+      end
+    end
+  end
+end
+

--- a/lib/reek/cli/help_command.rb
+++ b/lib/reek/cli/help_command.rb
@@ -1,3 +1,4 @@
+require 'reek/cli/command'
 
 module Reek
   module Cli
@@ -5,12 +6,9 @@ module Reek
     #
     # A command to display usage information for this application.
     #
-    class HelpCommand
-      def initialize(parser)
-        @parser = parser
-      end
+    class HelpCommand < Command
       def execute(view)
-        view.output(@parser.to_s)
+        view.output(@parser.help_text)
         view.report_success
       end
     end

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -106,15 +106,14 @@ EOB
 
       def parse
         @parser.parse!(@argv)
-        if @command_class == HelpCommand
-          HelpCommand.new(@parser)
-        elsif @command_class == VersionCommand
-          VersionCommand.new(@parser.program_name)
-        else
-          Rainbow.enabled = @colored
-          reporter = @report_class.new(@warning_formatter, ReportFormatter, @sort_by_issue_count, @format)
-          ReekCommand.create(get_sources, reporter, @config_files)
-        end
+        Rainbow.enabled = @colored
+        @command_class.new(self)
+      end
+
+      attr_reader :config_files
+
+      def reporter
+        @reporter ||= @report_class.new(@warning_formatter, ReportFormatter, @sort_by_issue_count, @format)
       end
 
       def get_sources
@@ -123,6 +122,14 @@ EOB
         else
           return Source::SourceLocator.new(@argv).all_sources
         end
+      end
+
+      def program_name
+        @parser.program_name
+      end
+
+      def help_text
+        @parser.to_s
       end
     end
   end

--- a/lib/reek/cli/reek_command.rb
+++ b/lib/reek/cli/reek_command.rb
@@ -1,3 +1,4 @@
+require 'reek/cli/command'
 require 'reek/examiner'
 
 module Reek
@@ -7,23 +8,23 @@ module Reek
     # A command to collect smells from a set of sources and write them out in
     # text report format.
     #
-    class ReekCommand
-      def self.create(sources, reporter, config_files = [])
-        new(reporter, sources, config_files)
-      end
-
-      def initialize(reporter, sources, config_files = [])
-        @sources = sources
-        @reporter = reporter
-        @config_files = config_files
-      end
-
+    class ReekCommand < Command
       def execute(app)
-        @sources.each do |source|
-          @reporter.add_examiner(Examiner.new(source, @config_files))
+        @parser.get_sources.each do |source|
+          reporter.add_examiner(Examiner.new(source, config_files))
         end
-        @reporter.has_smells? ? app.report_smells : app.report_success
-        @reporter.show
+        reporter.has_smells? ? app.report_smells : app.report_success
+        reporter.show
+      end
+
+      private
+
+      def reporter
+        @reporter ||= @parser.reporter
+      end
+
+      def config_files
+        @config_files ||= @parser.config_files
       end
     end
   end

--- a/lib/reek/cli/version_command.rb
+++ b/lib/reek/cli/version_command.rb
@@ -1,4 +1,5 @@
 require 'reek'
+require 'reek/cli/command'
 
 module Reek
   module Cli
@@ -6,12 +7,9 @@ module Reek
     #
     # A command to report the application's current version number.
     #
-    class VersionCommand
-      def initialize(progname)
-        @progname = progname
-      end
+    class VersionCommand < Command
       def execute(view)
-        view.output("#{@progname} #{Reek::VERSION}\n")
+        view.output("#{@parser.program_name} #{Reek::VERSION}\n")
         view.report_success
       end
     end

--- a/spec/reek/cli/help_command_spec.rb
+++ b/spec/reek/cli/help_command_spec.rb
@@ -5,18 +5,20 @@ include Reek::Cli
 
 describe HelpCommand do
   before :each do
-    @text = 'Piece of interesting text'
-    @cmd = HelpCommand.new(@text)
+    @help_text = 'Piece of interesting text'
+    @parser = double('parser')
+    @parser.stub(:help_text).and_return @help_text
+    @cmd = HelpCommand.new(@parser)
     @view = double('view').as_null_object
-    expect(@view).not_to receive(:report_smells)
   end
 
   it 'displays the correct text on the view' do
-    expect(@view).to receive(:output).with(@text)
+    expect(@view).to receive(:output).with(@help_text)
     @cmd.execute(@view)
   end
 
   it 'tells the view it succeeded' do
+    expect(@view).not_to receive(:report_smells)
     expect(@view).to receive(:report_success)
     @cmd.execute(@view)
   end

--- a/spec/reek/cli/version_command_spec.rb
+++ b/spec/reek/cli/version_command_spec.rb
@@ -6,14 +6,15 @@ include Reek::Cli
 
 describe VersionCommand do
   before :each do
-    @text = 'Piece of interesting text'
-    @cmd = VersionCommand.new(@text)
+    @program_name = 'the_name_of_the_program'
+    @parser = double('parser')
+    @parser.should_receive(:program_name).and_return @program_name
+    @cmd = VersionCommand.new(@parser)
     @view = double('view').as_null_object
-    expect(@view).not_to receive(:report_smells)
   end
 
   it 'displays the text on the view' do
-    expect(@view).to receive(:output).with(/#{@text}/)
+    expect(@view).to receive(:output).with(/#{@program_name}/)
     @cmd.execute(@view)
   end
 
@@ -24,6 +25,7 @@ describe VersionCommand do
 
   it 'tells the view it succeeded' do
     expect(@view).to receive(:report_success)
+    expect(@view).not_to receive(:report_smells)
     @cmd.execute(@view)
   end
 end


### PR DESCRIPTION
Simplifies Cli::Options implementation by unifying the interface of the different Commands.

This change may conflict with #276 since that PR also moves Cli::Options to a different file.
