### PR TITLE
Make reek run warning-free

### DIFF
--- a/lib/reek/core/module_context.rb
+++ b/lib/reek/core/module_context.rb
@@ -1,6 +1,4 @@
 require 'reek/core/code_context'
-require 'reek/core/code_parser'
-require 'reek/core/sniffer'
 require 'reek/source/sexp_formatter'
 
 module Reek

--- a/lib/reek/core/object_refs.rb
+++ b/lib/reek/core/object_refs.rb
@@ -23,7 +23,7 @@ module Reek
 
       def max_keys
         max = max_refs
-        @refs.reject {|key,val| val != max}
+        @refs.select {|key,val| val == max}
       end
 
       def self_is_max?

--- a/lib/reek/core/sniffer.rb
+++ b/lib/reek/core/sniffer.rb
@@ -1,7 +1,6 @@
 require 'reek/core/code_parser'
 require 'reek/core/smell_repository'
 require 'reek/source/config_file'
-require 'yaml'
 
 module Reek
   module Core

--- a/spec/reek/cli/report_spec.rb
+++ b/spec/reek/cli/report_spec.rb
@@ -34,8 +34,8 @@ describe QuietReport, " when empty" do
       end
 
       it 'should mention every smell name' do
-        expect(@result).to match('[UncommunicativeParameterName]')
-        expect(@result).to match('[Feature Envy]')
+        expect(@result).to include('UncommunicativeParameterName')
+        expect(@result).to include('FeatureEnvy')
       end
     end
 

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -9,7 +9,7 @@ namespace 'test' do
 
   RSpec::Core::RakeTask.new('spec') do |t|
     t.pattern = UNIT_TESTS
-    t.ruby_opts = ['-Ilib']
+    t.ruby_opts = ['-Ilib -w']
   end
 
   desc 'Tests various release attributes of the gem'


### PR DESCRIPTION
Enables warnings during the spec run, and fixes the following warnings:
- 'circular require considered harmful' due to some needless requires
- 'copying extra states' warning when using Hash#reject
- 'character class has duplicated range' warning due to using match
  matcher with a string argument
