### PR TITLE
Added simple HTML output

### DIFF
--- a/assets/html_output.html.erb
+++ b/assets/html_output.html.erb
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset='UTF-8' />
+    <title>Reek Output</title>
+    <style>
+    * {
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+    }
+    body {
+      background-color: #e8eef2;
+      font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+      margin: 0;
+    }
+    #header {
+      background-color: #fafbfc;
+      border-bottom: 1px solid #cfdbe2;
+      margin-bottom: 20px;
+      padding: 20px;
+      color: #444444;
+    }
+    h1 {
+      margin: 0;
+    }
+    .total-warnings {
+      color: #f47f7f;
+    }
+    #reek-smells {
+      padding: 20px;
+      width: 100%;
+    }
+    .box {
+      margin-bottom: 20px;
+      background-color: #ffffff;
+      border: 1px solid transparent;
+      border-radius: 4px;
+      border-color: #cfdbe2;
+      -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+      box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+      border-top-width: 3px;
+    }
+    .smell-list {
+      margin-bottom: 0px;
+      padding-left: 0px;
+    }
+    .list-item:first-child {
+      border-top-width: 0;
+    }
+    .list-item {
+      border-width: 1px 0;
+      border-radius: 0;
+      position: relative;
+      display: block;
+      padding: 10px 15px;
+      margin-bottom: -1px;
+      background-color: #ffffff;
+      border: 1px solid #f1f2f3;
+    }
+    .list-item > .content:first-child {
+      margin-top: 0px;
+    }
+    .list-item > .content {
+      overflow: hidden;
+    }
+    .list-item > .content > .heading {
+      margin: 0 0 5px 0;
+    }
+    .list-item > .content > small {
+      float: right;
+      color: #909fa7;
+      font-size: 0.8rem;
+    }
+    .list-item > .content > p {
+      margin: 0;
+      color: #656565;
+    }
+    </style>
+  </head>
+  <body>
+    <div id="header">
+      <h1>Reek Output - <span class="total-warnings"><%= @count %> total warnings</span></h1>
+    </div>
+    <div id="reek-smells">
+      <div class="box">
+        <div class="smell-list">
+          <% @smells.each do |smell| %>
+          <div class="list-item">
+            <div class="content">
+              <div class="heading"><strong><%= smell.context%></strong> <%= smell.message%> (<%= smell.subclass%>)</div>
+              <small class="text-muted pull-right">Line <%= smell.lines %></small>
+              <p>
+              <small><%= smell.source %></small>
+              </p>
+            </div>
+          </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -46,5 +46,6 @@ Feature: Reek can be controlled using command-line options
           -s, --single-line                Show IDE-compatible single-line-per-warning
           -S, --sort-by-issue-count        Sort by "issue-count", listing the "smelliest" files first
           -y, --yaml                       Report smells in YAML format
+          -H, --html                       Report smells in HTML format
 
       """

--- a/lib/reek/cli/command_line.rb
+++ b/lib/reek/cli/command_line.rb
@@ -99,6 +99,9 @@ EOB
         @parser.on("-y", "--yaml", "Report smells in YAML format") do
           @format = :yaml
         end
+        @parser.on("-H", "--html", "Report smells in HTML format") do
+          @format = :html
+        end
       end
 
       def parse

--- a/lib/reek/cli/report.rb
+++ b/lib/reek/cli/report.rb
@@ -68,6 +68,11 @@ module Reek
           else
             print ''
           end
+        when :html
+          if all_smells.size > 0
+            HtmlReport.new.output(all_smells)
+            print("Html file saved\n")
+          end
         end
       end
 
@@ -131,6 +136,23 @@ module Reek
           if examiner.smelly?
             result << summarize_single_examiner(examiner)
           end
+        end
+      end
+    end
+
+    #
+    # Saves the report as a HTML file
+    # 
+    class HtmlReport < Report
+      require 'erubis'
+      TEMPLATE = File.read(File.expand_path("../../../../assets/html_output.html.erb", __FILE__))
+      def output(smells)
+        File.open("reek.html", "w+") do |file|
+          eruby = Erubis::Eruby.new(TEMPLATE)
+          file.puts eruby.evaluate(
+            smells: smells,
+            count: smells.size
+          )
         end
       end
     end

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables = ["reek"]
   s.extra_rdoc_files = ["CHANGELOG", "License.txt"]
   s.files = Dir[".yardopts", "CHANGELOG", "License.txt", "README.md",
-                "Rakefile", "bin/reek", "config/defaults.reek",
+                "Rakefile", "assets/html_output.html.erb", "bin/reek", "config/defaults.reek",
                 "{features,lib,spec,tasks}/**/*",
                 "reek.gemspec" ] & `git ls-files -z`.split("\0")
   s.homepage = %q{http://wiki.github.com/troessner/reek}
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<sexp_processor>, ["~> 4.4"])
   s.add_runtime_dependency(%q<ruby2ruby>, [">= 2.0.8", "< 3.0"])
   s.add_runtime_dependency(%q<rainbow>, [">= 1.99", "< 3.0"])
+  s.add_runtime_dependency(%q<erubis>, ["~> 2.7.0"])
 
   s.add_development_dependency(%q<bundler>, ["~> 1.1"])
   s.add_development_dependency(%q<rake>, ["~> 10.0"])


### PR DESCRIPTION
I wanted reek to output as html file. So I added it.

`reek -H .`

or 

`reek --html .`

will output a `reek.html` file with all errors and messages
