### PR TITLE
Color total warning count depending on number of warnings

### DIFF
--- a/lib/reek/cli/report.rb
+++ b/lib/reek/cli/report.rb
@@ -40,6 +40,8 @@ module Reek
     #
     class Report
       DefaultFormat = :text
+      NoWarningsColor = :green
+      WarningsColor = :red
 
       def initialize(warning_formatter = SimpleWarningFormatter, report_formatter = ReportFormatter, sort_by_issue_count = false, format = DefaultFormat)
         @warning_formatter   = warning_formatter
@@ -103,7 +105,8 @@ module Reek
       end
 
       def total_smell_count_message
-        Rainbow("#{@total_smell_count} total warning#{'s' unless @total_smell_count == 1 }\n").red
+        colour = has_smells? ? WarningsColor : NoWarningsColor
+        Rainbow("#{@total_smell_count} total warning#{'s' unless @total_smell_count == 1 }\n").color(colour)
       end
 
       def summarize_single_examiner(examiner)

--- a/spec/reek/cli/report_spec.rb
+++ b/spec/reek/cli/report_spec.rb
@@ -42,22 +42,46 @@ describe QuietReport, " when empty" do
     context 'with colors enabled' do
       before :each do
         Rainbow.enabled = true
-        @rpt.add_examiner(Examiner.new('def simple(a) a[3] end'))
-        @rpt.add_examiner(Examiner.new('def simple(a) a[3] end'))
-        @result = @rpt.gather_results
       end
 
-      it 'has a header in color' do
-        expect(@result.first).to start_with "\e[36mstring -- \e[0m\e[33m2 warning\e[0m\e[33ms\e[0m"
+      context 'with non smelly files' do
+        before :each do
+          Rainbow.enabled = true
+          @rpt.add_examiner(Examiner.new('def simple() puts "a" end'))
+          @rpt.add_examiner(Examiner.new('def simple() puts "a" end'))
+          @result = @rpt.gather_results
+        end
+
+        it 'has a footer in color' do
+          stdout = StringIO.new
+          $stdout = stdout
+          @rpt.show
+          $stdout = STDOUT
+
+          expect(stdout.string).to end_with "\e[32m0 total warnings\n\e[0m"
+        end
       end
 
-      it 'has a footer in color' do
-        stdout = StringIO.new
-        $stdout = stdout
-        @rpt.show
-        $stdout = STDOUT
+      context 'with smelly files' do
+        before :each do
+          Rainbow.enabled = true
+          @rpt.add_examiner(Examiner.new('def simple(a) a[3] end'))
+          @rpt.add_examiner(Examiner.new('def simple(a) a[3] end'))
+          @result = @rpt.gather_results
+        end
 
-        expect(stdout.string).to end_with "\e[31m4 total warnings\n\e[0m"
+        it 'has a header in color' do
+          expect(@result.first).to start_with "\e[36mstring -- \e[0m\e[33m2 warning\e[0m\e[33ms\e[0m"
+        end
+
+        it 'has a footer in color' do
+          stdout = StringIO.new
+          $stdout = stdout
+          @rpt.show
+          $stdout = STDOUT
+
+          expect(stdout.string).to end_with "\e[31m4 total warnings\n\e[0m"
+        end
       end
     end
   end


### PR DESCRIPTION
If there are no warnings, the output will be green, other wise it will
be green.

Fixes #287
