### PR TITLE
Clean up cruft from rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,6 @@
 require 'rake/clean'
 require "bundler/gem_tasks"
 
-$:.unshift File.dirname(__FILE__) + '/lib'
-
-PROJECT_NAME = 'reek'
-
-BUILD_DIR = 'build'; directory BUILD_DIR
-PKG_DIR = "#{BUILD_DIR}/pkg"; directory PKG_DIR
-
-GEM_MANIFEST = "Manifest.txt"
-VERSION_FILE = 'lib/reek.rb'
-
-CLOBBER.include("#{BUILD_DIR}/*")
-
 Dir['tasks/**/*.rake'].each { |t| load t }
 
 task :default => [:test]
-

--- a/tasks/develop.rake
+++ b/tasks/develop.rake
@@ -1,28 +1,21 @@
 require 'rake/clean'
-require 'reek/core/sniffer'
-require 'yaml'
 
-CONFIG_DIR = 'config'
-CONFIG_FILE = "#{CONFIG_DIR}/defaults.reek"
+CONFIG_FILE = "config/defaults.reek"
 
-CLOBBER.include(CONFIG_DIR)
-
-directory CONFIG_DIR
-
-file CONFIG_FILE => [CONFIG_DIR] do
+file CONFIG_FILE do
   config = {}
+  require 'reek/core/sniffer'
   Reek::Core::SmellRepository.smell_classes.each do |klass|
     config[klass.name.split(/::/)[-1]] = klass.default_config
   end
   $stderr.puts "Creating #{CONFIG_FILE}"
+  require 'yaml'
   File.open(CONFIG_FILE, 'w') { |f| YAML.dump(config, f) }
 end
 
 task CONFIG_FILE => FileList['lib/reek/smells/*.rb']
 
-task 'test:spec' => [CONFIG_FILE]
-task 'test:slow' => [CONFIG_FILE]
-task 'test:quality' => [CONFIG_FILE]
-task 'test:features' => [CONFIG_FILE]
-task 'reek' => [CONFIG_FILE]
-task 'check:manifest' => [CONFIG_FILE]
+task 'test:spec' => CONFIG_FILE
+task 'test:quality' => CONFIG_FILE
+task 'test:features' => CONFIG_FILE
+task 'reek' => CONFIG_FILE

--- a/tasks/reek.rake
+++ b/tasks/reek.rake
@@ -8,8 +8,3 @@ begin
   end
 rescue Gem::LoadError
 end
-
-begin
-  require 'metric_fu'
-rescue LoadError
-end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,7 +1,4 @@
-require 'rubygems'
-require 'cucumber'
 require 'cucumber/rake/task'
-require 'rspec'
 require 'rspec/core/rake_task'
 
 namespace 'test' do


### PR DESCRIPTION
- Removes outdated cruft
- Makes `rake -T` run in 0.25s instead of 13s
- Makes `bundle exec rake -T` run in 1.0s instead of 1.4s (not as spectacular, but still a win)
