### PR TITLE
Start using RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,48 @@
+AllCops:
+  Exclude:
+    - 'spec/samples/**/*'
+    - 'tmp/**/*'
+
+# Be a little more lenient with line length
+Metrics/LineLength:
+  Max: 92
+
+# Allow small arrays of words with quotes
+Style/WordArray:
+  MinSize: 3
+
+# Allow single-line method definitions
+Style/SingleLineMethods:
+  Enabled: false
+
+# Always use raise to signal exceptions
+Style/SignalException:
+  EnforcedStyle: only_raise
+
+# Place . on the previous line
+Style/DotPosition:
+  EnforcedStyle: trailing
+
+# Require empty lines between defs, except for one-line defs
+Style/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: true
+
+# Enforce GaurdClause if there are 2 or more lines in the body
+Style/GuardClause:
+  MinBodyLength: 2
+
+# Allow s()
+Style/MethodCallParentheses:
+  Enabled: false
+
+# Allow multiline block chains
+Style/MultilineBlockChain:
+  Enabled: false
+
+# Allow Perl-style references to regex matches
+Style/PerlBackrefs:
+  Enabled: false
+
+# Only register TrivialAccessors offenses when the name matches
+Style/TrivialAccessors:
+  ExactNameMatch: true

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'rake/clean'
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 
-task :default => [:test]
+task default: [:test]

--- a/features/rake_task/rake_task.feature
+++ b/features/rake_task/rake_task.feature
@@ -46,7 +46,7 @@ Feature: Reek can be driven through its Task
       end
       """
     Then the exit status indicates an error
-    And stdout includes /spec\/samples\/masked\/dirty\.rb/
+    And stdout includes "spec/samples/masked/dirty.rb"
 
   Scenario: fail_on_error can hide the error status
     When I run rake reek with:

--- a/features/step_definitions/.rubocop.yml
+++ b/features/step_definitions/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from: ../../.rubocop.yml
+
+# Allow common When <regexp> syntax
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false

--- a/features/step_definitions/reek_steps.rb
+++ b/features/step_definitions/reek_steps.rb
@@ -14,8 +14,8 @@ Then /^stdout equals "([^\"]*)"$/ do |report|
   expect(@last_stdout).to eq report
 end
 
-Then /^stdout includes \/([^\"]*)\/$/ do |report|
-  expect(@last_stdout).to match(report)
+Then /^stdout includes "(.*)"$/ do |text|
+  expect(@last_stdout).to include text
 end
 
 Then /^it succeeds$/ do
@@ -45,7 +45,7 @@ Then /^stderr reports:$/ do |report|
 end
 
 Then /^it reports no errors$/ do
-  expect(@last_stderr.chomp).to eq ""
+  expect(@last_stderr.chomp).to eq ''
 end
 
 Then /^it reports an error$/ do

--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -2,14 +2,12 @@ require 'reek/cli/options'
 
 module Reek
   module Cli
-
     #
     # Represents an instance of a Reek application.
     # This is the entry point for all invocations of Reek from the
     # command line.
     #
     class Application
-
       STATUS_SUCCESS = 0
       STATUS_ERROR   = 1
       STATUS_SMELLS  = 2
@@ -27,7 +25,7 @@ module Reek
           $stderr.puts "Error: #{error}"
           @status = STATUS_ERROR
         end
-        return @status
+        @status
       end
 
       def output(text)

--- a/lib/reek/cli/command.rb
+++ b/lib/reek/cli/command.rb
@@ -1,6 +1,5 @@
 module Reek
   module Cli
-
     #
     # Base class for all commands
     #
@@ -11,4 +10,3 @@ module Reek
     end
   end
 end
-

--- a/lib/reek/cli/help_command.rb
+++ b/lib/reek/cli/help_command.rb
@@ -2,7 +2,6 @@ require 'reek/cli/command'
 
 module Reek
   module Cli
-
     #
     # A command to display usage information for this application.
     #

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -10,12 +10,10 @@ require 'reek/source'
 
 module Reek
   module Cli
-
     #
     # Parses the command line
     #
     class Options
-
       def initialize(argv)
         @argv = argv
         @parser = OptionParser.new
@@ -48,7 +46,7 @@ module Reek
         #      -q|-[no-]quiet      Only list files that have smells
         #      files               Names of files or dirs to be checked
         #
-        return <<EOB
+        <<EOB
 Usage: #{progname} [options] [files]
 
 Examples:
@@ -64,48 +62,48 @@ EOB
 
       def set_options
         @parser.banner = banner
-        @parser.separator "Common options:"
-        @parser.on("-h", "--help", "Show this message") do
+        @parser.separator 'Common options:'
+        @parser.on('-h', '--help', 'Show this message') do
           @command_class = HelpCommand
         end
-        @parser.on("-v", "--version", "Show version") do
+        @parser.on('-v', '--version', 'Show version') do
           @command_class = VersionCommand
         end
 
         @parser.separator "\nConfiguration:"
-        @parser.on("-c", "--config FILE", "Read configuration options from FILE") do |file|
+        @parser.on('-c', '--config FILE', 'Read configuration options from FILE') do |file|
           @config_files << file
         end
-        @parser.on("--smell SMELL", "Detect smell SMELL (default is all enabled smells)") do |smell|
+        @parser.on('--smell SMELL', 'Detect smell SMELL (default is all enabled smells)') do |smell|
           @smells_to_detect << smell
         end
 
         @parser.separator "\nReport formatting:"
-        @parser.on("-o", "--[no-]color", "Use colors for the output (this is the default)") do |opt|
+        @parser.on('-o', '--[no-]color', 'Use colors for the output (this is the default)') do |opt|
           @colored = opt
         end
-        @parser.on("-q", "--quiet", "Suppress headings for smell-free source files (this is the default)") do |opt|
+        @parser.on('-q', '--quiet', 'Suppress headings for smell-free source files (this is the default)') do |_opt|
           @strategy = Report::Strategy::Quiet
         end
-        @parser.on("-V", "--no-quiet", "--verbose", "Show headings for smell-free source files") do |opt|
+        @parser.on('-V', '--no-quiet', '--verbose', 'Show headings for smell-free source files') do |_opt|
           @strategy = Report::Strategy::Verbose
         end
-        @parser.on("-n", "--no-line-numbers", "Suppress line numbers from the output") do
+        @parser.on('-n', '--no-line-numbers', 'Suppress line numbers from the output') do
           @warning_formatter = Report::SimpleWarningFormatter
         end
-        @parser.on("--line-numbers", "Show line numbers in the output (this is the default)") do
+        @parser.on('--line-numbers', 'Show line numbers in the output (this is the default)') do
           @warning_formatter = Report::WarningFormatterWithLineNumbers
         end
-        @parser.on("-s", "--single-line", "Show IDE-compatible single-line-per-warning") do
+        @parser.on('-s', '--single-line', 'Show IDE-compatible single-line-per-warning') do
           @warning_formatter = Report::SingleLineWarningFormatter
         end
-        @parser.on("-S", "--sort-by-issue-count", 'Sort by "issue-count", listing the "smelliest" files first') do
+        @parser.on('-S', '--sort-by-issue-count', 'Sort by "issue-count", listing the "smelliest" files first') do
           @sort_by_issue_count = true
         end
-        @parser.on("-y", "--yaml", "Report smells in YAML format") do
+        @parser.on('-y', '--yaml', 'Report smells in YAML format') do
           @report_class = Report::YamlReport
         end
-        @parser.on("-H", "--html", "Report smells in HTML format") do
+        @parser.on('-H', '--html', 'Report smells in HTML format') do
           @report_class = Report::HtmlReport
         end
       end
@@ -120,15 +118,13 @@ EOB
       attr_reader :smells_to_detect
 
       def reporter
-        @reporter ||= @report_class.new( {
-          warning_formatter: @warning_formatter,
-          report_formatter: Report::Formatter,
-          sort_by_issue_count: @sort_by_issue_count,
-          strategy: @strategy
-        })
+        @reporter ||= @report_class.new(warning_formatter: @warning_formatter,
+                                        report_formatter: Report::Formatter,
+                                        sort_by_issue_count: @sort_by_issue_count,
+                                        strategy: @strategy)
       end
 
-      def get_sources
+      def sources
         if @argv.empty?
           return [$stdin.to_reek_source('$stdin')]
         else

--- a/lib/reek/cli/reek_command.rb
+++ b/lib/reek/cli/reek_command.rb
@@ -3,17 +3,16 @@ require 'reek/examiner'
 
 module Reek
   module Cli
-
     #
     # A command to collect smells from a set of sources and write them out in
     # text report format.
     #
     class ReekCommand < Command
       def execute(app)
-        @parser.get_sources.each do |source|
+        @parser.sources.each do |source|
           reporter.add_examiner(Examiner.new(source, config_files, smell_names))
         end
-        reporter.has_smells? ? app.report_smells : app.report_success
+        reporter.smells? ? app.report_smells : app.report_success
         reporter.show
       end
 

--- a/lib/reek/cli/report/formatter.rb
+++ b/lib/reek/cli/report/formatter.rb
@@ -36,6 +36,3 @@ module Reek
     end
   end
 end
-
-
-

--- a/lib/reek/cli/report/report.rb
+++ b/lib/reek/cli/report/report.rb
@@ -7,9 +7,9 @@ module Reek
       # A report that contains the smells and smell counts following source code analysis.
       #
       class Base
-        DefaultFormat = :text
-        NoWarningsColor = :green
-        WarningsColor = :red
+        DEFAULT_FORMAT = :text
+        NO_WARNINGS_COLOR = :green
+        WARNINGS_COLOR = :red
 
         def initialize(options = {})
           @warning_formatter   = options.fetch :warning_formatter, SimpleWarningFormatter
@@ -26,7 +26,7 @@ module Reek
           self
         end
 
-        def has_smells?
+        def smells?
           @total_smell_count > 0
         end
 
@@ -40,9 +40,7 @@ module Reek
       #
       class TextReport < Base
         def show
-          if has_smells?
-            sort_examiners
-          end
+          sort_examiners if smells?
           display_summary
           display_total_smell_count
         end
@@ -54,18 +52,17 @@ module Reek
         end
 
         def display_total_smell_count
-          if @examiners.size > 1
-            print "\n"
-            print total_smell_count_message
-          end
+          return unless @examiners.size > 1
+          print "\n"
+          print total_smell_count_message
         end
 
         def sort_examiners
-          @examiners.sort! {|first, second| second.smells_count <=> first.smells_count } if @sort_by_issue_count
+          @examiners.sort! { |first, second| second.smells_count <=> first.smells_count } if @sort_by_issue_count
         end
 
         def total_smell_count_message
-          colour = has_smells? ? WarningsColor : NoWarningsColor
+          colour = smells? ? WARNINGS_COLOR : NO_WARNINGS_COLOR
           Rainbow("#{@total_smell_count} total warning#{'s' unless @total_smell_count == 1 }\n").color(colour)
         end
       end
@@ -74,7 +71,7 @@ module Reek
       # Displays a list of smells in YAML format
       # YAML with empty array for 0 smells
       class YamlReport < Base
-        def initialize(options ={})
+        def initialize(options = {})
           @options = options
           super options.merge!(strategy: Strategy::Normal)
         end
@@ -88,7 +85,7 @@ module Reek
       # Saves the report as a HTML file
       #
       class HtmlReport < Base
-        def initialize(options ={})
+        def initialize(options = {})
           @options = options
           super @options.merge!(strategy: Strategy::Normal)
         end

--- a/lib/reek/cli/report/strategy.rb
+++ b/lib/reek/cli/report/strategy.rb
@@ -42,9 +42,7 @@ module Reek
         class Quiet < Base
           def gather_results
             examiners.each_with_object([]) do |examiner, result|
-              if examiner.smelly?
-                result << summarize_single_examiner(examiner)
-              end
+              result << summarize_single_examiner(examiner) if examiner.smelly?
             end
           end
         end
@@ -55,8 +53,8 @@ module Reek
         #
         class Normal < Base
           def gather_results
-            examiners.each_with_object([]) { |examiner, smells| smells << examiner.smells }
-                             .flatten
+            examiners.each_with_object([]) { |examiner, smells| smells << examiner.smells }.
+                             flatten
           end
         end
       end

--- a/lib/reek/cli/version_command.rb
+++ b/lib/reek/cli/version_command.rb
@@ -3,7 +3,6 @@ require 'reek/cli/command'
 
 module Reek
   module Cli
-
     #
     # A command to report the application's current version number.
     #

--- a/lib/reek/config_file_exception.rb
+++ b/lib/reek/config_file_exception.rb
@@ -3,6 +3,5 @@ module Reek
   # An exception that occured when loading the configuration file.
   #
   class ConfigFileException < RuntimeError
-
   end
 end

--- a/lib/reek/core/code_context.rb
+++ b/lib/reek/core/code_context.rb
@@ -1,7 +1,6 @@
 
 module Reek
   module Core
-
     #
     # Superclass for all types of source code context. Each instance represents
     # a code element of some kind, and each provides behaviour relevant to that
@@ -9,7 +8,6 @@ module Reek
     # with each context holding a reference to a unique outer context.
     #
     class CodeContext
-
       attr_reader :exp
 
       def initialize(outer, exp)
@@ -35,7 +33,7 @@ module Reek
 
       def matches?(candidates)
         my_fq_name = full_name
-        candidates.any? {|str| /#{str}/ === my_fq_name }
+        candidates.any? { |str| /#{str}/ =~ my_fq_name }
       end
 
       #

--- a/lib/reek/core/code_parser.rb
+++ b/lib/reek/core/code_parser.rb
@@ -6,7 +6,6 @@ require 'reek/core/singleton_method_context'
 
 module Reek
   module Core
-
     #
     # Traverses a Sexp abstract syntax tree and fires events whenever
     # it encounters specific node types.
@@ -22,12 +21,12 @@ module Reek
       def process(exp)
         meth = "process_#{exp[0]}"
         meth = :process_default unless self.respond_to?(meth)
-        self.send(meth, exp)
+        send(meth, exp)
         @element
       end
 
       def process_default(exp)
-        exp.each { |sub| process(sub) if Array === sub }
+        exp.each { |sub| process(sub) if sub.is_a? Array }
       end
 
       def process_module(exp)
@@ -36,7 +35,7 @@ module Reek
         end
       end
 
-      alias process_class process_module
+      alias_method :process_class, :process_module
 
       def process_defn(exp)
         inside_new_context(MethodContext, exp) do
@@ -63,21 +62,21 @@ module Reek
         process_default(exp)
       end
 
-      alias process_attrasgn process_call
-      alias process_op_asgn1 process_call
+      alias_method :process_attrasgn, :process_call
+      alias_method :process_op_asgn1, :process_call
 
       def process_ivar(exp)
         @element.record_use_of_self
         process_default(exp)
       end
 
-      alias process_iasgn process_ivar
+      alias_method :process_iasgn, :process_ivar
 
       def process_self(_)
         @element.record_use_of_self
       end
 
-      alias process_zsuper process_self
+      alias_method :process_zsuper, :process_self
 
       #
       # Statement counting
@@ -107,7 +106,7 @@ module Reek
         process_default(exp)
       end
 
-      alias process_until process_while
+      alias_method :process_until, :process_while
 
       def process_for(exp)
         count_clause(exp[3])

--- a/lib/reek/core/method_context.rb
+++ b/lib/reek/core/method_context.rb
@@ -3,7 +3,6 @@ require 'reek/core/object_refs'
 
 module Reek
   module Core
-
     #
     # The parameters in a method's definition.
     #
@@ -11,7 +10,7 @@ module Reek
       def default_assignments
         result = []
         self[1..-1].each do |exp|
-          result << exp[1..2] if Sexp === exp && exp[0] == :lasgn
+          result << exp[1..2] if exp.is_a?(Sexp) && exp[0] == :lasgn
         end
         result
       end
@@ -71,7 +70,7 @@ module Reek
       end
 
       def uses_super_with_implicit_arguments?
-        exp.body.has_nested_node? :zsuper
+        exp.body.contains_nested_node? :zsuper
       end
     end
   end

--- a/lib/reek/core/module_context.rb
+++ b/lib/reek/core/module_context.rb
@@ -3,12 +3,10 @@ require 'reek/source/sexp_formatter'
 
 module Reek
   module Core
-
     #
     # A context wrapper for any module found in a syntax tree.
     #
     class ModuleContext < CodeContext
-
       def initialize(outer, exp)
         super(outer, exp)
         @name = Source::SexpFormatter.format(exp[1])

--- a/lib/reek/core/object_refs.rb
+++ b/lib/reek/core/object_refs.rb
@@ -1,6 +1,5 @@
 module Reek
   module Core
-
     #
     # Manages and counts the references out of a method to other objects.
     #
@@ -18,12 +17,12 @@ module Reek
       end
 
       def max_refs
-        @refs.values.max or 0
+        @refs.values.max || 0
       end
 
       def max_keys
         max = max_refs
-        @refs.select {|key,val| val == max}
+        @refs.select { |_key, val| val == max }
       end
 
       def self_is_max?

--- a/lib/reek/core/singleton_method_context.rb
+++ b/lib/reek/core/singleton_method_context.rb
@@ -2,12 +2,10 @@ require 'reek/core/method_context'
 
 module Reek
   module Core
-
     #
     # A context wrapper for any singleton method definition found in a syntax tree.
     #
     class SingletonMethodContext < MethodContext
-
       def initialize(outer, exp)
         super(outer, exp)
       end

--- a/lib/reek/core/smell_configuration.rb
+++ b/lib/reek/core/smell_configuration.rb
@@ -1,11 +1,9 @@
 module Reek
   module Core
-
     #
     # Represents a single set of configuration options for a smell detector
     #
     class SmellConfiguration
-
       # The name of the config field that specifies whether a smell is
       # enabled. Set to +true+ or +false+.
       ENABLED_KEY = 'enabled'
@@ -39,8 +37,8 @@ module Reek
       # Returns +fall_back+ if this config has no value for the key.
       #
       def value(key, context, fall_back)
-        overrides_for(context).each { |conf| return conf[key] if conf.has_key?(key) }
-        return @options.fetch(key, fall_back)
+        overrides_for(context).each { |conf| return conf[key] if conf.key?(key) }
+        @options.fetch(key, fall_back)
       end
     end
 
@@ -54,7 +52,7 @@ module Reek
 
       # Find any overrides that match the supplied context
       def for_context(context)
-        contexts = @hash.keys.select {|ckey| context.matches?([ckey])}
+        contexts = @hash.keys.select { |ckey| context.matches?([ckey]) }
         contexts.map { |exc| @hash[exc] }
       end
     end

--- a/lib/reek/core/smell_repository.rb
+++ b/lib/reek/core/smell_repository.rb
@@ -6,7 +6,6 @@ module Reek
     # Contains all the existing smells and exposes operations on them.
     #
     class SmellRepository
-
       def self.smell_classes
         # SMELL: Duplication -- these should be loaded by listing the files
         [
@@ -36,9 +35,9 @@ module Reek
         ]
       end
 
-      def initialize source_description, smell_classes=SmellRepository.smell_classes
+      def initialize(source_description, smell_classes = SmellRepository.smell_classes)
         @typed_detectors = nil
-        @detectors = Hash.new
+        @detectors = {}
         smell_classes.each do |klass|
           @detectors[klass] = klass.new(source_description)
         end
@@ -48,7 +47,7 @@ module Reek
         @detectors[klass].configure_with(config) if @detectors[klass]
       end
 
-      def report_on listener
+      def report_on(listener)
         @detectors.each_value { |detector| detector.report_on(listener) }
       end
 
@@ -60,9 +59,9 @@ module Reek
 
       private
 
-      def smell_listeners()
+      def smell_listeners
         unless @typed_detectors
-          @typed_detectors = Hash.new {|hash,key| hash[key] = [] }
+          @typed_detectors = Hash.new { |hash, key| hash[key] = [] }
           @detectors.each_value { |detector| detector.register(@typed_detectors) }
         end
         @typed_detectors

--- a/lib/reek/core/sniffer.rb
+++ b/lib/reek/core/sniffer.rb
@@ -4,18 +4,16 @@ require 'reek/source/config_file'
 
 module Reek
   module Core
-
     #
     # Configures all available smell detectors and applies them to a source.
     #
     class Sniffer
-
-      def initialize(src, extra_config_files = [], smell_repository=Core::SmellRepository.new(src.desc))
+      def initialize(src, extra_config_files = [], smell_repository = Core::SmellRepository.new(src.desc))
         @smell_repository = smell_repository
         @source = src
 
         config_files = extra_config_files + @source.relevant_config_files
-        config_files.each{ |cf| Reek::Source::ConfigFile.new(cf).configure(@smell_repository) }
+        config_files.each { |cf| Reek::Source::ConfigFile.new(cf).configure(@smell_repository) }
       end
 
       def report_on(listener)

--- a/lib/reek/core/stop_context.rb
+++ b/lib/reek/core/stop_context.rb
@@ -1,16 +1,14 @@
 module Reek
   module Core
-
     #
     # A context wrapper representing the root of an abstract syntax tree.
     #
     class StopContext
-
       def initialize
         @name = ''
       end
 
-      def method_missing(method, *args)
+      def method_missing(_method, *_args)
         nil
       end
 
@@ -18,7 +16,7 @@ module Reek
         {}
       end
 
-      def count_statements(num)
+      def count_statements(_num)
         0
       end
 

--- a/lib/reek/core/warning_collector.rb
+++ b/lib/reek/core/warning_collector.rb
@@ -2,7 +2,6 @@ require 'set'
 
 module Reek
   module Core
-
     #
     # Collects and sorts smells warnings.
     #

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -3,12 +3,10 @@ require 'reek/core/warning_collector'
 require 'reek/source/source_repository'
 
 module Reek
-
   #
   # Finds the active code smells in Ruby source code.
   #
   class Examiner
-
     #
     # A simple description of the source being analysed for smells.
     # If the source is a single File, this will be the file's path.
@@ -30,7 +28,7 @@ module Reek
     def initialize(source, config_files = [], smell_names = [])
       sources = Source::SourceRepository.parse(source)
       @description = sources.description
-      collector = Core::WarningCollector.new
+      @collector = Core::WarningCollector.new
 
       smell_classes = Core::SmellRepository.smell_classes
       if smell_names.any?
@@ -39,9 +37,8 @@ module Reek
 
       sources.each do |src|
         repository = Core::SmellRepository.new(src.desc, smell_classes)
-        Core::Sniffer.new(src, config_files, repository).report_on(collector)
+        Core::Sniffer.new(src, config_files, repository).report_on(@collector)
       end
-      @smells = collector.warnings
     end
 
     #
@@ -50,21 +47,21 @@ module Reek
     # @return [Array<SmellWarning>]
     #
     def smells
-      @smells
+      @smells ||= @collector.warnings
     end
 
     #
     # Returns the number of smells found in the source
     #
     def smells_count
-      @smells.length
+      smells.length
     end
 
     #
     # True if and only if there are code smells in the source.
     #
     def smelly?
-      not @smells.empty?
+      !smells.empty?
     end
 
     #
@@ -73,9 +70,7 @@ module Reek
     #
     # @deprecated Use #smells instead.
     #
-    def all_active_smells
-      @smells
-    end
+    alias_method :all_active_smells, :smells
 
     #
     # Returns an Array of SmellWarning objects, one for each smell
@@ -85,17 +80,15 @@ module Reek
     #
     # @deprecated Use #smells instead.
     #
-    def all_smells
-      @smells
-    end
+    alias_method :all_smells, :smells
 
     #
     # Returns the number of non-masked smells in the source.
     #
-    # @deprecated Use #smells instead.
+    # @deprecated Use #smells_count instead.
     #
     def num_active_smells
-      @smells.length
+      smells.length
     end
 
     #

--- a/lib/reek/rake/task.rb
+++ b/lib/reek/rake/task.rb
@@ -4,14 +4,12 @@ require 'rake'
 require 'rake/tasklib'
 
 module Reek
-
   #
   # Defines a task library for running reek.
   # (Classes here will be configured via the Rakefile, and therefore will
   # possess a :reek:attribute or two.)
   #
   module Rake
-
     # A Rake task that runs reek on a set of source files.
     #
     # Example:
@@ -33,7 +31,6 @@ module Reek
     #   rake reek REEK_OPTS=-s                   # sorts the report by smell
     #
     class Task < ::Rake::TaskLib
-
       # Name of reek task.
       # Defaults to :reek.
       attr_accessor :name
@@ -85,7 +82,7 @@ module Reek
         define
       end
 
-  private
+      private
 
       def define # :nodoc:
         desc 'Check for code smells' unless ::Rake.application.last_comment
@@ -97,7 +94,7 @@ module Reek
         return if source_file_list.empty?
         cmd = cmd_words.join(' ')
         puts cmd if @verbose
-        raise('Smells found!') if !system(cmd) and fail_on_error
+        raise('Smells found!') if !system(cmd) && fail_on_error
       end
 
       def self.reek_script
@@ -111,16 +108,16 @@ module Reek
       def cmd_words
         [Task.ruby_exe] +
             ruby_options +
-            [ %Q|"#{Task.reek_script}"| ] +
+            [%("#{Task.reek_script}")] +
             [sort_option] +
-            config_file_list.collect { |fn| ['-c', %["#{fn}"]] }.flatten +
-            source_file_list.collect { |fn| %["#{fn}"] }
+            config_file_list.map { |fn| ['-c', %("#{fn}")] }.flatten +
+            source_file_list.map { |fn| %("#{fn}") }
       end
 
       def config_file_list
         files = ENV['REEK_CFG'] || @config_files
         return [] unless files
-        return FileList[files]
+        FileList[files]
       end
 
       def ruby_options
@@ -143,7 +140,7 @@ module Reek
       def source_file_list # :nodoc:
         files = ENV['REEK_SRC'] || @source_files
         return [] unless files
-        return FileList[files]
+        FileList[files]
       end
     end
   end

--- a/lib/reek/smell_warning.rb
+++ b/lib/reek/smell_warning.rb
@@ -1,11 +1,9 @@
 module Reek
-
   #
   # Reports a warning that a smell has been found.
   # This object is essentially a DTO, and therefore contains a :reek:attribute or two.
   #
   class SmellWarning
-
     include Comparable
 
     MESSAGE_KEY = 'message'
@@ -23,7 +21,7 @@ module Reek
       @smell = {
         CLASS_KEY => class_name,
         SUBCLASS_KEY => subclass_name,
-        MESSAGE_KEY => message,
+        MESSAGE_KEY => message
       }
       @smell.merge!(parameters)
       @status = {
@@ -69,8 +67,6 @@ module Reek
     #
     attr_reader :status
 
-    def is_active() @status[ACTIVE_KEY] end
-
     def hash
       sort_key.hash
     end
@@ -85,18 +81,18 @@ module Reek
 
     def contains_all?(patterns)
       rpt = sort_key.to_s
-      return patterns.all? {|pattern| pattern === rpt}
+      patterns.all? { |pattern| pattern =~ rpt }
     end
 
     def matches?(klass, patterns)
-      @smell.values.include?(klass.to_s) and contains_all?(patterns)
+      @smell.values.include?(klass.to_s) && contains_all?(patterns)
     end
 
     def report_on(listener)
       listener.found_smell(self)
     end
 
-  protected
+    protected
 
     def sort_key
       [@location[CONTEXT_KEY], @smell[MESSAGE_KEY], @smell[CLASS_KEY]]

--- a/lib/reek/smells.rb
+++ b/lib/reek/smells.rb
@@ -24,7 +24,6 @@ require 'reek/smells/utility_function'
 # SMELL: Duplication -- all these should be found automagically
 
 module Reek
-
   #
   # This module contains the various smell detectors.
   #

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -4,7 +4,6 @@ require 'reek/core/smell_configuration'
 
 module Reek
   module Smells
-
     #
     # A class that publishes a getter or setter for an instance variable
     # invites client classes to become too intimate with its inner workings,
@@ -14,13 +13,11 @@ module Reek
     # +attr_reader+, +attr_writer+ and +attr_accessor+ -- including those
     # that are private.
     #
-    # TODO:
-    # * eliminate private attributes
-    # * catch attributes declared "by hand"
+    # TODO: Eliminate private attributes
+    # TODO: Catch attributes declared "by hand"
     #
     class Attribute < SmellDetector
-
-      SMELL_CLASS = self.name.split(/::/)[-1]
+      SMELL_CLASS = name.split(/::/)[-1]
       SMELL_SUBCLASS = SMELL_CLASS
 
       ATTRIBUTE_KEY = 'attribute'
@@ -41,21 +38,21 @@ module Reek
       def examine_context(ctx)
         attributes_in(ctx).map do |attr, line|
           smell = SmellWarning.new(SMELL_CLASS, ctx.full_name, [line],
-            "declares the attribute #{attr}",
-            @source, SMELL_SUBCLASS,
-            {ATTRIBUTE_KEY => attr.to_s})
+                                   "declares the attribute #{attr}",
+                                   @source, SMELL_SUBCLASS,
+                                   ATTRIBUTE_KEY => attr.to_s)
           smell
         end
       end
 
-    private
+      private
 
       def attributes_in(module_ctx)
         result = Set.new
         attr_defn_methods = [:attr, :attr_reader, :attr_writer, :attr_accessor]
         module_ctx.local_nodes(:call) do |call_node|
           if attr_defn_methods.include?(call_node.method_name)
-            call_node.arg_names.each {|arg| result << [arg, call_node.line] }
+            call_node.arg_names.each { |arg| result << [arg, call_node.line] }
           end
         end
         result

--- a/lib/reek/smells/boolean_parameter.rb
+++ b/lib/reek/smells/boolean_parameter.rb
@@ -3,19 +3,17 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # A Boolean parameter effectively permits a method's caller
     # to decide which execution path to take. The
     # offending parameter is a kind of Control Couple.
-    # 
+    #
     # Currently Reek can only detect a Boolean parameter when it has a
     # default initializer.
     #
     class BooleanParameter < SmellDetector
-
       SMELL_CLASS = 'ControlCouple'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
 
       PARAMETER_KEY = 'parameter'
 
@@ -25,13 +23,13 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(method_ctx)
-        method_ctx.parameters.default_assignments.select do |param, value|
+        method_ctx.parameters.default_assignments.select do |_param, value|
           [:true, :false].include?(value[0])
-        end.map do |param, value|
+        end.map do |param, _value|
           param_name = param.to_s
           SmellWarning.new(SMELL_CLASS, method_ctx.full_name, [method_ctx.exp.line],
                            "has boolean parameter '#{param_name}'",
-                           @source, SMELL_SUBCLASS, {PARAMETER_KEY => param_name})
+                           @source, SMELL_SUBCLASS, PARAMETER_KEY => param_name)
         end
       end
     end

--- a/lib/reek/smells/class_variable.rb
+++ b/lib/reek/smells/class_variable.rb
@@ -4,7 +4,6 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # Class variables form part of the global runtime state, and as such make
     # it easy for one part of the system to accidentally or inadvertently
@@ -14,8 +13,7 @@ module Reek
     # the context of the test includes all global state).
     #
     class ClassVariable < SmellDetector
-
-      SMELL_CLASS = self.name.split(/::/)[-1]
+      SMELL_CLASS = name.split(/::/)[-1]
       SMELL_SUBCLASS = SMELL_CLASS
 
       VARIABLE_KEY = 'variable'
@@ -33,9 +31,9 @@ module Reek
         class_variables_in(ctx.exp).map do |attr_name, lines|
           attr_name = attr_name.to_s
           smell = SmellWarning.new(SMELL_CLASS, ctx.full_name, lines,
-            "declares the class variable #{attr_name}",
-            @source, SMELL_SUBCLASS,
-            {VARIABLE_KEY => attr_name})
+                                   "declares the class variable #{attr_name}",
+                                   @source, SMELL_SUBCLASS,
+                                   VARIABLE_KEY => attr_name)
           smell
         end
       end
@@ -45,7 +43,7 @@ module Reek
       # in the given module.
       #
       def class_variables_in(ast)
-        result = Hash.new {|hash,key| hash[key] = []}
+        result = Hash.new { |hash, key| hash[key] = [] }
         collector = proc do |cvar_node|
           result[cvar_node.name].push(cvar_node.line)
         end

--- a/lib/reek/smells/control_parameter.rb
+++ b/lib/reek/smells/control_parameter.rb
@@ -3,7 +3,6 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # Control Coupling occurs when a method or block checks the value of
     # a parameter in order to decide which execution path to take. The
@@ -42,9 +41,8 @@ module Reek
     # the source code.
     #
     class ControlParameter < SmellDetector
-
       SMELL_CLASS = 'ControlCouple'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
       PARAMETER_KEY = 'parameter'
       VALUE_POSITION = 1
 
@@ -59,7 +57,7 @@ module Reek
           SmellWarning.new(SMELL_CLASS, ctx.full_name, control_parameter.lines,
                            control_parameter.smell_message,
                            @source, SMELL_SUBCLASS,
-                           {PARAMETER_KEY => control_parameter.name})
+                           PARAMETER_KEY => control_parameter.name)
         end
       end
 
@@ -98,7 +96,7 @@ module Reek
         end
 
         def control_parameters
-          result = Hash.new {|hash, key| hash[key] = FoundControlParameter.new(key)}
+          result = Hash.new { |hash, key| hash[key] = FoundControlParameter.new(key) }
           potential_parameters.each do |param|
             matches = find_matches(param)
             result[param].record(matches) if matches.any?
@@ -111,13 +109,13 @@ module Reek
         # Returns parameters that aren't used outside of a conditional statements and that
         # could be good candidates for being a control parameter.
         def potential_parameters
-          @context.exp.parameter_names.select {|param| !used_outside_conditional?(param)}
+          @context.exp.parameter_names.select { |param| !used_outside_conditional?(param) }
         end
 
         # Returns wether the parameter is used outside of the conditional statement.
         def used_outside_conditional?(param)
           nodes = @context.exp.each_node(:lvar, [:if, :case, :and, :or, :args])
-          nodes.any? {|node| node.value == param}
+          nodes.any? { |node| node.value == param }
         end
 
         # Find the use of the param that match the definition of a control parameter.
@@ -126,7 +124,7 @@ module Reek
           [:if, :case, :and, :or].each do |keyword|
             @context.local_nodes(keyword).each do |node|
               return [] if used_besides_in_condition?(node, param)
-              node.each_node(:lvar, []) {|inner| matches.push(inner) if inner.value == param}
+              node.each_node(:lvar, []) { |inner| matches.push(inner) if inner.value == param }
             end
           end
           matches
@@ -136,12 +134,12 @@ module Reek
         # conditional statement.
         def used_besides_in_condition?(node, param)
           times_in_conditional, times_total = 0, 0
-          node.each_node(:lvar, [:if, :case]) {|lvar| times_total +=1 if lvar.value == param}
+          node.each_node(:lvar, [:if, :case]) { |lvar| times_total += 1 if lvar.value == param }
           if node.condition
             times_in_conditional += 1 if node.condition[VALUE_POSITION] == param
-            times_in_conditional += node.condition.count {|inner| inner.class == Sexp && inner[VALUE_POSITION] == param}
+            times_in_conditional += node.condition.count { |inner| inner.class == Sexp && inner[VALUE_POSITION] == param }
           end
-          return times_total > times_in_conditional
+          times_total > times_in_conditional
         end
       end
     end

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -3,7 +3,6 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # Duplication occurs when two fragments of code look nearly identical,
     # or when two fragments of code have nearly identical effects
@@ -19,7 +18,7 @@ module Reek
     #
     class DuplicateMethodCall < SmellDetector
       SMELL_CLASS = 'Duplication'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
 
       CALL_KEY = 'call'
       OCCURRENCES_KEY = 'occurrences'
@@ -57,7 +56,7 @@ module Reek
           SmellWarning.new(SMELL_CLASS, ctx.full_name, found_call.lines,
                            found_call.smell_message,
                            @source, SMELL_SUBCLASS,
-                           {CALL_KEY => found_call.call, OCCURRENCES_KEY => found_call.occurs})
+                           CALL_KEY => found_call.call, OCCURRENCES_KEY => found_call.occurs)
         end
       end
 
@@ -86,7 +85,7 @@ module Reek
         end
 
         def lines
-          @occurences.map {|exp| exp.line}
+          @occurences.map(&:line)
         end
       end
 
@@ -101,14 +100,14 @@ module Reek
         end
 
         def calls
-          result = Hash.new {|hash,key| hash[key] = FoundCall.new(key)}
+          result = Hash.new { |hash, key| hash[key] = FoundCall.new(key) }
           collect_calls(result)
           collect_assignments(result)
-          result.values.sort_by {|found_call| found_call.call}
+          result.values.sort_by(&:call)
         end
 
         def smelly_calls
-          calls.select {|found_call| smelly_call? found_call }
+          calls.select { |found_call| smelly_call? found_call }
         end
 
         private
@@ -131,11 +130,11 @@ module Reek
         end
 
         def smelly_call?(found_call)
-          found_call.occurs > @max_allowed_calls and not allow_calls?(found_call.call)
+          found_call.occurs > @max_allowed_calls && !allow_calls?(found_call.call)
         end
 
         def allow_calls?(method)
-          @allow_calls.any? { |allow| /#{allow}/ === method }
+          @allow_calls.any? { |allow| /#{allow}/ =~ method }
         end
       end
     end

--- a/lib/reek/smells/feature_envy.rb
+++ b/lib/reek/smells/feature_envy.rb
@@ -3,15 +3,14 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # Feature Envy occurs when a code fragment references another object
     # more often than it references itself, or when several clients do
     # the same series of manipulations on a particular type of object.
-    # 
+    #
     # A simple example would be the following method, which "belongs"
     # on the Item class and not on the Cart class:
-    # 
+    #
     #  class Cart
     #    def price
     #      @item.price + @item.tax
@@ -22,12 +21,12 @@ module Reek
     # code that "belongs" on one class but which is located in another
     # can be hard to find, and may upset the "System of Names"
     # in the host class.
-    # 
+    #
     # Feature Envy also affects the design's flexibility: A code fragment
     # that is in the wrong class creates couplings that may not be natural
     # within the application's domain, and creates a loss of cohesion
     # in the unwilling host class.
-    # 
+    #
     # Currently +FeatureEnvy+ reports any method that refers to self less
     # often than it refers to (ie. send messages to) some other object.
     #
@@ -35,7 +34,7 @@ module Reek
       include ExcludeInitialize
 
       SMELL_CLASS = 'LowCohesion'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
 
       RECEIVER_KEY = 'receiver'
       REFERENCES_KEY = 'references'
@@ -51,7 +50,7 @@ module Reek
           target = ref.format_ruby
           SmellWarning.new(SMELL_CLASS, method_ctx.full_name, [method_ctx.exp.line],
                            "refers to #{target} more than self",
-                           @source, SMELL_SUBCLASS, {RECEIVER_KEY => target, REFERENCES_KEY => occurs})
+                           @source, SMELL_SUBCLASS, RECEIVER_KEY => target, REFERENCES_KEY => occurs)
         end
       end
     end

--- a/lib/reek/smells/irresponsible_module.rb
+++ b/lib/reek/smells/irresponsible_module.rb
@@ -4,14 +4,12 @@ require 'reek/source/code_comment'
 
 module Reek
   module Smells
-
     #
     # It is considered good practice to annotate every class and module
     # with a brief comment outlining its responsibilities.
     #
     class IrresponsibleModule < SmellDetector
-
-      SMELL_CLASS = self.name.split(/::/)[-1]
+      SMELL_CLASS = name.split(/::/)[-1]
       SMELL_SUBCLASS = SMELL_CLASS
 
       MODULE_NAME_KEY = 'module_name'
@@ -31,10 +29,10 @@ module Reek
       #
       def examine_context(ctx)
         comment = Source::CodeComment.new(ctx.exp.comments)
-        return [] if self.class.descriptive[ctx.full_name] ||= comment.is_descriptive?
+        return [] if self.class.descriptive[ctx.full_name] ||= comment.descriptive?
         smell = SmellWarning.new(SMELL_CLASS, ctx.full_name, [ctx.exp.line],
-          'has no descriptive comment',
-          @source, SMELL_SUBCLASS, {MODULE_NAME_KEY => ctx.exp.text_name})
+                                 'has no descriptive comment',
+                                 @source, SMELL_SUBCLASS, MODULE_NAME_KEY => ctx.exp.text_name)
         [smell]
       end
     end

--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -4,7 +4,6 @@ require 'reek/core/smell_configuration'
 
 module Reek
   module Smells
-
     #
     # A Long Parameter List occurs when a method has more than one
     # or two parameters, or when a method yields more than one or
@@ -14,9 +13,8 @@ module Reek
     # many parameters.
     #
     class LongParameterList < SmellDetector
-
       SMELL_CLASS = 'LongParameterList'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
 
       PARAMETER_COUNT_KEY = 'parameter_count'
 
@@ -32,7 +30,7 @@ module Reek
         super.merge(
           MAX_ALLOWED_PARAMS_KEY => DEFAULT_MAX_ALLOWED_PARAMS,
           Core::SmellConfiguration::OVERRIDES_KEY => {
-            "initialize" => {MAX_ALLOWED_PARAMS_KEY => 5}
+            'initialize' => { MAX_ALLOWED_PARAMS_KEY => 5 }
           }
         )
       end
@@ -47,9 +45,9 @@ module Reek
         num_params = ctx.exp.arg_names.length
         return [] if num_params <= @max_allowed_params
         smell = SmellWarning.new(SMELL_CLASS, ctx.full_name, [ctx.exp.line],
-          "has #{num_params} parameters",
-          @source, SMELL_SUBCLASS,
-          {PARAMETER_COUNT_KEY => num_params})
+                                 "has #{num_params} parameters",
+                                 @source, SMELL_SUBCLASS,
+                                 PARAMETER_COUNT_KEY => num_params)
         [smell]
       end
     end

--- a/lib/reek/smells/long_yield_list.rb
+++ b/lib/reek/smells/long_yield_list.rb
@@ -3,15 +3,13 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # A variant on LongParameterList that checks the number of items
     # passed to a block by a +yield+ call.
     #
     class LongYieldList < SmellDetector
-
       SMELL_CLASS = 'LongParameterList'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
 
       # The name of the config field that sets the maximum number of
       # parameters permitted in any method or block.
@@ -42,7 +40,7 @@ module Reek
           num_params = yield_node.args.length
           SmellWarning.new(SMELL_CLASS, method_ctx.full_name, [yield_node.line],
                            "yields #{num_params} parameters",
-                           @source, SMELL_SUBCLASS, {PARAMETER_COUNT_KEY => num_params})
+                           @source, SMELL_SUBCLASS, PARAMETER_COUNT_KEY => num_params)
         end
       end
     end

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -3,15 +3,13 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # A Nested Iterator occurs when a block contains another block.
     #
     # +NestedIterators+ reports failing methods only once.
     #
     class NestedIterators < SmellDetector
-
-      SMELL_CLASS = self.name.split(/::/)[-1]
+      SMELL_CLASS = name.split(/::/)[-1]
       SMELL_SUBCLASS = SMELL_CLASS
       # SMELL: should be a subclass of UnnecessaryComplexity
       NESTING_DEPTH_KEY = 'depth'
@@ -45,9 +43,9 @@ module Reek
 
         if depth && depth > value(MAX_ALLOWED_NESTING_KEY, ctx, DEFAULT_MAX_ALLOWED_NESTING)
           smell = SmellWarning.new(SMELL_CLASS, ctx.full_name, [exp.line],
-            "contains iterators nested #{depth} deep",
-            @source, SMELL_SUBCLASS,
-            {NESTING_DEPTH_KEY => depth})
+                                   "contains iterators nested #{depth} deep",
+                                   @source, SMELL_SUBCLASS,
+                                   NESTING_DEPTH_KEY => depth)
           [smell]
         else
           []
@@ -55,17 +53,17 @@ module Reek
         # BUG: no longer reports nesting outside methods (eg. in Optparse)
       end
 
-    private
+      private
 
       def find_deepest_iterator(ctx)
         @ignore_iterators = value(IGNORE_ITERATORS_KEY, ctx, DEFAULT_IGNORE_ITERATORS)
 
-        find_iters(ctx.exp, 1).sort_by {|item| item[1]}.last
+        find_iters(ctx.exp, 1).sort_by { |item| item[1] }.last
       end
 
       def find_iters(exp, depth)
         exp.map do |elem|
-          next unless Sexp === elem
+          next unless elem.is_a? Sexp
           case elem.first
           when :iter
             find_iters_for_iter_node(elem, depth)
@@ -87,7 +85,7 @@ module Reek
 
       def ignored_iterator?(exp)
         name = exp.call.method_name.to_s
-        @ignore_iterators.any? { |pattern| /#{pattern}/ === name }
+        @ignore_iterators.any? { |pattern| /#{pattern}/ =~ name }
       end
     end
   end

--- a/lib/reek/smells/nil_check.rb
+++ b/lib/reek/smells/nil_check.rb
@@ -3,13 +3,11 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     # Checking for nil is a special kind of type check, and therefore a case of
     # SimulatedPolymorphism.
     class NilCheck < SmellDetector
-
       SMELL_CLASS = 'SimulatedPolymorphism'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
 
       def examine_context(ctx)
         call_nodes = CallNodeFinder.new(ctx)
@@ -18,7 +16,7 @@ module Reek
 
         smelly_nodes.map do |node|
           SmellWarning.new(SMELL_CLASS, ctx.full_name, Array(node.line),
-                           "performs a nil-check.",
+                           'performs a nil-check.',
                            @source, SMELL_SUBCLASS)
         end
       end
@@ -42,16 +40,16 @@ module Reek
         end
 
         def smelly
-          @nodes.select{ |call|
-            nil_chk?(call) 
-          }
+          @nodes.select do |call|
+            nil_chk?(call)
+          end
         end
 
         def nil_chk?(call)
-          nilQ_use?(call) || eq_nil_use?(call) 
+          nil_query_use?(call) || eq_nil_use?(call)
         end
 
-        def nilQ_use?(call)
+        def nil_query_use?(call)
           call.last == :nil?
         end
 
@@ -75,16 +73,15 @@ module Reek
         end
 
         def smelly
-          @nodes.select{ |when_node|
+          @nodes.select do |when_node|
             nil_chk?(when_node)
-          }
+          end
         end
 
         def nil_chk?(when_node)
           when_node.include?(CASE_NIL_NODE)
         end
       end
-
     end
   end
 end

--- a/lib/reek/smells/prima_donna_method.rb
+++ b/lib/reek/smells/prima_donna_method.rb
@@ -6,19 +6,22 @@ module Reek
     # Excerpt from:
     # http://dablog.rubypal.com/2007/8/15/bang-methods-or-danger-will-rubyist
     # since this sums it up really well:
-    # ------------------------------
-    # The ! in method names that end with ! means, “This method is dangerous”
-    # or, more precisely, this method is the “dangerous” version of an
-    # equivalent method, with the same name minus the !.  “Danger” is relative;
-    # the ! doesn’t mean anything at all unless the method name it’s in
-    # corresponds to a similar but bang-less method name.  Don’t add ! to your
-    # destructive (receiver-changing) methods’ names, unless you consider the
-    # changing to be “dangerous” and you have a “non-dangerous” equivalent
-    # method without the !.  If some arbitrary subset of destructive methods end
-    # with !, then the whole point of ! gets distorted and diluted, and ! ceases
-    # to convey any information whatsoever
-    # ------------------------------
+    #
+    #   The ! in method names that end with ! means, "This method is dangerous"
+    #   -- or, more precisely, this method is the "dangerous" version of an
+    #   equivalent method, with the same name minus the !. "Danger" is
+    #   relative; the ! doesn't mean anything at all unless the method name
+    #   it's in corresponds to a similar but bang-less method name.
+    #
+    #   Don't add ! to your destructive (receiver-changing) methods' names,
+    #   unless you consider the changing to be "dangerous" and you have a
+    #   "non-dangerous" equivalent method without the !. If some arbitrary
+    #   subset of destructive methods end with !, then the whole point of !
+    #   gets distorted and diluted, and ! ceases to convey any information
+    #   whatsoever.
+    #
     # Such a method is called PrimaDonnaMethod and is reported as a smell.
+    #
     class PrimaDonnaMethod < SmellDetector
       SMELL_CLASS    = smell_class_name
       SMELL_SUBCLASS = smell_class_name
@@ -29,11 +32,16 @@ module Reek
 
       def examine_context(ctx)
         ctx.node_instance_methods.map do |method_sexp|
-          if method_sexp.ends_with_bang?
-            SmellWarning.new(SMELL_CLASS, ctx.full_name, [ctx.exp.line],
-                             %Q!has prima donna method `#{method_sexp.name}`!,
-                             @source, SMELL_SUBCLASS) unless ctx.node_instance_methods.detect {|sexp_item| sexp_item.name.to_s == method_sexp.name_without_bang }
+          next unless method_sexp.ends_with_bang?
+
+          version_without_bang = ctx.node_instance_methods.find do |sexp_item|
+            sexp_item.name.to_s == method_sexp.name_without_bang
           end
+          next if version_without_bang
+
+          SmellWarning.new(SMELL_CLASS, ctx.full_name, [ctx.exp.line],
+                           "has prima donna method `#{method_sexp.name}`",
+                           @source, SMELL_SUBCLASS)
         end.compact
       end
     end

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -3,7 +3,6 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # Simulated Polymorphism occurs when
     # * code uses a case statement (especially on a type field);
@@ -22,9 +21,8 @@ module Reek
     # testing the same value throughout a single class.
     #
     class RepeatedConditional < SmellDetector
-
       SMELL_CLASS = 'SimulatedPolymorphism'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
 
       def self.contexts      # :nodoc:
         [:class]
@@ -47,7 +45,7 @@ module Reek
       #
       def examine_context(ctx)
         @max_identical_ifs = value(MAX_IDENTICAL_IFS_KEY, ctx, DEFAULT_MAX_IFS)
-        conditional_counts(ctx).select do |key, lines|
+        conditional_counts(ctx).select do |_key, lines|
           lines.length > @max_identical_ifs
         end.map do |key, lines|
           occurs = lines.length
@@ -55,7 +53,7 @@ module Reek
           SmellWarning.new(SMELL_CLASS, ctx.full_name, lines,
                            "tests #{expr} at least #{occurs} times",
                            @source, SMELL_SUBCLASS,
-                           {'expression' => expr, 'occurrences' => occurs})
+                           'expression' => expr, 'occurrences' => occurs)
         end
       end
 
@@ -65,13 +63,13 @@ module Reek
       # occurs. Ignores nested classes and modules.
       #
       def conditional_counts(sexp)
-        result = Hash.new {|hash, key| hash[key] = []}
-        collector = proc { |node|
+        result = Hash.new { |hash, key| hash[key] = [] }
+        collector = proc do |node|
           condition = node.condition
-          next if condition.nil? or condition == s(:call, nil, :block_given?)
+          next if condition.nil? || condition == s(:call, nil, :block_given?)
           result[condition].push(condition.line)
-        }
-        [:if, :case].each {|stmt| sexp.local_nodes(stmt, &collector) }
+        end
+        [:if, :case].each { |stmt| sexp.local_nodes(stmt, &collector) }
         result
       end
     end

--- a/lib/reek/smells/smell_detector.rb
+++ b/lib/reek/smells/smell_detector.rb
@@ -4,7 +4,6 @@ require 'reek/core/smell_configuration'
 
 module Reek
   module Smells
-
     module ExcludeInitialize
       def self.default_config
         super.merge(EXCLUDE_KEY => ['initialize'])
@@ -15,7 +14,6 @@ module Reek
     # Shared responsibilities of all smell detectors.
     #
     class SmellDetector
-
       # The name of the config field that lists the names of code contexts
       # that should not be checked. Add this field to the config for each
       # smell that should ignore this code element.
@@ -65,11 +63,15 @@ module Reek
       end
 
       def examine(context)
-        enabled = @config.enabled? && config_for(context)[Core::SmellConfiguration::ENABLED_KEY] != false
-        if enabled && !exception?(context)
-          sm = examine_context(context)
-          @smells_found += sm
-        end
+        return unless enabled_for? context
+        return if exception?(context)
+
+        sm = examine_context(context)
+        @smells_found += sm
+      end
+
+      def enabled_for?(context)
+        enabled? && config_for(context)[Core::SmellConfiguration::ENABLED_KEY] != false
       end
 
       def exception?(context)

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -3,18 +3,16 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # A Large Class is a class or module that has a large number of
     # instance variables, methods or lines of code.
-    # 
+    #
     # +TooManyInstanceVariables' reports classes having more than a
     # configurable number of instance variables.
     #
     class TooManyInstanceVariables < SmellDetector
-
       SMELL_CLASS = 'LargeClass'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
       IVAR_COUNT_KEY = 'ivar_count'
 
       # The name of the config field that sets the maximum number of instance
@@ -44,15 +42,15 @@ module Reek
         check_num_ivars(ctx)
       end
 
-    private
+      private
 
       def check_num_ivars(ctx)  # :nodoc:
-        count = ctx.local_nodes(:iasgn).map {|iasgn| iasgn[1]}.uniq.length
+        count = ctx.local_nodes(:iasgn).map { |iasgn| iasgn[1] }.uniq.length
         return [] if count <= @max_allowed_ivars
         smell = SmellWarning.new(SMELL_CLASS, ctx.full_name, [ctx.exp.line],
-          "has at least #{count} instance variables",
-          @source, SMELL_SUBCLASS,
-          {IVAR_COUNT_KEY => count})
+                                 "has at least #{count} instance variables",
+                                 @source, SMELL_SUBCLASS,
+                                 IVAR_COUNT_KEY => count)
         [smell]
       end
     end

--- a/lib/reek/smells/too_many_methods.rb
+++ b/lib/reek/smells/too_many_methods.rb
@@ -3,20 +3,18 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # A Large Class is a class or module that has a large number of
     # instance variables, methods or lines of code.
-    # 
+    #
     # +TooManyMethods+ reports classes having more than a configurable number
     # of methods. The method count includes public, protected and private
     # methods, and excludes methods inherited from superclasses or included
     # modules.
     #
     class TooManyMethods < SmellDetector
-
       SMELL_CLASS = 'LargeClass'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
       METHOD_COUNT_KEY = 'method_count'
 
       # The name of the config field that sets the maximum number of methods
@@ -46,15 +44,15 @@ module Reek
         check_num_methods(ctx)
       end
 
-    private
+      private
 
       def check_num_methods(ctx)  # :nodoc:
         actual = ctx.local_nodes(:defn).length
         return [] if actual <= @max_allowed_methods
         smell = SmellWarning.new(SMELL_CLASS, ctx.full_name, [ctx.exp.line],
-          "has at least #{actual} methods",
-          @source, SMELL_SUBCLASS,
-          {METHOD_COUNT_KEY => actual})
+                                 "has at least #{actual} methods",
+                                 @source, SMELL_SUBCLASS,
+                                 METHOD_COUNT_KEY => actual)
         [smell]
       end
     end

--- a/lib/reek/smells/too_many_statements.rb
+++ b/lib/reek/smells/too_many_statements.rb
@@ -3,16 +3,14 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # A Long Method is any method that has a large number of lines.
     #
     # +TooManyStatements+ reports any method with more than 5 statements.
     #
     class TooManyStatements < SmellDetector
-
       SMELL_CLASS = 'LongMethod'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
 
       STATEMENT_COUNT_KEY = 'statement_count'
 
@@ -39,9 +37,9 @@ module Reek
         num = ctx.num_statements
         return [] if num <= @max_allowed_statements
         smell = SmellWarning.new(SMELL_CLASS, ctx.full_name, [ctx.exp.line],
-          "has approx #{num} statements",
-          @source, SMELL_SUBCLASS,
-          {STATEMENT_COUNT_KEY => num})
+                                 "has approx #{num} statements",
+                                 @source, SMELL_SUBCLASS,
+                                 STATEMENT_COUNT_KEY => num)
         [smell]
       end
     end

--- a/lib/reek/smells/uncommunicative_method_name.rb
+++ b/lib/reek/smells/uncommunicative_method_name.rb
@@ -3,11 +3,10 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # An Uncommunicative Name is a name that doesn't communicate its intent
     # well enough.
-    # 
+    #
     # Poor names make it hard for the reader to build a mental picture
     # of what's going on in the code. They can also be mis-interpreted;
     # and they hurt the flow of reading, because the reader must slow
@@ -18,9 +17,8 @@ module Reek
     # * names ending with a number
     #
     class UncommunicativeMethodName < SmellDetector
-
       SMELL_CLASS = 'UncommunicativeName'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
       METHOD_NAME_KEY = 'method_name'
 
       # The name of the config field that lists the regexps of
@@ -59,10 +57,10 @@ module Reek
         return [] if @accept_names.include?(ctx.full_name)
         var = name.gsub(/^[@\*\&]*/, '')
         return [] if @accept_names.include?(var)
-        return [] unless @reject_names.detect {|patt| patt === var}
+        return [] unless @reject_names.find { |patt| patt =~ var }
         smell = SmellWarning.new('UncommunicativeName', ctx.full_name, [ctx.exp.line],
-          "has the name '#{name}'",
-          @source, 'UncommunicativeMethodName', {METHOD_NAME_KEY => name})
+                                 "has the name '#{name}'",
+                                 @source, 'UncommunicativeMethodName', METHOD_NAME_KEY => name)
         [smell]
       end
     end

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -3,11 +3,10 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # An Uncommunicative Name is a name that doesn't communicate its intent
     # well enough.
-    # 
+    #
     # Poor names make it hard for the reader to build a mental picture
     # of what's going on in the code. They can also be mis-interpreted;
     # and they hurt the flow of reading, because the reader must slow
@@ -18,9 +17,8 @@ module Reek
     # * names ending with a number
     #
     class UncommunicativeModuleName < SmellDetector
-
       SMELL_CLASS = 'UncommunicativeName'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
       MODULE_NAME_KEY = 'module_name'
 
       # The name of the config field that lists the regexps of
@@ -62,10 +60,10 @@ module Reek
         return [] if @accept_names.include?(full_name)
         var = name.gsub(/^[@\*\&]*/, '')
         return [] if @accept_names.include?(var)
-        return [] unless @reject_names.detect {|patt| patt === var}
+        return [] unless @reject_names.find { |patt| patt =~ var }
         smell = SmellWarning.new(SMELL_CLASS, full_name, [exp.line],
-          "has the name '#{name}'",
-          @source, SMELL_SUBCLASS, {MODULE_NAME_KEY => name})
+                                 "has the name '#{name}'",
+                                 @source, SMELL_SUBCLASS, MODULE_NAME_KEY => name)
         [smell]
       end
     end

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -3,11 +3,10 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # An Uncommunicative Name is a name that doesn't communicate its intent
     # well enough.
-    # 
+    #
     # Poor names make it hard for the reader to build a mental picture
     # of what's going on in the code. They can also be mis-interpreted;
     # and they hurt the flow of reading, because the reader must slow
@@ -18,9 +17,8 @@ module Reek
     # * names ending with a number
     #
     class UncommunicativeParameterName < SmellDetector
-
       SMELL_CLASS = 'UncommunicativeName'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
       PARAMETER_NAME_KEY = 'parameter_name'
 
       # The name of the config field that lists the regexps of
@@ -57,18 +55,18 @@ module Reek
         @accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
         context_expression = ctx.exp
         context_expression.parameter_names.select do |name|
-          is_bad_name?(name) && ctx.uses_param?(name)
+          bad_name?(name) && ctx.uses_param?(name)
         end.map do |name|
           SmellWarning.new(SMELL_CLASS, ctx.full_name, [context_expression.line],
                            "has the parameter name '#{name}'",
-                           @source, SMELL_SUBCLASS, {PARAMETER_NAME_KEY => name.to_s})
+                           @source, SMELL_SUBCLASS, PARAMETER_NAME_KEY => name.to_s)
         end
       end
 
-      def is_bad_name?(name)
+      def bad_name?(name)
         var = name.to_s.gsub(/^[@\*\&]*/, '')
-        return false if var == '*' or @accept_names.include?(var)
-        @reject_names.detect {|patt| patt === var}
+        return false if var == '*' || @accept_names.include?(var)
+        @reject_names.find { |patt| patt =~ var }
       end
     end
   end

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -3,11 +3,10 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # An Uncommunicative Name is a name that doesn't communicate its intent
     # well enough.
-    # 
+    #
     # Poor names make it hard for the reader to build a mental picture
     # of what's going on in the code. They can also be mis-interpreted;
     # and they hurt the flow of reading, because the reader must slow
@@ -18,9 +17,8 @@ module Reek
     # * names ending with a number
     #
     class UncommunicativeVariableName < SmellDetector
-
       SMELL_CLASS = 'UncommunicativeName'
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
       VARIABLE_NAME_KEY = 'variable_name'
 
       # The name of the config field that lists the regexps of
@@ -55,37 +53,37 @@ module Reek
       def examine_context(ctx)
         @reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
         @accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
-        variable_names(ctx.exp).select do |name, lines|
-          is_bad_name?(name, ctx)
+        variable_names(ctx.exp).select do |name, _lines|
+          bad_name?(name, ctx)
         end.map do |name, lines|
           SmellWarning.new(SMELL_CLASS, ctx.full_name, lines,
                            "has the variable name '#{name}'",
-                           @source, SMELL_SUBCLASS, {VARIABLE_NAME_KEY => name.to_s})
+                           @source, SMELL_SUBCLASS, VARIABLE_NAME_KEY => name.to_s)
         end
       end
 
-      def is_bad_name?(name, ctx)
+      def bad_name?(name, _ctx)
         var = name.to_s.gsub(/^[@\*\&]*/, '')
         return false if @accept_names.include?(var)
-        @reject_names.detect {|patt| patt === var}
+        @reject_names.find { |patt| patt =~ var }
       end
 
       def variable_names(exp)
-        result = Hash.new {|hash, key| hash[key] = []}
+        result = Hash.new { |hash, key| hash[key] = [] }
         find_assignment_variable_names(exp, result)
         find_block_argument_variable_names(exp, result)
-        result.to_a.sort_by {|name, _| name.to_s}
+        result.to_a.sort_by { |name, _| name.to_s }
       end
 
       def find_assignment_variable_names(exp, accumulator)
         assignment_nodes = exp.each_node(:lasgn, [:class, :module, :defs, :defn])
 
         case exp.first
-          when :class, :module
-            assignment_nodes += exp.each_node(:iasgn, [:class, :module])
+        when :class, :module
+          assignment_nodes += exp.each_node(:iasgn, [:class, :module])
         end
 
-        assignment_nodes.each {|asgn| accumulator[asgn[1]].push(asgn.line) }
+        assignment_nodes.each { |asgn| accumulator[asgn[1]].push(asgn.line) }
       end
 
       def find_block_argument_variable_names(exp, accumulator)
@@ -115,10 +113,9 @@ module Reek
 
       def record_variable_name(exp, symbol, accumulator)
         varname = symbol.to_s.sub(/^\*/, '')
-        if varname != ""
-          var = varname.to_sym
-          accumulator[var].push(exp.line)
-        end
+        return if varname == ''
+        var = varname.to_sym
+        accumulator[var].push(exp.line)
       end
     end
   end

--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -3,12 +3,10 @@ require 'reek/smell_warning'
 
 module Reek
   module Smells
-
     #
     # Methods should use their parameters.
     #
     class UnusedParameters < SmellDetector
-
       SMELL_CLASS = 'UnusedCode'
       SMELL_SUBCLASS = name.split(/::/)[-1]
 
@@ -33,14 +31,13 @@ module Reek
         SmellWarning.new(
           SMELL_CLASS,
           method_ctx.full_name,
-          [ method_ctx.exp.line ],
+          [method_ctx.exp.line],
           "has unused parameter '#{param_name}'",
           @source,
           SMELL_SUBCLASS,
-          { PARAMETER_KEY => param_name }
+          PARAMETER_KEY => param_name
         )
       end
-
     end
   end
 end

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -4,13 +4,12 @@ require 'reek/source/reference_collector'
 
 module Reek
   module Smells
-
-    # 
+    #
     # A Utility Function is any instance method that has no
     # dependency on the state of the instance.
-    # 
+    #
     # Currently +UtilityFunction+ will warn about any method that:
-    # 
+    #
     # * is non-empty, and
     # * does not override an inherited method, and
     # * calls at least one method on another object, and
@@ -34,8 +33,7 @@ module Reek
     # likely belong there.
     #
     class UtilityFunction < SmellDetector
-
-      SMELL_SUBCLASS = self.name.split(/::/)[-1]
+      SMELL_SUBCLASS = name.split(/::/)[-1]
       SMELL_CLASS = 'LowCohesion'
 
       # The name of the config field that sets the maximum number of
@@ -50,6 +48,7 @@ module Reek
         def contexts      # :nodoc:
           [:defn]
         end
+
         def default_config
           super.merge(HELPER_CALLS_LIMIT_KEY => DEFAULT_HELPER_CALLS_LIMIT)
         end
@@ -64,14 +63,14 @@ module Reek
         return [] if method_ctx.num_statements == 0
         return [] if depends_on_instance?(method_ctx.exp)
         return [] if num_helper_methods(method_ctx) <= value(HELPER_CALLS_LIMIT_KEY, method_ctx, DEFAULT_HELPER_CALLS_LIMIT)
-          # SMELL: loads of calls to value{} with the above pattern
+        # SMELL: loads of calls to value{} with the above pattern
         smell = SmellWarning.new(SMELL_CLASS, method_ctx.full_name, [method_ctx.exp.line],
-          "doesn't depend on instance state",
-          @source, SMELL_SUBCLASS)
+                                 "doesn't depend on instance state",
+                                 @source, SMELL_SUBCLASS)
         [smell]
       end
 
-    private
+      private
 
       def depends_on_instance?(exp)
         Reek::Source::ReferenceCollector.new(exp).num_refs_to_self > 0

--- a/lib/reek/source.rb
+++ b/lib/reek/source.rb
@@ -8,7 +8,6 @@ require 'reek/source/source_locator'
 require 'reek/source/tree_dresser'
 
 module Reek
-
   #
   # This module contains a set of classes for interacting with Ruby
   # source code and abstract syntax trees.

--- a/lib/reek/source/code_comment.rb
+++ b/lib/reek/source/code_comment.rb
@@ -1,7 +1,6 @@
 
 module Reek
   module Source
-
     #
     # A comment header from an abstract syntax tree; found directly above
     # module, class and method definitions.
@@ -10,7 +9,6 @@ module Reek
       CONFIG_REGEX = /:reek:(\w+)(:\s*\{.*?\})?/
 
       def initialize(text)
-        @config =  Hash.new { |hash,key| hash[key] = {} }
         @text = text.gsub(CONFIG_REGEX) do
           add_to_config($1, $2)
           ''
@@ -18,19 +16,20 @@ module Reek
       end
 
       def config
-        @config
+        @config ||= Hash.new { |hash, key| hash[key] = {} }
       end
 
-      def is_descriptive?
+      def descriptive?
         @text.split(/\s+/).length >= 2
       end
 
-    protected
+      protected
+
       def add_to_config(smell, options)
         options ||= ': { enabled: false }'
-        @config.merge! YAML.load(smell.gsub(/(?:^|_)(.)/) { $1.upcase } + options)
-        # extend this to all configs --------------------------^
-        # extend to allow configuration of whole smell class, not just subclass
+        config.merge! YAML.load(smell.gsub(/(?:^|_)(.)/) { $1.upcase } + options)
+        # TODO: extend this to all configs -------------------^
+        # TODO: extend to allow configuration of whole smell class, not just subclass
       end
     end
   end

--- a/lib/reek/source/config_file.rb
+++ b/lib/reek/source/config_file.rb
@@ -3,13 +3,11 @@ require 'reek/config_file_exception'
 
 module Reek
   module Source
-
     #
     # A file called <something>.reek containing configuration settings for
     # any or all of the smell detectors.
     #
     class ConfigFile
-
       #
       # Load the YAML config file from the supplied +file_path+.
       #
@@ -59,7 +57,7 @@ module Reek
           report_error(error.to_s)
         end
 
-        report_error('Not a hash') unless Hash === result
+        report_error('Not a hash') unless result.is_a? Hash
 
         result
       end
@@ -79,7 +77,7 @@ module Reek
       # Error.
       #
       def report_error(reason)
-        raise ConfigFileException.new message(reason)
+        raise ConfigFileException, message(reason)
       end
 
       def message(reason)

--- a/lib/reek/source/core_extras.rb
+++ b/lib/reek/source/core_extras.rb
@@ -26,7 +26,7 @@ class IO
   # @return [Reek::Source::SourceCode]
   #
   def to_reek_source(description = 'io')
-    Reek::Source::SourceCode.new(self.readlines.join, description)
+    Reek::Source::SourceCode.new(readlines.join, description)
   end
 end
 

--- a/lib/reek/source/reference_collector.rb
+++ b/lib/reek/source/reference_collector.rb
@@ -1,7 +1,6 @@
 
 module Reek
   module Source
-
     #
     # Locates references to the current object within a portion
     # of an abstract syntax tree.
@@ -16,7 +15,7 @@ module Reek
       def num_refs_to_self
         result = 0
         [:self, :zsuper, :ivar, :iasgn].each do |node_type|
-          @ast.look_for(node_type, STOP_NODES) { result += 1}
+          @ast.look_for(node_type, STOP_NODES) { result += 1 }
         end
         @ast.look_for(:call, STOP_NODES) do |call|
           result += 1 unless call.receiver

--- a/lib/reek/source/sexp_extensions.rb
+++ b/lib/reek/source/sexp_extensions.rb
@@ -10,7 +10,7 @@ module Reek
           @name = name
         end
 
-        def == other
+        def ==(other)
           @name == other
         end
 
@@ -32,11 +32,11 @@ module Reek
       end
 
       module AndNode
-        def condition() self[1..2].tap {|node| node.extend SexpNode } end
+        def condition() self[1..2].tap { |node| node.extend SexpNode } end
       end
 
       module OrNode
-        def condition() self[1..2].tap {|node| node.extend SexpNode } end
+        def condition() self[1..2].tap { |node| node.extend SexpNode } end
       end
 
       module AttrasgnNode
@@ -51,8 +51,9 @@ module Reek
         def receiver() self[1] end
         def method_name() self[2] end
         def args() self[3..-1] end
+
         def arg_names
-          args.map {|arg| arg[1]}
+          args.map { |arg| arg[1] }
         end
       end
 
@@ -69,7 +70,7 @@ module Reek
 
       module MethodNode
         def arguments
-          @arguments ||= parameters.reject {|param| param.block? }
+          @arguments ||= parameters.reject(&:block?)
         end
 
         def arg_names
@@ -77,9 +78,9 @@ module Reek
         end
 
         def parameters
-          @parameters ||= argslist[1..-1].map { |param|
-            MethodParameter.new(Sexp === param ?  param[1] : param)
-          }
+          @parameters ||= argslist[1..-1].map do |param|
+            MethodParameter.new(param.is_a?(Sexp) ? param[1] : param)
+          end
         end
 
         def parameter_names
@@ -98,7 +99,8 @@ module Reek
       module DefnNode
         def name() self[1] end
         def argslist() self[2] end
-        def body()
+
+        def body
           self[3..-1].extend SexpNode
         end
         include MethodNode
@@ -112,7 +114,8 @@ module Reek
         def receiver() self[1] end
         def name() self[2] end
         def argslist() self[3] end
-        def body()
+
+        def body
           self[4..-1].extend SexpNode
         end
         include MethodNode
@@ -131,6 +134,7 @@ module Reek
         def args() self[2] end
         def block() self[3] end
         def parameters() self[2] || [] end
+
         def parameter_names
           parameters[1..-1].to_a
         end
@@ -158,13 +162,14 @@ module Reek
         def name() self[1] end
 
         def simple_name
-          Sexp === name ? name.simple_name : name
+          name.is_a?(Sexp) ? name.simple_name : name
         end
 
         def full_name(outer)
           prefix = outer == '' ? '' : "#{outer}::"
           "#{prefix}#{text_name}"
         end
+
         def text_name
           SexpNode.format(name)
         end
@@ -177,8 +182,9 @@ module Reek
 
       module YieldNode
         def args() self[1..-1] end
+
         def arg_names
-          args.map {|arg| arg[1]}
+          args.map { |arg| arg[1] }
         end
       end
     end

--- a/lib/reek/source/sexp_formatter.rb
+++ b/lib/reek/source/sexp_formatter.rb
@@ -2,14 +2,13 @@ require 'ruby2ruby'
 
 module Reek
   module Source
-
     #
     # Formats snippets of syntax tree back into Ruby source code.
     #
     class SexpFormatter
       def self.format(sexp)
-        return sexp.to_s unless Array === sexp
-        sexp = Sexp.from_array(YAML::load(YAML::dump(sexp)))
+        return sexp.to_s unless sexp.is_a? Array
+        sexp = Sexp.from_array(YAML.load(YAML.dump(sexp)))
         Ruby2Ruby.new.process(sexp)
       end
     end

--- a/lib/reek/source/sexp_node.rb
+++ b/lib/reek/source/sexp_node.rb
@@ -13,15 +13,7 @@ module Reek
       end
 
       def hash
-        self.inspect.hash
-      end
-
-      def is_language_node?
-        Symbol === first
-      end
-
-      def has_type?(type)
-        is_language_node? and first == type
+        inspect.hash
       end
 
       def each_node(type, ignoring, &blk)
@@ -29,13 +21,13 @@ module Reek
           look_for(type, ignoring, &blk)
         else
           result = []
-          look_for(type, ignoring) {|exp| result << exp}
+          look_for(type, ignoring) { |exp| result << exp }
           result
         end
       end
 
       def each_sexp
-        each { |elem| yield elem if Sexp === elem }
+        each { |elem| yield elem if elem.is_a? Sexp }
       end
 
       #
@@ -50,8 +42,8 @@ module Reek
         blk.call(self) if first == target_type
       end
 
-      def has_nested_node?(target_type)
-        look_for(target_type) { |elem| return true }
+      def contains_nested_node?(target_type)
+        look_for(target_type) { |_elem| return true }
         false
       end
 
@@ -60,7 +52,7 @@ module Reek
       end
 
       def deep_copy
-        Sexp.new(*map { |elem| Sexp === elem ? elem.deep_copy : elem })
+        Sexp.new(*map { |elem| elem.is_a?(Sexp) ? elem.deep_copy : elem })
       end
     end
   end

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -4,22 +4,10 @@ require 'reek/source/tree_dresser'
 
 module Reek
   module Source
-
     #
     # A +Source+ object represents a chunk of Ruby source code.
     #
     class SourceCode
-
-      @@err_io = $stderr
-
-      class << self
-        def err_io=(io)
-          original = @@err_io
-          @@err_io = io
-          original
-        end
-      end
-
       attr_reader :desc
 
       def initialize(code, desc, parser = RubyParser.new)
@@ -36,7 +24,7 @@ module Reek
         begin
           ast = @parser.parse(@source, @desc)
         rescue Racc::ParseError, RubyParser::SyntaxError => error
-          @@err_io.puts "#{desc}: #{error.class.name}: #{error}"
+          $stderr.puts "#{desc}: #{error.class.name}: #{error}"
         end
         ast ||= s()
         TreeDresser.new.dress(ast)

--- a/lib/reek/source/source_file.rb
+++ b/lib/reek/source/source_file.rb
@@ -2,13 +2,11 @@ require 'reek/source/source_code'
 
 module Reek
   module Source
-
     #
     # Represents a file of Ruby source, whose contents will be examined
     # for code smells.
     #
     class SourceFile < SourceCode
-
       def initialize(path)
         @path = path
         super(IO.readlines(@path).join, @path)

--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -2,24 +2,23 @@ require 'reek/source/core_extras'
 
 module Reek
   module Source
-
     #
     # Finds Ruby source files in a filesystem.
     #
     class SourceLocator
       def initialize(paths)
-        @paths = paths.map {|path| path.chomp('/') }
+        @paths = paths.map { |path| path.chomp('/') }
       end
 
       def all_sources
-        valid_paths.map {|path| File.new(path).to_reek_source }
+        valid_paths.map { |path| File.new(path).to_reek_source }
       end
 
-    private
+      private
 
       def all_ruby_source_files(paths)
         paths.map do |path|
-          if test ?d, path
+          if test 'd', path
             all_ruby_source_files(Dir["#{path}/**/*.rb"])
           else
             path
@@ -29,7 +28,7 @@ module Reek
 
       def valid_paths
         all_ruby_source_files(@paths).select do |path|
-          if test ?f, path
+          if test 'f', path
             true
           else
             $stderr.puts "Error: No such file - #{path}"

--- a/lib/reek/source/source_repository.rb
+++ b/lib/reek/source/source_repository.rb
@@ -10,7 +10,7 @@ module Reek
     # single unit of Ruby source code.
     #
     class SourceRepository
-      def self.parse source
+      def self.parse(source)
         case source
         when Array
           new 'dir', Source::SourceLocator.new(source).all_sources
@@ -25,12 +25,12 @@ module Reek
       include Enumerable
       attr_reader :description
 
-      def initialize description, sources
+      def initialize(description, sources)
         @description = description
         @sources = sources
       end
 
-      def each &block
+      def each(&block)
         @sources.each(&block)
       end
     end

--- a/lib/reek/source/tree_dresser.rb
+++ b/lib/reek/source/tree_dresser.rb
@@ -33,12 +33,12 @@ module Reek
 
       def extension_map
         @extension_map ||= begin
-                             assoc = @extensions_module.constants.map { |const|
+                             assoc = @extensions_module.constants.map do |const|
                                [
                                  const.to_s.sub(/Node$/, '').downcase.to_sym,
                                  @extensions_module.const_get(const)
                                ]
-                             }
+                             end
                              Hash[assoc]
                            end
       end

--- a/lib/reek/spec.rb
+++ b/lib/reek/spec.rb
@@ -3,7 +3,6 @@ require 'reek/spec/should_reek_of'
 require 'reek/spec/should_reek_only_of'
 
 module Reek
-
   #
   # Provides matchers for Rspec, making it easy to check code quality.
   #
@@ -34,7 +33,7 @@ module Reek
   #  'def equals(other) other.thing == self.thing end'.should_not reek
   #
   # To check for specific smells, use something like this:
-  # 
+  #
   #   ruby = 'def double_thing() @other.thing.foo + @other.thing.foo end'
   #   ruby.should reek_of(:Duplication, /@other.thing[^\.]/)
   #   ruby.should reek_of(:Duplication, /@other.thing.foo/)

--- a/lib/reek/spec/should_reek.rb
+++ b/lib/reek/spec/should_reek.rb
@@ -5,7 +5,6 @@ require 'reek/cli/report/strategy'
 
 module Reek
   module Spec
-
     #
     # An rspec matcher that matches when the +actual+ has code smells.
     #

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -2,7 +2,6 @@ require 'reek/examiner'
 
 module Reek
   module Spec
-
     #
     # An rspec matcher that matches when the +actual+ has the specified
     # code smell.
@@ -16,7 +15,7 @@ module Reek
       def matches?(actual)
         @examiner = Examiner.new(actual)
         @all_smells = @examiner.smells
-        @all_smells.any? {|warning| warning.matches?(@klass, @patterns)}
+        @all_smells.any? { |warning| warning.matches?(@klass, @patterns) }
       end
 
       def failure_message

--- a/lib/reek/spec/should_reek_only_of.rb
+++ b/lib/reek/spec/should_reek_only_of.rb
@@ -5,7 +5,6 @@ require 'reek/cli/report/strategy'
 
 module Reek
   module Spec
-
     #
     # An rspec matcher that matches when the +actual+ has the specified
     # code smell and no others.
@@ -18,7 +17,7 @@ module Reek
       def matches_examiner?(examiner)
         @examiner = examiner
         @warnings = @examiner.smells
-        @warnings.length == 1 and @warnings[0].matches?(@klass, @patterns)
+        @warnings.length == 1 && @warnings[0].matches?(@klass, @patterns)
       end
 
       def failure_message

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -1,44 +1,44 @@
 # -*- encoding: utf-8 -*-
-$:.push File.join(File.dirname(__FILE__), "lib")
+$LOAD_PATH.push File.join(File.dirname(__FILE__), 'lib')
 require 'reek/version'
 
 Gem::Specification.new do |s|
-  s.name = %q{reek}
+  s.name = 'reek'
   s.version = Reek::VERSION
 
   s.authors = ['Kevin Rutherford', 'Timo Roessner', 'Matijs van Zuijlen']
-  s.default_executable = %q{reek}
+  s.default_executable = 'reek'
   s.description = <<-DESC
     Reek is a tool that examines Ruby classes, modules and methods and reports
     any code smells it finds.
   DESC
 
   s.license = 'MIT'
-  s.email = ["timo.roessner@googlemail.com"]
-  s.executables = ["reek"]
-  s.extra_rdoc_files = ["CHANGELOG", "License.txt"]
-  s.files = Dir[".yardopts", "CHANGELOG", "License.txt", "README.md",
-                "Rakefile", "assets/html_output.html.erb", "bin/reek", "config/defaults.reek",
-                "{features,lib,spec,tasks}/**/*",
-                "reek.gemspec" ] & `git ls-files -z`.split("\0")
-  s.homepage = %q{http://wiki.github.com/troessner/reek}
-  s.rdoc_options = ["--main", "README.md",
-                    "-x", "assets/|bin/|config/|features/|spec/|tasks/"]
-  s.require_paths = ["lib"]
-  s.rubyforge_project = %q{reek}
-  s.rubygems_version = %q{1.3.6}
-  s.required_ruby_version = %q{>= 1.9.2}
-  s.summary = %q{Code smell detector for Ruby}
+  s.email = ['timo.roessner@googlemail.com']
+  s.executables = ['reek']
+  s.extra_rdoc_files = ['CHANGELOG', 'License.txt']
+  s.files = Dir['.yardopts', 'CHANGELOG', 'License.txt', 'README.md',
+                'Rakefile', 'assets/html_output.html.erb', 'bin/reek', 'config/defaults.reek',
+                '{features,lib,spec,tasks}/**/*',
+                'reek.gemspec'] & `git ls-files -z`.split("\0")
+  s.homepage = 'http://wiki.github.com/troessner/reek'
+  s.rdoc_options = ['--main', 'README.md',
+                    '-x', 'assets/|bin/|config/|features/|spec/|tasks/']
+  s.require_paths = ['lib']
+  s.rubyforge_project = 'reek'
+  s.rubygems_version = '1.3.6'
+  s.required_ruby_version = '>= 1.9.2'
+  s.summary = 'Code smell detector for Ruby'
 
-  s.add_runtime_dependency(%q<ruby_parser>, [">= 3.5.0", "< 4.0"])
-  s.add_runtime_dependency(%q<sexp_processor>, ["~> 4.4"])
-  s.add_runtime_dependency(%q<ruby2ruby>, [">= 2.0.8", "< 3.0"])
-  s.add_runtime_dependency(%q<rainbow>, [">= 1.99", "< 3.0"])
+  s.add_runtime_dependency('ruby_parser', ['>= 3.5.0', '< 4.0'])
+  s.add_runtime_dependency('sexp_processor', ['~> 4.4'])
+  s.add_runtime_dependency('ruby2ruby', ['>= 2.0.8', '< 3.0'])
+  s.add_runtime_dependency('rainbow', ['>= 1.99', '< 3.0'])
 
-  s.add_development_dependency(%q<bundler>, ["~> 1.1"])
-  s.add_development_dependency(%q<rake>, ["~> 10.0"])
-  s.add_development_dependency(%q<cucumber>, ["~> 1.3"])
-  s.add_development_dependency(%q<rspec>, ["~> 3.0"])
-  s.add_development_dependency(%q<flay>, ["~> 2.4"])
-  s.add_development_dependency(%q<yard>, [">= 0.8.7", "< 0.9"])
+  s.add_development_dependency('bundler', ['~> 1.1'])
+  s.add_development_dependency('rake', ['~> 10.0'])
+  s.add_development_dependency('cucumber', ['~> 1.3'])
+  s.add_development_dependency('rspec', ['~> 3.0'])
+  s.add_development_dependency('flay', ['~> 2.4'])
+  s.add_development_dependency('yard', ['>= 0.8.7', '< 0.9'])
 end

--- a/spec/gem/updates_spec.rb
+++ b/spec/gem/updates_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'find'
 
 release_timestamp_file = 'build/.last-release'
-if test(?f, release_timestamp_file)
+if test('f', release_timestamp_file)
   describe 'updates' do
     before :each do
       @release_time = File.stat(release_timestamp_file).mtime
@@ -23,4 +23,3 @@ if test(?f, release_timestamp_file)
     end
   end
 end
-

--- a/spec/gem/yard_spec.rb
+++ b/spec/gem/yard_spec.rb
@@ -12,4 +12,3 @@ describe 'yardoc' do
     expect(@stderr).to eq('')
   end
 end
-

--- a/spec/matchers/smell_of_matcher.rb
+++ b/spec/matchers/smell_of_matcher.rb
@@ -41,19 +41,17 @@ module SmellOfMatcher
     end
 
     def no_smells_found?
-      if @actual_smells.empty?
-        @reason = 'no smells found by detector'
-        return true
-      end
+      return false if @actual_smells.any?
+      @reason = 'no smells found by detector'
+      true
     end
 
     def wrong_number_of_smells_found?
       return false if @expected_smells.empty?
+      return false if expected_number_of_smells == actual_number_of_smells
 
-      if expected_number_of_smells != actual_number_of_smells
-        @reason = "expected #{expected_number_of_smells} smell(s), found #{actual_number_of_smells}"
-        true
-      end
+      @reason = "expected #{expected_number_of_smells} smell(s), found #{actual_number_of_smells}"
+      true
     end
 
     def expected_number_of_smells
@@ -68,10 +66,10 @@ module SmellOfMatcher
       @expected_smells.zip(@actual_smells).each do |expected_smell, actual_smell|
         expected_smell.each do |key, value|
           actual_value = actual_smell.smell[key]
-          if actual_value != value
-            @reason = "expected #{key} to be #{value}, was #{actual_value}"
-            return true
-          end
+          next if actual_value == value
+
+          @reason = "expected #{key} to be #{value}, was #{actual_value}"
+          return true
         end
       end
       false

--- a/spec/quality/reek_source_spec.rb
+++ b/spec/quality/reek_source_spec.rb
@@ -4,7 +4,7 @@ require 'flay'
 RSpec::Matchers.define :flay do |threshold|
   match do |dirs_and_files|
     @threshold = threshold
-    @flay = Flay.new({:fuzzy => false, :verbose => false, :mass => @threshold})
+    @flay = Flay.new(fuzzy: false, verbose: false, mass: @threshold)
     @flay.process(*Flay.expand_dirs_to_files(dirs_and_files))
     @flay.total > 0
   end
@@ -21,8 +21,8 @@ RSpec::Matchers.define :flay do |threshold|
     lines = ["Total mass = #{@flay.total} (threshold = #{@threshold})"]
     @flay.masses.each do |hash, mass|
       nodes = @flay.hashes[hash]
-      match = @flay.identical[hash] ? "IDENTICAL" : "Similar"
-      lines << ("%s code found in %p (%d)" % [match, nodes.first.first, mass])
+      match = @flay.identical[hash] ? 'IDENTICAL' : 'Similar'
+      lines << format('%s code found in %p (%d)', match, nodes.first.first, mass)
       nodes.each { |x| lines << "  #{x.file}:#{x.line}" }
     end
     lines.join("\n")

--- a/spec/reek/cli/help_command_spec.rb
+++ b/spec/reek/cli/help_command_spec.rb
@@ -7,7 +7,7 @@ describe HelpCommand do
   before :each do
     @help_text = 'Piece of interesting text'
     @parser = double('parser')
-    @parser.stub(:help_text).and_return @help_text
+    allow(@parser).to receive(:help_text).and_return @help_text
     @cmd = HelpCommand.new(@parser)
     @view = double('view').as_null_object
   end

--- a/spec/reek/cli/report_spec.rb
+++ b/spec/reek/cli/report_spec.rb
@@ -22,10 +22,10 @@ def report_options
     warning_formatter: Report::SimpleWarningFormatter,
     report_formatter: Report::Formatter,
     strategy: Report::Strategy::Quiet
-    }
+  }
 end
 
-describe Report::TextReport, " when empty" do
+describe Report::TextReport, ' when empty' do
   context 'empty source' do
     let(:examiner) { Examiner.new('') }
 
@@ -36,7 +36,7 @@ describe Report::TextReport, " when empty" do
     it 'has an empty quiet_report' do
       tr = Report::TextReport.new
       tr.add_examiner(examiner)
-      expect{tr.show}.to_not output.to_stdout
+      expect { tr.show }.to_not output.to_stdout
     end
 
     context 'when output format is html' do
@@ -48,7 +48,7 @@ describe Report::TextReport, " when empty" do
         text = File.read(file)
         File.delete(file)
 
-        expect(text).to include("0 total warnings")
+        expect(text).to include('0 total warnings')
       end
     end
 
@@ -56,14 +56,14 @@ describe Report::TextReport, " when empty" do
       it 'prints empty yaml' do
         yaml_report = report(Report::YamlReport.new(report_options))
         output = capture_output_stream { yaml_report.show }
-        expect(output).to match /^--- \[\]\n.*$/
+        expect(output).to match(/^--- \[\]\n.*$/)
       end
     end
 
     context 'when output format is text' do
       it 'prints nothing' do
         text_report = report(Report::TextReport.new)
-        expect{text_report.show}.to_not output.to_stdout
+        expect { text_report.show }.to_not output.to_stdout
       end
     end
   end

--- a/spec/reek/cli/version_command_spec.rb
+++ b/spec/reek/cli/version_command_spec.rb
@@ -8,7 +8,7 @@ describe VersionCommand do
   before :each do
     @program_name = 'the_name_of_the_program'
     @parser = double('parser')
-    @parser.should_receive(:program_name).and_return @program_name
+    expect(@parser).to receive(:program_name).and_return @program_name
     @cmd = VersionCommand.new(@parser)
     @view = double('view').as_null_object
   end

--- a/spec/reek/core/code_context_spec.rb
+++ b/spec/reek/core/code_context_spec.rb
@@ -71,15 +71,15 @@ describe CodeContext do
         @ctx = CodeContext.new(nil, ast)
       end
       it 'yields no calls' do
-        @ctx.each_node(:call, []) {|exp| raise "#{exp} yielded by empty module!"}
+        @ctx.each_node(:call, []) { |exp| raise "#{exp} yielded by empty module!" }
       end
       it 'yields one module' do
         mods = 0
-        @ctx.each_node(:module, []) {|exp| mods += 1}
+        @ctx.each_node(:module, []) { |_exp| mods += 1 }
         expect(mods).to eq(1)
       end
       it "yields the module's full AST" do
-        @ctx.each_node(:module, []) {|exp| expect(exp[1]).to eq(@module_name.to_sym)}
+        @ctx.each_node(:module, []) { |exp| expect(exp[1]).to eq(@module_name.to_sym) }
       end
 
       context 'with no block' do
@@ -98,19 +98,19 @@ describe CodeContext do
         @ctx = CodeContext.new(nil, ast)
       end
       it 'yields no ifs' do
-        @ctx.each_node(:if, []) {|exp| raise "#{exp} yielded by empty module!"}
+        @ctx.each_node(:if, []) { |exp| raise "#{exp} yielded by empty module!" }
       end
       it 'yields one module' do
         expect(@ctx.each_node(:module, []).length).to eq(1)
       end
       it "yields the module's full AST" do
-        @ctx.each_node(:module, []) {|exp| expect(exp[1]).to eq(@module_name.to_sym)}
+        @ctx.each_node(:module, []) { |exp| expect(exp[1]).to eq(@module_name.to_sym) }
       end
       it 'yields one method' do
         expect(@ctx.each_node(:defn, []).length).to eq(1)
       end
       it "yields the method's full AST" do
-        @ctx.each_node(:defn, []) {|exp| expect(exp[1]).to eq(@method_name.to_sym)}
+        @ctx.each_node(:defn, []) { |exp| expect(exp[1]).to eq(@method_name.to_sym) }
       end
 
       context 'pruning the traversal' do
@@ -156,8 +156,7 @@ EOS
     end
 
     it 'gets its configuration from the exp comments' do
-      expect(ctx.config_for(sniffer)).to eq({
-        'allow_calls' => [ 'puts' ] })
+      expect(ctx.config_for(sniffer)).to eq('allow_calls' => ['puts'])
     end
 
     context 'when there is an outer' do
@@ -165,12 +164,12 @@ EOS
 
       before :each do
         allow(outer).to receive(:config_for).with(sniffer).and_return(
-          { 'max_calls' => 2 })
+          'max_calls' => 2)
       end
 
       it 'merges the outer config with its own configuration' do
-        expect(ctx.config_for(sniffer)).to eq({ 'allow_calls' => [ 'puts' ],
-                                            'max_calls' => 2 })
+        expect(ctx.config_for(sniffer)).to eq('allow_calls' => ['puts'],
+                                              'max_calls' => 2)
       end
     end
   end

--- a/spec/reek/core/code_parser_spec.rb
+++ b/spec/reek/core/code_parser_spec.rb
@@ -3,7 +3,7 @@ require 'reek/core/code_parser'
 
 include Reek::Core
 
-describe CodeParser, "with no method definitions" do
+describe CodeParser, 'with no method definitions' do
   it 'reports no problems for empty source code' do
     expect('').not_to reek
   end

--- a/spec/reek/core/method_context_spec.rb
+++ b/spec/reek/core/method_context_spec.rb
@@ -49,7 +49,7 @@ describe MethodParameters, 'default assignments' do
   def assignments_from(src)
     exp = src.to_reek_source.syntax_tree
     ctx = MethodContext.new(StopContext.new, exp)
-    return ctx.parameters.default_assignments
+    ctx.parameters.default_assignments
   end
 
   context 'with no defaults' do
@@ -61,7 +61,7 @@ describe MethodParameters, 'default assignments' do
 
   context 'with 1 default' do
     before :each do
-      src = "def meth(arga, argb=456, &blk) end"
+      src = 'def meth(arga, argb=456, &blk) end'
       @defaults = assignments_from(src)
     end
     it 'returns the param-value pair' do
@@ -74,7 +74,7 @@ describe MethodParameters, 'default assignments' do
 
   context 'with 2 defaults' do
     before :each do
-      src = "def meth(arga=123, argb=456, &blk) end"
+      src = 'def meth(arga=123, argb=456, &blk) end'
       @defaults = assignments_from(src)
     end
     it 'returns both param-value pairs' do

--- a/spec/reek/core/object_refs_spec.rb
+++ b/spec/reek/core/object_refs_spec.rb
@@ -14,7 +14,7 @@ describe ObjectRefs do
     end
   end
 
-  context "with references to a, b, and a" do
+  context 'with references to a, b, and a' do
     context 'with no refs to self' do
       before(:each) do
         @refs.record_reference_to('a')
@@ -27,14 +27,14 @@ describe ObjectRefs do
       end
 
       it 'should report :a as the max' do
-        expect(@refs.max_keys).to eq({'a' => 2})
+        expect(@refs.max_keys).to eq('a' => 2)
       end
 
       it 'should not report self as the max' do
         expect(@refs.self_is_max?).to eq(false)
       end
 
-      context "with one reference to self" do
+      context 'with one reference to self' do
         before(:each) do
           @refs.record_reference_to(:self)
         end
@@ -71,7 +71,7 @@ describe ObjectRefs do
     end
 
     it 'should report self among the max' do
-      expect(@refs.max_keys).to eq({ :self => 4})
+      expect(@refs.max_keys).to eq(self: 4)
     end
 
     it 'should report self as the max' do
@@ -124,4 +124,3 @@ describe ObjectRefs do
     end
   end
 end
-

--- a/spec/reek/core/smell_configuration_spec.rb
+++ b/spec/reek/core/smell_configuration_spec.rb
@@ -11,37 +11,37 @@ describe SmellConfiguration do
 
   context 'when overriding default configs' do
     before(:each) do
-      @base_config = {"enabled"=>true, "exclude"=>[],
-                      "reject"=>[/^.$/, /[0-9]$/, /[A-Z]/],
-                      "accept"=>["_"]}
+      @base_config = { 'enabled' => true, 'exclude' => [],
+                      'reject' => [/^.$/, /[0-9]$/, /[A-Z]/],
+                      'accept' => ['_'] }
       @smell_config = SmellConfiguration.new(@base_config)
     end
 
     it { expect(@smell_config.merge!({})).to eq(@base_config) }
-    it { expect(@smell_config.merge!({"enabled"=>true})).to eq(@base_config) }
-    it { expect(@smell_config.merge!({"exclude"=>[]})).to eq(@base_config) }
-    it { expect(@smell_config.merge!({"accept"=>["_"]})).to eq(@base_config) }
-    it { expect(@smell_config.merge!({"reject"=>[/^.$/, /[0-9]$/, /[A-Z]/]})).to eq(@base_config) }
-    it { expect(@smell_config.merge!({"enabled"=>true, "accept"=>["_"]})).to eq(@base_config) }
+    it { expect(@smell_config.merge!('enabled' => true)).to eq(@base_config) }
+    it { expect(@smell_config.merge!('exclude' => [])).to eq(@base_config) }
+    it { expect(@smell_config.merge!('accept' => ['_'])).to eq(@base_config) }
+    it { expect(@smell_config.merge!('reject' => [/^.$/, /[0-9]$/, /[A-Z]/])).to eq(@base_config) }
+    it { expect(@smell_config.merge!('enabled' => true, 'accept' => ['_'])).to eq(@base_config) }
 
     it 'should override single values' do
-      expect(@smell_config.merge!({"enabled"=>false})).to eq({"enabled"=>false, "exclude"=>[],
-                                                          "reject"=>[/^.$/, /[0-9]$/, /[A-Z]/],
-                                                          "accept"=>["_"]})
+      expect(@smell_config.merge!('enabled' => false)).to eq('enabled' => false, 'exclude' => [],
+                                                          'reject' => [/^.$/, /[0-9]$/, /[A-Z]/],
+                                                          'accept' => ['_'])
     end
 
     it 'should override arrays of values' do
-      expect(@smell_config.merge!({"reject"=>[/^.$/, /[3-9]$/]})).to eq({"enabled"=>true,
-                                                          "exclude"=>[],
-                                                          "reject"=>[/^.$/, /[3-9]$/],
-                                                          "accept"=>["_"]})
+      expect(@smell_config.merge!('reject' => [/^.$/, /[3-9]$/])).to eq('enabled' => true,
+                                                                        'exclude' => [],
+                                                                        'reject' => [/^.$/, /[3-9]$/],
+                                                                        'accept' => ['_'])
     end
 
     it 'should override multiple values' do
-      expect(@smell_config.merge!({"enabled"=>false, "accept"=>[/[A-Z]$/]})).to eq(
-                           {"enabled"=>false, "exclude"=>[],
-                            "reject"=>[/^.$/, /[0-9]$/, /[A-Z]/],
-                            "accept"=>[/[A-Z]$/]}
+      expect(@smell_config.merge!('enabled' => false, 'accept' => [/[A-Z]$/])).to eq(
+                           'enabled' => false, 'exclude' => [],
+                            'reject' => [/^.$/, /[0-9]$/, /[A-Z]/],
+                            'accept' => [/[A-Z]$/]
       )
     end
   end

--- a/spec/reek/core/stop_context_spec.rb
+++ b/spec/reek/core/stop_context_spec.rb
@@ -10,7 +10,7 @@ describe StopContext do
   end
 
   context 'full_name' do
-    it "reports full context" do
+    it 'reports full context' do
       expect(@stop.full_name).to eq('')
     end
   end

--- a/spec/reek/core/warning_collector_spec.rb
+++ b/spec/reek/core/warning_collector_spec.rb
@@ -17,7 +17,7 @@ describe WarningCollector do
 
   context 'with one warning' do
     before :each do
-      @warning = Reek::SmellWarning.new('ControlCouple', 'fred', [1,2,3], 'hello')
+      @warning = Reek::SmellWarning.new('ControlCouple', 'fred', [1, 2, 3], 'hello')
       @collector.found_smell(@warning)
     end
     it 'reports that warning' do

--- a/spec/reek/smell_warning_spec.rb
+++ b/spec/reek/smell_warning_spec.rb
@@ -23,8 +23,8 @@ describe SmellWarning do
 
     context 'smells differing only by detector' do
       before :each do
-        @first = SmellWarning.new('Duplication', "self", 27, "self", false)
-        @second = SmellWarning.new('FeatureEnvy', "self", 27, "self", true)
+        @first = SmellWarning.new('Duplication', 'self', 27, 'self', false)
+        @second = SmellWarning.new('FeatureEnvy', 'self', 27, 'self', true)
       end
 
       it_should_behave_like 'first sorts ahead of second'
@@ -32,8 +32,8 @@ describe SmellWarning do
 
     context 'smells differing only by context' do
       before :each do
-        @first = SmellWarning.new('FeatureEnvy', "first", 27, "self", true)
-        @second = SmellWarning.new('FeatureEnvy', "second", 27, "self", false)
+        @first = SmellWarning.new('FeatureEnvy', 'first', 27, 'self', true)
+        @second = SmellWarning.new('FeatureEnvy', 'second', 27, 'self', false)
       end
 
       it_should_behave_like 'first sorts ahead of second'
@@ -41,8 +41,8 @@ describe SmellWarning do
 
     context 'smells differing only by message' do
       before :each do
-        @first = SmellWarning.new('FeatureEnvy', "context", 27, "first", true)
-        @second = SmellWarning.new('FeatureEnvy', "context", 27, "second", false)
+        @first = SmellWarning.new('FeatureEnvy', 'context', 27, 'first', true)
+        @second = SmellWarning.new('FeatureEnvy', 'context', 27, 'second', false)
       end
 
       it_should_behave_like 'first sorts ahead of second'
@@ -50,8 +50,8 @@ describe SmellWarning do
 
     context 'message takes precedence over smell name' do
       before :each do
-        @first = SmellWarning.new('UtilityFunction', "context", 27, "first", true)
-        @second = SmellWarning.new('FeatureEnvy', "context", 27, "second", false)
+        @first = SmellWarning.new('UtilityFunction', 'context', 27, 'first', true)
+        @second = SmellWarning.new('FeatureEnvy', 'context', 27, 'second', false)
       end
 
       it_should_behave_like 'first sorts ahead of second'
@@ -59,8 +59,8 @@ describe SmellWarning do
 
     context 'smells differing everywhere' do
       before :each do
-        @first = SmellWarning.new('UncommunicativeName', "Dirty", 27, "has the variable name '@s'", true)
-        @second = SmellWarning.new('Duplication', 'Dirty#a', 27, "calls @s.title twice", false)
+        @first = SmellWarning.new('UncommunicativeName', 'Dirty', 27, "has the variable name '@s'", true)
+        @second = SmellWarning.new('Duplication', 'Dirty#a', 27, 'calls @s.title twice', false)
       end
 
       it_should_behave_like 'first sorts ahead of second'
@@ -100,9 +100,9 @@ describe SmellWarning do
       before :each do
         @source = 'a/ruby/source/file.rb'
         @subclass = 'TooManyParties'
-        @parameters = {'one' => 34, 'two' => 'second'}
+        @parameters = { 'one' => 34, 'two' => 'second' }
         @warning = SmellWarning.new(@class, @context_name, @lines, @message,
-          @source, @subclass, @parameters)
+                                    @source, @subclass, @parameters)
         @yaml = @warning.to_yaml
       end
 
@@ -115,7 +115,7 @@ describe SmellWarning do
         expect(@yaml).to match(/source:\s*#{@source}/)
       end
       it 'includes the parameters' do
-        @parameters.each do |key,value|
+        @parameters.each do |key, value|
           expect(@yaml).to match(/#{key}:\s*#{value}/)
         end
       end

--- a/spec/reek/smells/boolean_parameter_spec.rb
+++ b/spec/reek/smells/boolean_parameter_spec.rb
@@ -18,8 +18,8 @@ describe BooleanParameter do
       it 'reports two parameters defaulted to booleans' do
         src = 'def cc(nowt, arga = true, argb = false, &blk) end'
         expect(src).to smell_of(BooleanParameter,
-          {BooleanParameter::PARAMETER_KEY => 'arga'},
-          {BooleanParameter::PARAMETER_KEY => 'argb'})
+                                { BooleanParameter::PARAMETER_KEY => 'arga' },
+                                BooleanParameter::PARAMETER_KEY => 'argb')
       end
     end
 
@@ -35,8 +35,8 @@ describe BooleanParameter do
       it 'reports two parameters defaulted to booleans' do
         src = 'def Module.cc(nowt, arga = true, argb = false, &blk) end'
         expect(src).to smell_of(BooleanParameter,
-          {BooleanParameter::PARAMETER_KEY => 'arga'},
-          {BooleanParameter::PARAMETER_KEY => 'argb'})
+                                { BooleanParameter::PARAMETER_KEY => 'arga' },
+                                BooleanParameter::PARAMETER_KEY => 'argb')
       end
     end
   end

--- a/spec/reek/smells/data_clump_spec.rb
+++ b/spec/reek/smells/data_clump_spec.rb
@@ -46,7 +46,7 @@ EOS
       expect(@smells[0].smell[DataClump::METHODS_KEY]).to eq(['first', 'second', 'third'])
     end
     it 'reports the declaration line numbers' do
-      expect(@smells[0].lines).to eq([2,3,4])
+      expect(@smells[0].lines).to eq([2, 3, 4])
     end
     it 'reports the correct smell class' do
       expect(@smells[0].smell_class).to eq(DataClump::SMELL_CLASS)
@@ -64,8 +64,9 @@ EOS
   def tri(pa, pb) pa - pb + @fred; end
 end
 EOS
-    expect(src).to smell_of(DataClump, {DataClump::OCCURRENCES_KEY => 3,
-      DataClump::PARAMETERS_KEY => ['pa', 'pb']})
+    expect(src).to smell_of(DataClump,
+                            DataClump::OCCURRENCES_KEY => 3,
+                            DataClump::PARAMETERS_KEY => ['pa', 'pb'])
   end
 
   it 'reports 3 identical parameter sets' do
@@ -76,8 +77,9 @@ EOS
   def third(pa, pb, pc) pa - pb + @fred; end
 end
 EOS
-    expect(src).to smell_of(DataClump, {DataClump::OCCURRENCES_KEY => 3,
-      DataClump::PARAMETERS_KEY => ['pa', 'pb', 'pc']})
+    expect(src).to smell_of(DataClump,
+                            DataClump::OCCURRENCES_KEY => 3,
+                            DataClump::PARAMETERS_KEY => ['pa', 'pb', 'pc'])
   end
 
   it 'reports re-ordered identical parameter sets' do
@@ -88,8 +90,9 @@ EOS
   def third(pa, pb, pc) pa - pb + @fred; end
 end
 EOS
-    expect(src).to smell_of(DataClump, {DataClump::OCCURRENCES_KEY => 3,
-      DataClump::PARAMETERS_KEY => ['pa', 'pb', 'pc']})
+    expect(src).to smell_of(DataClump,
+                            DataClump::OCCURRENCES_KEY => 3,
+                            DataClump::PARAMETERS_KEY => ['pa', 'pb', 'pc'])
   end
 
   it 'counts only identical parameter sets' do
@@ -138,7 +141,7 @@ EOS
       end
     EOS
     expect(src).to smell_of(DataClump,
-                        { DataClump::PARAMETERS_KEY => %w(p1 p2) })
+                            DataClump::PARAMETERS_KEY => %w(p1 p2))
   end
 end
 

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -33,11 +33,11 @@ EOS
       expect(@warning.smell[DuplicateMethodCall::CALL_KEY]).to eq('other[@thing]')
     end
     it 'reports the correct lines' do
-      expect(@warning.lines).to eq([2,4])
+      expect(@warning.lines).to eq([2, 4])
     end
   end
 
-  context "with repeated method calls" do
+  context 'with repeated method calls' do
     it 'reports repeated call' do
       src = 'def double_thing() @other.thing + @other.thing end'
       expect(src).to smell_of(DuplicateMethodCall, DuplicateMethodCall::CALL_KEY => '@other.thing')
@@ -52,8 +52,8 @@ EOS
     end
     it 'should report nested calls' do
       src = 'def double_thing() @other.thing.foo + @other.thing.foo end'
-      expect(src).to smell_of(DuplicateMethodCall, {DuplicateMethodCall::CALL_KEY => '@other.thing'},
-                                       {DuplicateMethodCall::CALL_KEY => '@other.thing.foo'})
+      expect(src).to smell_of(DuplicateMethodCall, { DuplicateMethodCall::CALL_KEY => '@other.thing' },
+                              DuplicateMethodCall::CALL_KEY => '@other.thing.foo')
     end
     it 'should ignore calls to new' do
       src = 'def double_thing() @other.new + @other.new end'
@@ -61,7 +61,7 @@ EOS
     end
   end
 
-  context "with repeated simple method calls" do
+  context 'with repeated simple method calls' do
     it 'reports no smell' do
       src = <<-EOS
         def foo
@@ -77,7 +77,7 @@ EOS
     end
   end
 
-  context "with repeated simple method calls with blocks" do
+  context 'with repeated simple method calls with blocks' do
     it 'reports a smell if the blocks are identical' do
       src = <<-EOS
         def foo
@@ -99,7 +99,7 @@ EOS
     end
   end
 
-  context "with repeated method calls with receivers with blocks" do
+  context 'with repeated method calls with receivers with blocks' do
     it 'reports a smell if the blocks are identical' do
       src = <<-EOS
         def foo
@@ -137,7 +137,7 @@ EOS
     end
   end
 
-  context "non-repeated method calls" do
+  context 'non-repeated method calls' do
     it 'should not report similar calls' do
       src = 'def equals(other) other.thing == self.thing end'
       expect(src).not_to smell_of(DuplicateMethodCall)
@@ -148,9 +148,9 @@ EOS
     end
   end
 
-  context "allowing up to 3 calls" do
+  context 'allowing up to 3 calls' do
     before :each do
-      @config = {DuplicateMethodCall::MAX_ALLOWED_CALLS_KEY => 3}
+      @config = { DuplicateMethodCall::MAX_ALLOWED_CALLS_KEY => 3 }
     end
     it 'does not report double calls' do
       src = 'def double_thing() @other.thing + @other.thing end'
@@ -162,13 +162,13 @@ EOS
     end
     it 'reports quadruple calls' do
       src = 'def double_thing() @other.thing + @other.thing + @other.thing + @other.thing end'
-      expect(src).to smell_of(DuplicateMethodCall, {DuplicateMethodCall::CALL_KEY => '@other.thing', DuplicateMethodCall::OCCURRENCES_KEY => 4}).with_config(@config)
+      expect(src).to smell_of(DuplicateMethodCall, DuplicateMethodCall::CALL_KEY => '@other.thing', DuplicateMethodCall::OCCURRENCES_KEY => 4).with_config(@config)
     end
   end
 
-  context "allowing calls to some methods" do
+  context 'allowing calls to some methods' do
     before :each do
-      @config = {DuplicateMethodCall::ALLOW_CALLS_KEY => ['@some.thing',/puts/]}
+      @config = { DuplicateMethodCall::ALLOW_CALLS_KEY => ['@some.thing', /puts/] }
     end
     it 'does not report calls to some methods' do
       src = 'def double_some_thing() @some.thing + @some.thing end'
@@ -176,11 +176,11 @@ EOS
     end
     it 'reports calls to other methods' do
       src = 'def double_other_thing() @other.thing + @other.thing end'
-      expect(src).to smell_of(DuplicateMethodCall, {DuplicateMethodCall::CALL_KEY => '@other.thing'}).with_config(@config)
+      expect(src).to smell_of(DuplicateMethodCall, DuplicateMethodCall::CALL_KEY => '@other.thing').with_config(@config)
     end
     it 'does not report calls to methods specifed with a regular expression' do
       src = 'def double_puts() puts @other.thing; puts @other.thing end'
-      expect(src).to smell_of(DuplicateMethodCall, {DuplicateMethodCall::CALL_KEY => '@other.thing'}).with_config(@config)
+      expect(src).to smell_of(DuplicateMethodCall, DuplicateMethodCall::CALL_KEY => '@other.thing').with_config(@config)
     end
   end
 end

--- a/spec/reek/smells/irresponsible_module_spec.rb
+++ b/spec/reek/smells/irresponsible_module_spec.rb
@@ -21,7 +21,7 @@ describe IrresponsibleModule do
     expect(src).not_to reek_of(:IrresponsibleModule)
   end
 
-  it "does not report a class having a comment" do
+  it 'does not report a class having a comment' do
     src = <<EOS
 # test class
 class Responsible; end
@@ -29,7 +29,7 @@ EOS
     ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
     expect(@detector.examine_context(ctx)).to be_empty
   end
-  it "reports a class without a comment" do
+  it 'reports a class without a comment' do
     src = "class #{@bad_module_name}; end"
     ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
     smells = @detector.examine_context(ctx)
@@ -39,11 +39,11 @@ EOS
     expect(smells[0].lines).to eq([1])
     expect(smells[0].smell[IrresponsibleModule::MODULE_NAME_KEY]).to eq(@bad_module_name)
   end
-  it "reports a class with an empty comment" do
+  it 'reports a class with an empty comment' do
     src = <<EOS
 #
 #
-#  
+#
 class #{@bad_module_name}; end
 EOS
     ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -94,7 +94,7 @@ EOS
 
   context 'when the allowed nesting depth is 3' do
     before :each do
-      @config = {NestedIterators::MAX_ALLOWED_NESTING_KEY => 3}
+      @config = { NestedIterators::MAX_ALLOWED_NESTING_KEY => 3 }
     end
 
     it 'should not report nested iterators 2 levels deep' do
@@ -127,7 +127,7 @@ EOS
 
   context 'when ignoring iterators' do
     before :each do
-      @config = {NestedIterators::IGNORE_ITERATORS_KEY => ['ignore_me']}
+      @config = { NestedIterators::IGNORE_ITERATORS_KEY => ['ignore_me'] }
     end
 
     it 'should not report nesting the ignored iterator inside another' do

--- a/spec/reek/smells/nil_check_spec.rb
+++ b/spec/reek/smells/nil_check_spec.rb
@@ -34,18 +34,18 @@ describe NilCheck do
       end
       eos
       expect(src).to smell_of(NilCheck,
-                          {NilCheck => nil}, {NilCheck => nil})
+                              { NilCheck => nil }, NilCheck => nil)
     end
 
     it 'should report twice when scope uses == nil and === nil' do
-      src= <<-eos
+      src = <<-eos
       def chk_eq_nil(para)
         para == nil
         para === nil
       end
       eos
       expect(src).to smell_of(NilCheck,
-                          {NilCheck => nil}, {NilCheck => nil})
+                              { NilCheck => nil }, NilCheck => nil)
     end
 
     it 'should report when scope uses nil ==' do
@@ -66,7 +66,7 @@ describe NilCheck do
       end
       eos
       expect(src).to smell_of(NilCheck,
-                          {NilCheck => nil}, {NilCheck => nil})
+                              { NilCheck => nil }, NilCheck => nil)
     end
   end
 end

--- a/spec/reek/smells/prima_donna_method_spec.rb
+++ b/spec/reek/smells/prima_donna_method_spec.rb
@@ -23,9 +23,9 @@ describe PrimaDonnaMethod do
       smells = detector.examine_context(ctx)
       warning = smells[0]
 
-      expect(warning.smell['class']).to    eq('PrimaDonnaMethod')
+      expect(warning.smell['class']).to eq('PrimaDonnaMethod')
       expect(warning.smell['subclass']).to eq('PrimaDonnaMethod')
-      expect(warning.lines).to             eq([1])
+      expect(warning.lines).to eq([1])
     end
   end
 end

--- a/spec/reek/smells/smell_detector_shared.rb
+++ b/spec/reek/smells/smell_detector_shared.rb
@@ -22,7 +22,7 @@ shared_examples_for 'SmellDetector' do
 
   context 'configuration' do
     it 'becomes disabled when disabled' do
-      @detector.configure_with({SmellConfiguration::ENABLED_KEY => false})
+      @detector.configure_with(SmellConfiguration::ENABLED_KEY => false)
       expect(@detector).not_to be_enabled
     end
   end

--- a/spec/reek/smells/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_parameter_name_spec.rb
@@ -15,7 +15,7 @@ describe UncommunicativeParameterName do
   it_should_behave_like 'SmellDetector'
 
   { 'obj.' => 'with a receiveer',
-    '' => 'without a receiver'}.each do |host, description|
+    '' => 'without a receiver' }.each do |host, description|
     context "in a method definition #{description}" do
       it 'does not recognise *' do
         expect("def #{host}help(xray, *) basics(17) end").
@@ -25,10 +25,10 @@ describe UncommunicativeParameterName do
       it "reports parameter's name" do
         src = "def #{host}help(x) basics(x) end"
         expect(src).to smell_of(UncommunicativeParameterName,
-                            {UncommunicativeParameterName::PARAMETER_NAME_KEY => 'x'})
+                                UncommunicativeParameterName::PARAMETER_NAME_KEY => 'x')
       end
 
-      it "does not report unused parameters" do
+      it 'does not report unused parameters' do
         src = "def #{host}help(x) basics(17) end"
         expect(src).not_to smell_of(UncommunicativeParameterName)
       end
@@ -41,13 +41,13 @@ describe UncommunicativeParameterName do
       it 'reports names of the form "x2"' do
         src = "def #{host}help(x2) basics(x2) end"
         expect(src).to smell_of(UncommunicativeParameterName,
-                            {UncommunicativeParameterName::PARAMETER_NAME_KEY => 'x2'})
+                                UncommunicativeParameterName::PARAMETER_NAME_KEY => 'x2')
       end
 
       it 'reports long name ending in a number' do
         src = "def #{host}help(param2) basics(param2) end"
         expect(src).to smell_of(UncommunicativeParameterName,
-                            {UncommunicativeParameterName::PARAMETER_NAME_KEY => 'param2'})
+                                UncommunicativeParameterName::PARAMETER_NAME_KEY => 'param2')
       end
 
       it 'does not report unused anonymous parameter' do

--- a/spec/reek/smells/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_variable_name_spec.rb
@@ -15,7 +15,7 @@ describe UncommunicativeVariableName do
 
   it_should_behave_like 'SmellDetector'
 
-  context "field name" do
+  context 'field name' do
     it 'does not report use of one-letter fieldname' do
       src = 'class Thing; def simple(fred) @x end end'
       expect(src).not_to smell_of(UncommunicativeVariableName)
@@ -26,7 +26,7 @@ describe UncommunicativeVariableName do
     end
   end
 
-  context "local variable name" do
+  context 'local variable name' do
     it 'does not report one-word variable name' do
       expect('def help(fred) simple = jim(45) end').not_to smell_of(UncommunicativeVariableName)
     end
@@ -36,18 +36,18 @@ describe UncommunicativeVariableName do
     it 'reports one-letter variable name' do
       src = 'def simple(fred) x = jim(45) end'
       expect(src).to smell_of(UncommunicativeVariableName,
-        {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x'})
+                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x')
     end
     it 'reports name of the form "x2"' do
       src = 'def simple(fred) x2 = jim(45) end'
       expect(src).to smell_of(UncommunicativeVariableName,
-        {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x2'})
+                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x2')
     end
     it 'reports long name ending in a number' do
       @bad_var = 'var123'
       src = "def simple(fred) #{@bad_var} = jim(45) end"
       expect(src).to smell_of(UncommunicativeVariableName,
-        {UncommunicativeVariableName::VARIABLE_NAME_KEY => @bad_var})
+                              UncommunicativeVariableName::VARIABLE_NAME_KEY => @bad_var)
     end
     it 'reports variable name only once' do
       src = 'def simple(fred) x = jim(45); x = y end'
@@ -56,20 +56,20 @@ describe UncommunicativeVariableName do
       expect(smells.length).to eq(1)
       expect(smells[0].subclass).to eq(UncommunicativeVariableName::SMELL_SUBCLASS)
       expect(smells[0].smell[UncommunicativeVariableName::VARIABLE_NAME_KEY]).to eq('x')
-      expect(smells[0].lines).to eq([1,1])
+      expect(smells[0].lines).to eq([1, 1])
     end
     it 'reports a bad name inside a block' do
       src = 'def clean(text) text.each { q2 = 3 } end'
       expect(src).to smell_of(UncommunicativeVariableName,
-        {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'q2'})
+                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'q2')
     end
     it 'reports variable name outside any method' do
       expect('class Simple; x = jim(45); end').to reek_of(:UncommunicativeVariableName, /x/)
     end
   end
 
-  context "block parameter name" do
-    it "reports deep block parameter" do
+  context 'block parameter name' do
+    it 'reports deep block parameter' do
       src = <<EOS
   def bad
     unless @mod then
@@ -78,72 +78,72 @@ describe UncommunicativeVariableName do
   end
 EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-        {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x'})
+                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x')
     end
 
-    it "reports all relevant block parameters" do
+    it 'reports all relevant block parameters' do
       src = <<-EOS
         def bad
           @foo.map { |x, y| x + y }
         end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                          {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x'},
-                          {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y'})
+                              { UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x' },
+                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y')
     end
 
-    it "reports block parameters used outside of methods" do
+    it 'reports block parameters used outside of methods' do
       src = <<-EOS
       class Foo
         @foo.map { |x| x * 2 }
       end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                          {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x'})
+                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x')
     end
 
-    it "reports splatted block parameters correctly" do
+    it 'reports splatted block parameters correctly' do
       src = <<-EOS
         def bad
           @foo.map { |*y| y << 1 }
         end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                          {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y'})
+                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y')
     end
 
-    it "reports nested block parameters" do
+    it 'reports nested block parameters' do
       src = <<-EOS
         def bad
           @foo.map { |(x, y)| x + y }
         end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                          {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x'},
-                          {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y'})
+                              { UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x' },
+                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y')
     end
 
-    it "reports splatted nested block parameters" do
+    it 'reports splatted nested block parameters' do
       src = <<-EOS
         def bad
           @foo.map { |(x, *y)| x + y }
         end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                          {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x'},
-                          {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y'})
+                              { UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x' },
+                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y')
     end
 
-    it "reports deeply nested block parameters" do
+    it 'reports deeply nested block parameters' do
       src = <<-EOS
         def bad
           @foo.map { |(x, (y, z))| x + y + z }
         end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                          {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x'},
-                          {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y'},
-                          {UncommunicativeVariableName::VARIABLE_NAME_KEY => 'z'})
+                              { UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x' },
+                              { UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y' },
+                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'z')
     end
 
   end
@@ -168,7 +168,7 @@ EOS
 
     it 'reports the correct values' do
       expect(@warning.smell['variable_name']).to eq('x2')
-      expect(@warning.lines).to eq([3,5])
+      expect(@warning.lines).to eq([3, 5])
     end
   end
 

--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -20,14 +20,14 @@ describe UnusedParameters do
     it 'reports for 1 used and 2 unused parameter' do
       src = 'def simple(num,sum,denum); sum end'
       expect(src).to smell_of(UnusedParameters,
-                          {UnusedParameters::PARAMETER_KEY => 'num'},
-                          {UnusedParameters::PARAMETER_KEY => 'denum'})
+                              { UnusedParameters::PARAMETER_KEY => 'num' },
+                              UnusedParameters::PARAMETER_KEY => 'denum')
     end
 
     it 'reports for 3 used and 1 unused parameter' do
       src = 'def simple(num,sum,denum,quotient); num + denum + sum end'
       expect(src).to smell_of(UnusedParameters,
-                          {UnusedParameters::PARAMETER_KEY => 'quotient'})
+                              UnusedParameters::PARAMETER_KEY => 'quotient')
     end
 
     it 'reports nothing for used splatted parameter' do

--- a/spec/reek/source/code_comment_spec.rb
+++ b/spec/reek/source/code_comment_spec.rb
@@ -9,7 +9,7 @@ describe CodeComment do
       @comment = CodeComment.new('')
     end
     it 'is not descriptive' do
-      expect(@comment.is_descriptive?).to be_falsey
+      expect(@comment).not_to be_descriptive
     end
     it 'has an empty config' do
       expect(@comment.config).to be_empty
@@ -18,64 +18,64 @@ describe CodeComment do
 
   context 'comment checks' do
     it 'rejects an empty comment' do
-      expect(CodeComment.new('#').is_descriptive?).to be_falsey
+      expect(CodeComment.new('#')).not_to be_descriptive
     end
     it 'rejects a 1-word comment' do
-      expect(CodeComment.new("# fred\n#  ").is_descriptive?).to be_falsey
+      expect(CodeComment.new("# fred\n#  ")).not_to be_descriptive
     end
     it 'accepts a 2-word comment' do
-      expect(CodeComment.new('# fred here  ').is_descriptive?).to be_truthy
+      expect(CodeComment.new('# fred here  ')).to be_descriptive
     end
     it 'accepts a multi-word comment' do
-      expect(CodeComment.new("# fred here \n# with \n   # biscuits ").is_descriptive?).to be_truthy
+      expect(CodeComment.new("# fred here \n# with \n   # biscuits ")).to be_descriptive
     end
   end
 
   context 'comment config' do
     it 'parses hashed options' do
-      config = CodeComment.new("# :reek:Duplication: { enabled: false }").config
+      config = CodeComment.new('# :reek:Duplication: { enabled: false }').config
       expect(config).to include('Duplication')
       expect(config['Duplication']).to include('enabled')
       expect(config['Duplication']['enabled']).to be_falsey
     end
     it 'parses hashed options with ruby names' do
-      config = CodeComment.new("# :reek:nested_iterators: { enabled: true }").config
+      config = CodeComment.new('# :reek:nested_iterators: { enabled: true }').config
       expect(config).to include('NestedIterators')
       expect(config['NestedIterators']).to include('enabled')
       expect(config['NestedIterators']['enabled']).to be_truthy
     end
     it 'parses multiple hashed options' do
       config = CodeComment.new("# :reek:Duplication: { enabled: false }\n:reek:nested_iterators: { enabled: true }").config
-      expect(config).to include('Duplication','NestedIterators')
+      expect(config).to include('Duplication', 'NestedIterators')
       expect(config['Duplication']).to include('enabled')
       expect(config['Duplication']['enabled']).to be_falsey
       expect(config['NestedIterators']).to include('enabled')
       expect(config['NestedIterators']['enabled']).to be_truthy
     end
     it 'parses multiple hashed options on the same line' do
-      config = CodeComment.new("# :reek:Duplication: { enabled: false } and :reek:nested_iterators: { enabled: true }").config
-      expect(config).to include('Duplication','NestedIterators')
+      config = CodeComment.new('# :reek:Duplication: { enabled: false } and :reek:nested_iterators: { enabled: true }').config
+      expect(config).to include('Duplication', 'NestedIterators')
       expect(config['Duplication']).to include('enabled')
       expect(config['Duplication']['enabled']).to be_falsey
       expect(config['NestedIterators']).to include('enabled')
       expect(config['NestedIterators']['enabled']).to be_truthy
     end
     it 'parses multiple unhashed options on the same line' do
-      config = CodeComment.new("# :reek:Duplication and :reek:nested_iterators").config
-      expect(config).to include('Duplication','NestedIterators')
+      config = CodeComment.new('# :reek:Duplication and :reek:nested_iterators').config
+      expect(config).to include('Duplication', 'NestedIterators')
       expect(config['Duplication']).to include('enabled')
       expect(config['Duplication']['enabled']).to be_falsey
       expect(config['NestedIterators']).to include('enabled')
       expect(config['NestedIterators']['enabled']).to be_falsey
     end
     it 'disables the smell if no options are specifed' do
-      config = CodeComment.new("# :reek:Duplication").config
+      config = CodeComment.new('# :reek:Duplication').config
       expect(config).to include('Duplication')
       expect(config['Duplication']).to include('enabled')
       expect(config['Duplication']['enabled']).to be_falsey
     end
     it 'ignores smells after a space' do
-      config = CodeComment.new("# :reek: Duplication").config
+      config = CodeComment.new('# :reek: Duplication').config
       expect(config).not_to include('Duplication')
     end
   end

--- a/spec/reek/source/object_source_spec.rb
+++ b/spec/reek/source/object_source_spec.rb
@@ -11,7 +11,7 @@ describe Dir do
   end
 
   it 'copes with daft file specs' do
-    expect(Dir["spec/samples/two_smelly_files/*/.rb"]).not_to reek
+    expect(Dir['spec/samples/two_smelly_files/*/.rb']).not_to reek
   end
 
   it 'copes with empty array' do

--- a/spec/reek/source/sexp_formatter_spec.rb
+++ b/spec/reek/source/sexp_formatter_spec.rb
@@ -4,16 +4,15 @@ require 'reek/source/sexp_formatter'
 include Reek::Source
 
 describe SexpFormatter do
-  describe "::format" do
+  describe '::format' do
     it 'formats a simple s-expression' do
       result = SexpFormatter.format s(:lvar, :foo)
-      expect(result).to eq("foo")
+      expect(result).to eq('foo')
     end
 
     it 'formats a more complex s-expression' do
       result = SexpFormatter.format s(:call, nil, :foo, s(:arglist, s(:lvar, :bar)))
-      expect(result).to eq("foo(bar)")
+      expect(result).to eq('foo(bar)')
     end
   end
 end
-

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -13,10 +13,11 @@ describe SourceCode do
 
     before :each do
       @catcher = StringIO.new
-      @old_err_io = (SourceCode.err_io = @catcher)
+      @old_std_err = $stderr
+      $stderr = @catcher
     end
 
-    shared_examples_for "handling and recording the error" do
+    shared_examples_for 'handling and recording the error' do
       it 'does not raise an error' do
         src.syntax_tree
       end
@@ -41,27 +42,27 @@ describe SourceCode do
       end
     end
 
-    context "with a RubyParser::SyntaxError" do
+    context 'with a RubyParser::SyntaxError' do
       let(:error_class) { RubyParser::SyntaxError }
 
       before do
         allow(parser).to receive(:parse).and_raise(error_class.new(error_message))
       end
 
-      it_should_behave_like "handling and recording the error"
+      it_should_behave_like 'handling and recording the error'
     end
 
-    context "with a Racc::ParseError" do
+    context 'with a Racc::ParseError' do
       let(:error_class) { Racc::ParseError }
 
       before do
         allow(parser).to receive(:parse).and_raise(error_class.new(error_message))
       end
 
-      it_should_behave_like "handling and recording the error"
+      it_should_behave_like 'handling and recording the error'
     end
 
-    context "with a generic error" do
+    context 'with a generic error' do
       let(:error_class) { RuntimeError }
 
       before do
@@ -74,7 +75,7 @@ describe SourceCode do
     end
 
     after :each do
-      SourceCode.err_io = @old_err_io
+      $stderr = @old_std_err
     end
   end
 end

--- a/spec/reek/spec/should_reek_only_of_spec.rb
+++ b/spec/reek/spec/should_reek_only_of_spec.rb
@@ -10,7 +10,7 @@ describe ShouldReekOnlyOf do
     @expected_context_name = 'SmellyClass#big_method'
     @matcher = ShouldReekOnlyOf.new(@expected_smell_class, [/#{@expected_context_name}/])
     @examiner = double('examiner').as_null_object
-    expect(@examiner).to receive(:smells) {smells}
+    expect(@examiner).to receive(:smells) { smells }
     @match = @matcher.matches_examiner?(@examiner)
   end
 
@@ -53,7 +53,7 @@ describe ShouldReekOnlyOf do
       [
         SmellWarning.new('ControlCouple', 'context', [1], 'any old message'),
         SmellWarning.new('FeatureEnvy', 'context', [1], 'any old message')
-        ]
+      ]
     end
 
     it_should_behave_like 'no match'
@@ -64,7 +64,7 @@ describe ShouldReekOnlyOf do
       [
         SmellWarning.new('ControlCouple', 'context', [1], 'any old message'),
         SmellWarning.new(@expected_smell_class.to_s, 'context', [1], "message mentioning #{@expected_context_name}")
-        ]
+      ]
     end
 
     it_should_behave_like 'no match'

--- a/tasks/develop.rake
+++ b/tasks/develop.rake
@@ -1,6 +1,6 @@
 require 'rake/clean'
 
-CONFIG_FILE = "config/defaults.reek"
+CONFIG_FILE = 'config/defaults.reek'
 
 file CONFIG_FILE do
   config = {}

--- a/tasks/reek.rake
+++ b/tasks/reek.rake
@@ -1,10 +1,7 @@
-begin
-  require 'reek/rake/task'
+require 'reek/rake/task'
 
-  Reek::Rake::Task.new do |t|
-    t.fail_on_error = true
-    t.verbose = false
-    t.reek_opts = '--quiet'
-  end
-rescue Gem::LoadError
+Reek::Rake::Task.new do |t|
+  t.fail_on_error = true
+  t.verbose = false
+  t.reek_opts = '--quiet'
 end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -19,7 +19,7 @@ namespace 'test' do
   end
 
   Cucumber::Rake::Task.new(:features) do |t|
-    t.cucumber_opts = "features --format progress --color"
+    t.cucumber_opts = 'features --format progress --color'
   end
 
   desc 'Runs all unit tests and acceptance tests'


### PR DESCRIPTION
This PR introduces RuboCop, fixing #286.

Several of RuboCop's 'cops' are configured to RuboCop to match the style of the current code base (for example, we use multiline method-chaining in several places, and it seems silly to rewrite that code), and also according to my own taste. Many other offenses have been fixed, in particular those that RuboCop can correct by itself.

I have kept corrections and/or fixes for each cop in a separate commit, so if there is any style issue for which we conclude that a different choice should be made, we can fix it by removing or amending that commit.

The StringLiterals cop has been disabled until a consensus is reached (which might be to leave it disabled). See  #286 for discussion.
