### PR TITLE
Require Ruby 1.9.2 or up

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubyforge_project = %q{reek}
   s.rubygems_version = %q{1.3.6}
+  s.required_ruby_version = %q{>= 1.9.2}
   s.summary = %q{Code smell detector for Ruby}
 
   s.add_runtime_dependency(%q<ruby_parser>, [">= 3.5.0", "< 4.0"])


### PR DESCRIPTION
Since reek requires Ruby 1.9.2 or higher to work, it's nice to state so in the gemspec (as per @estolfo's BaRuCo 2014 talk, 'Release Responsibly').
