### PR TITLE
Remove ruby 1.9.2 from our travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 bundler_args: --without local_development
 script: bundle exec rake
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.0


### PR DESCRIPTION
Ruby 1.9.2 hasnt been supported anymore for quite a while: 

> > Effective immediately, 1.8.7 and 1.9.2 will be supported for security patches until June 2014.

from: https://www.ruby-lang.org/en/news/2013/12/17/maintenance-of-1-8-7-and-1-9-2/

This PR should also fix: https://github.com/troessner/reek/pull/303
