### PR TITLE
Improve and refactor ControlParameter

### DIFF
--- a/lib/reek/source/sexp_extensions.rb
+++ b/lib/reek/source/sexp_extensions.rb
@@ -32,19 +32,33 @@ module Reek
       end
 
       module AndNode
-        def condition() self[1..2].tap { |node| node.extend SexpNode } end
+        def condition() self[1] end
+
+        def body
+          self[2]
+        end
       end
 
+      # Utility methods for :or nodes
       module OrNode
-        def condition() self[1..2].tap { |node| node.extend SexpNode } end
+        def condition() self[1] end
+
+        def body
+          self[2]
+        end
       end
 
       module AttrasgnNode
         def args() self[3] end
       end
 
+      # Utility methods for :case nodes
       module CaseNode
         def condition() self[1] end
+
+        def body
+          self[2..-1].extend SexpNode
+        end
       end
 
       # Utility methods for :when nodes
@@ -54,10 +68,15 @@ module Reek
         end
       end
 
+      # Utility methods for :call nodes
       module CallNode
         def receiver() self[1] end
         def method_name() self[2] end
         def args() self[3..-1] end
+
+        def participants
+          ([receiver] + args).compact
+        end
 
         def arg_names
           args.map { |arg| arg[1] }
@@ -72,7 +91,7 @@ module Reek
       CvdeclNode = CvarNode
 
       module LvarNode
-        def value() self[1] end
+        def var_name() self[1] end
       end
 
       module MethodNode
@@ -132,8 +151,13 @@ module Reek
         end
       end
 
+      # Utility methods for :if nodes
       module IfNode
         def condition() self[1] end
+
+        def body
+          self[2..-1].extend SexpNode
+        end
       end
 
       module IterNode

--- a/lib/reek/source/sexp_node.rb
+++ b/lib/reek/source/sexp_node.rb
@@ -16,7 +16,7 @@ module Reek
         inspect.hash
       end
 
-      def each_node(type, ignoring, &blk)
+      def each_node(type, ignoring = [], &blk)
         if block_given?
           look_for(type, ignoring, &blk)
         else
@@ -24,6 +24,18 @@ module Reek
           look_for(type, ignoring) { |exp| result << exp }
           result
         end
+      end
+
+      def unnested_nodes(types)
+        result = []
+        if types.include? first
+          result << self
+        else
+          each_sexp do |elem|
+            result += elem.unnested_nodes(types)
+          end
+        end
+        result
       end
 
       def each_sexp

--- a/spec/reek/smells/control_parameter_spec.rb
+++ b/spec/reek/smells/control_parameter_spec.rb
@@ -12,222 +12,246 @@ describe ControlParameter do
 
   it_should_behave_like 'SmellDetector'
 
-  it 'should not report a ternary check on an ivar' do
-    src = 'def simple(arga) @ivar ? arga : 3 end'
-    expect(src).not_to smell_of(ControlParameter)
-  end
 
-  it 'should not report a ternary check on a lvar' do
-    src = 'def simple(arga) lvar = 27; lvar ? arga : @ivar end'
-    expect(src).not_to smell_of(ControlParameter)
-  end
-
-  it 'should not report when parameter is unused' do
-    src = 'def simple(arg) test = 1 end'
-    expect(src).not_to smell_of(ControlParameter)
-  end
-
-  it 'should not report when parameter is used inside conditional' do
-    src = 'def simple(arg) if true then puts arg end end'
-    expect(src).not_to smell_of(ControlParameter)
-  end
-
-  it 'should not report when used in first conditional but not second' do
-    src = <<EOS
-def things(arg)
-  if arg
-    puts arg
-  end
-  if arg
-    puts 'a'
-  end
-end
-EOS
-    expect(src).not_to smell_of(ControlParameter)
-  end
-
-  it 'should not report when used in second conditional but not first' do
-    src = <<EOS
-def things(arg)
-  if arg
-    puts 'a'
-  end
-  if arg
-    puts arg
-  end
-end
-EOS
-    expect(src).not_to smell_of(ControlParameter)
-  end
-
-  it 'should not report on complex non smelly method' do
-    src = <<EOS
-  def self.guess(arg)
-    case arg
-    when ""
-      t = self
-    when "a"
-      t = Switch::OptionalArgument
-    when "b"
-      t = Switch::PlacedArgument
-    else
-      t = Switch::RequiredArgument
+  context 'parameter not used to determine code path' do
+    it 'does not report a ternary check on an ivar' do
+      src = 'def simple(arga) @ivar ? arga : 3 end'
+      expect(src).not_to smell_of(ControlParameter)
     end
-    self >= t or incompatible_argument_styles(arg, t)
-    t
+
+    it 'does not report a ternary check on a lvar' do
+      src = 'def simple(arga) lvar = 27; lvar ? arga : @ivar end'
+      expect(src).not_to smell_of(ControlParameter)
+    end
+
+    it 'does not report when parameter is unused' do
+      src = 'def simple(arg) test = 1 end'
+      expect(src).not_to smell_of(ControlParameter)
+    end
+
+    it 'does not report when parameter is used inside conditional' do
+      src = 'def simple(arg) if true then puts arg end end'
+      expect(src).not_to smell_of(ControlParameter)
+    end
   end
-EOS
-    expect(src).not_to smell_of(ControlParameter)
-  end
+
 
   context 'parameter only used to determine code path' do
-    it 'should report a ternary check on a parameter' do
+    it 'reports a ternary check on a parameter' do
       src = 'def simple(arga) arga ? @ivar : 3 end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arga')
     end
 
-    it 'should spot a couple inside a block' do
+    it 'reports a couple inside a block' do
       src = 'def blocks(arg) @text.map { |blk| arg ? blk : "#{blk}" } end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on an if statement modifier' do
+    it 'reports on an if statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => \'A\') if arg end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on an unless statement modifier' do
+    it 'reports on an unless statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => \'A\') unless arg end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on if control expression' do
+    it 'reports on if control expression' do
       src = 'def simple(arg) args = {}; if arg then args.merge(\'a\' => \'A\') end end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on if control expression with &&' do
+    it 'reports on if control expression with &&' do
       src = 'def simple(arg) if arg && true then puts "arg" end end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on if control expression with preceding &&' do
+    it 'reports on if control expression with preceding &&' do
       src = 'def simple(arg) if true && arg then puts "arg" end end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on if control expression with two && conditions' do
+    it 'reports on if control expression with two && conditions' do
       src = 'def simple(a) ag = {}; if a && true && true then puts "2" end end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'a')
     end
 
-    it 'should report on if control expression with ||' do
+    it 'reports on if control expression with ||' do
       src = 'def simple(arg) args = {}; if arg || true then puts "arg" end end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on if control expression with or' do
+    it 'reports on if control expression with or' do
       src = 'def simple(arg) args = {}; if arg or true then puts "arg" end end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on && notation' do
+    it 'reports on if control expression with if' do
+      src = 'def simple(arg) args = {}; if (arg if true) then puts "arg" end end'
+      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+    end
+
+    it 'reports on && notation' do
       src = 'def simple(arg) args = {}; arg && args.merge(\'a\' => \'A\') end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on || notation' do
+    it 'reports on || notation' do
       src = 'def simple(arg) args = {}; arg || args.merge(\'a\' => \'A\') end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on case statement' do
+    it 'reports on case statement' do
       src = 'def simple(arg) case arg when nil; nil when false; nil else nil end end'
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report when the argument is a hash on which we access a key' do
-      src = 'def simple(arg) if arg[\'a\'] then puts \'a\' else puts \'b\' end end'
+    it 'reports on nested if statements that are both control parameters' do
+      src = <<-EOS
+        def nested(arg)
+          if arg
+            puts 'a'
+            puts 'b' if arg
+          end
+        end
+      EOS
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on nested if statements that are both control parameters' do
-      src = <<EOS
-def nested(arg)
-  if arg
-    puts 'a'
-    puts 'b' if arg
-  end
-end
-EOS
+    it 'reports on nested if statements where the inner if is a control parameter' do
+      src = <<-EOS
+        def nested(arg)
+          if true
+            puts 'a'
+            puts 'b' if arg
+          end
+        end
+      EOS
       expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
     end
 
-    it 'should report on nested if statements where the inner if is a control parameter' do
-      src = <<EOS
-def nested(arg)
-  if true
-    puts 'a'
-    puts 'b' if arg
-  end
-end
-EOS
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+    it 'reports on explicit comparison in the condition' do
+      src = 'def simple(arg) if arg == :foo then :foo else :bar end end'
+      expect(src).to smell_of(ControlParameter)
+    end
+
+    it 'reports on explicit negative comparison in the condition' do
+      src = 'def simple(arg) if arg != :foo then :bar else :foo end end'
+      expect(src).to smell_of(ControlParameter)
     end
   end
 
   context 'parameter used besides determining code path' do
-    it 'should not report on if conditional expression' do
+    it 'does not report on if conditional expression' do
       src = 'def simple(arg) if arg then use(arg) else use(@other) end end'
       expect(src).not_to smell_of(ControlParameter)
     end
 
-    it 'should not report on an if statement modifier' do
+    it 'does not report on an if statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => arg) if arg end'
       expect(src).not_to smell_of(ControlParameter)
     end
 
-    it 'should not report on an unless statement modifier' do
+    it 'does not report on an unless statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => arg) unless arg end'
       expect(src).not_to smell_of(ControlParameter)
     end
 
-    it 'should not report on if control expression' do
+    it 'does not report on if control expression' do
       src = 'def simple(arg) args = {}; if arg then args.merge(\'a\' => arg) end end'
       expect(src).not_to smell_of(ControlParameter)
     end
 
-    it 'should not report on if control expression with &&' do
+    it 'does not report on if control expression with &&' do
       src = 'def simple(arg) if arg && true then puts arg end end'
       expect(src).not_to smell_of(ControlParameter)
     end
 
-    it 'should not report on && notation' do
+    it 'does not report on && notation' do
       src = 'def simple(arg) args = {}; arg && args.merge(\'a\' => arg) end'
       expect(src).not_to smell_of(ControlParameter)
     end
 
-    it 'should not report on || notation' do
+    it 'does not report on || notation' do
       src = 'def simple(arg) args = {}; arg || args.merge(\'a\' => arg) end'
       expect(src).not_to smell_of(ControlParameter)
     end
 
-    it 'should not report when parameter is used outside conditional' do
+    it 'does not report when parameter is used outside conditional' do
       src = 'def simple(arg) puts arg; if arg then @a = 1 end end'
+      expect(src).not_to smell_of(ControlParameter)
+    end
+
+    it 'does not report when parameter is used as a method call argument in a condition' do
+      src = 'def simple(arg) if foo(arg) then @a = 1 end end'
+      expect(src).not_to smell_of(ControlParameter)
+    end
+
+    it 'does not report when parameter is used as a method call receiver in a condition' do
+      src = 'def simple(arg) if arg.foo? then @a = 1 end end'
+      expect(src).not_to smell_of(ControlParameter)
+    end
+
+    it 'does not report when the argument is a hash on which we access a key' do
+      src = 'def simple(arg) if arg[\'a\'] then puts \'a\' else puts \'b\' end end'
+      expect(src).not_to smell_of ControlParameter
+    end
+
+    it 'does not report when used in first conditional but not second' do
+      src = <<-EOS
+        def things(arg)
+          if arg
+            puts arg
+          end
+          if arg
+            puts 'a'
+          end
+        end
+      EOS
+      expect(src).not_to smell_of(ControlParameter)
+    end
+
+    it 'does not report when used in second conditional but not first' do
+      src = <<-EOS
+        def things(arg)
+          if arg
+            puts 'a'
+          end
+          if arg
+            puts arg
+          end
+        end
+      EOS
+      expect(src).not_to smell_of(ControlParameter)
+    end
+
+    it 'does not report when used in body of control flow operator' do
+      src = <<-EOS
+        def foo(arg)
+          case arg
+          when :bar
+            puts 'a'
+          else
+            puts 'b'
+          end
+          qux or quuz(arg)
+        end
+      EOS
       expect(src).not_to smell_of(ControlParameter)
     end
   end
 
   context 'when a smell is reported' do
     before :each do
-      src = <<EOS
-def things(arg)
-  @text.map do |blk|
-    arg ? blk : "blk"
-  end
-  puts "hello" if arg
-end
-EOS
+      src = <<-EOS
+        def things(arg)
+          @text.map do |blk|
+            arg ? blk : "blk"
+          end
+          puts "hello" if arg
+        end
+      EOS
       ctx = MethodContext.new(nil, src.to_reek_source.syntax_tree)
       smells = @detector.examine(ctx)
       expect(smells.length).to eq(1)


### PR DESCRIPTION
- Make detector concentrate on use of parameter as a value. Using the
  result of a method call involving the parameter is considered
  legitimate use. Comparing to a value is not.
- Handle edge cases like use of if inside a condition
- Re-format specs
- Refactor smell detector
