### PR TITLE
Required keyword arguments support

### DIFF
--- a/features/samples.feature
+++ b/features/samples.feature
@@ -290,3 +290,13 @@ Feature: Basic smell detection
     spec/samples/ruby20_syntax.rb -- 1 warning:
       [1]:SomeClass has no descriptive comment (IrresponsibleModule)
     """
+
+  @ruby21
+  Scenario: Correct smells from a source file with Ruby 2.1 specific syntax
+    When I run reek spec/samples/ruby21_syntax.rb
+    Then the exit status indicates smells
+    And it reports:
+    """
+    spec/samples/ruby21_syntax.rb -- 1 warning:
+      [1]:SomeClass has no descriptive comment (IrresponsibleModule)
+    """

--- a/lib/reek/source/sexp_extensions.rb
+++ b/lib/reek/source/sexp_extensions.rb
@@ -40,6 +40,11 @@ module Reek
         include ArgNodeBase
       end
 
+      # Utility methods for :kwarg nodes.
+      module KwargNode
+        include ArgNodeBase
+      end
+
       # Utility methods for :optarg nodes.
       module OptargNode
         include ArgNodeBase

--- a/spec/samples/ruby21_syntax.rb
+++ b/spec/samples/ruby21_syntax.rb
@@ -1,0 +1,5 @@
+class SomeClass
+  def method_with_required_keyword_arguments(foo:)
+    puts foo
+  end
+end


### PR DESCRIPTION
Reek 1.5.0 blows up on required keyword arguments – while Reek 1.4.0 didn’t. :)

This adds required keyword arguments support and the relevant test (which blows up when there is no `Source::SexpExtensions::KwargNode`).
