### PR TITLE
Recognise :casgn scoping and fix ModuleInitialize

### DIFF
--- a/lib/reek/core/code_context.rb
+++ b/lib/reek/core/code_context.rb
@@ -24,7 +24,7 @@ module Reek
       end
 
       def local_nodes(type, &blk)
-        each_node(type, [:class, :module], &blk)
+        each_node(type, [:casgn, :class, :module], &blk)
       end
 
       def each_node(type, ignoring, &blk)

--- a/spec/reek/smells/module_initialize_spec.rb
+++ b/spec/reek/smells/module_initialize_spec.rb
@@ -16,5 +16,31 @@ describe ModuleInitialize do
         expect(src).to smell_of(ModuleInitialize)
       end
     end
+
+    context 'with method named initialize in a nested class' do
+      it 'does not smell' do
+        src = <<-EOF
+          module A
+            class B
+              def initialize; end
+            end
+          end
+        EOF
+        expect(src).not_to smell_of(ModuleInitialize)
+      end
+    end
+
+    context 'with method named initialize in a nested struct' do
+      it 'does not smell' do
+        src = <<-EOF
+          module A
+            B = Struct.new(:c) do
+              def initialize; end
+            end
+          end
+        EOF
+        expect(src).not_to smell_of(ModuleInitialize)
+      end
+    end
   end
 end


### PR DESCRIPTION
I noticed bogus `ModuleInitialize` reports for an `initialize` method in a `Struct`-introduced scope.

I believe this fixes it, but as it alters `CodeContext#local_nodes` scope I would love if it was diligently reviewed.
