### PR TITLE
Get rid of all smell parameter constants.

### DIFF
--- a/features/reports/yaml.feature
+++ b/features/reports/yaml.feature
@@ -26,8 +26,8 @@ Feature: Report smells using simple YAML layout
         - 4
         - 6
         message: calls @s.title 2 times
-        call: "@s.title"
-        occurrences: 2
+        name: "@s.title"
+        count: 2
       - smell_category: Duplication
         smell_type: DuplicateMethodCall
         source: spec/samples/masked/dirty.rb
@@ -36,8 +36,8 @@ Feature: Report smells using simple YAML layout
         - 4
         - 6
         message: calls puts(@s.title) 2 times
-        call: puts(@s.title)
-        occurrences: 2
+        name: puts(@s.title)
+        count: 2
       - smell_category: NestedIterators
         smell_type: NestedIterators
         source: spec/samples/masked/dirty.rb
@@ -45,7 +45,7 @@ Feature: Report smells using simple YAML layout
         lines:
         - 5
         message: contains iterators nested 2 deep
-        depth: 2
+        count: 2
       """
 
   @stdin
@@ -62,5 +62,5 @@ Feature: Report smells using simple YAML layout
         lines:
         - 1
         message: has no descriptive comment
-        module_name: Turn
+        name: Turn
       """

--- a/lib/reek/smell_warning.rb
+++ b/lib/reek/smell_warning.rb
@@ -51,7 +51,7 @@ module Reek
       coder['lines']           = lines
       coder['message']         = message
       parameters.each do |key, value|
-        coder[key] = value
+        coder[key.to_s] = value
       end
     end
 

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -17,8 +17,6 @@ module Reek
     # TODO: Catch attributes declared "by hand"
     #
     class Attribute < SmellDetector
-      ATTRIBUTE_KEY = 'attribute'
-
       def self.contexts # :nodoc:
         [:class, :module]
       end
@@ -38,7 +36,7 @@ module Reek
                            context: ctx.full_name,
                            lines: [line],
                            message:  "declares the attribute #{attribute}",
-                           parameters: { ATTRIBUTE_KEY => attribute.to_s }
+                           parameters: { name: attribute.to_s }
         end
       end
 

--- a/lib/reek/smells/boolean_parameter.rb
+++ b/lib/reek/smells/boolean_parameter.rb
@@ -12,8 +12,6 @@ module Reek
     # default initializer.
     #
     class BooleanParameter < SmellDetector
-      PARAMETER_KEY = 'parameter'
-
       def self.smell_category
         'ControlCouple'
       end
@@ -31,7 +29,7 @@ module Reek
                            context: method_ctx.full_name,
                            lines: [method_ctx.exp.line],
                            message: "has boolean parameter '#{parameter}'",
-                           parameters: { PARAMETER_KEY => parameter.to_s }
+                           parameters: { name: parameter.to_s }
         end
       end
     end

--- a/lib/reek/smells/class_variable.rb
+++ b/lib/reek/smells/class_variable.rb
@@ -13,8 +13,6 @@ module Reek
     # the context of the test includes all global state).
     #
     class ClassVariable < SmellDetector
-      VARIABLE_KEY = 'variable'
-
       def self.contexts # :nodoc:
         [:class, :module]
       end
@@ -30,7 +28,7 @@ module Reek
                            context: ctx.full_name,
                            lines: lines,
                            message: "declares the class variable #{variable}",
-                           parameters: { VARIABLE_KEY => variable.to_s }
+                           parameters: { name: variable.to_s }
         end
       end
 

--- a/lib/reek/smells/control_parameter.rb
+++ b/lib/reek/smells/control_parameter.rb
@@ -41,8 +41,6 @@ module Reek
     # the source code.
     #
     class ControlParameter < SmellDetector
-      PARAMETER_KEY = 'parameter'
-
       def self.smell_category
         'ControlCouple'
       end
@@ -59,7 +57,7 @@ module Reek
                            context: ctx.full_name,
                            lines: control_parameter.lines,
                            message: "is controlled by argument #{control_parameter.name}",
-                           parameters: { PARAMETER_KEY => control_parameter.name.to_s }
+                           parameters: { name: control_parameter.name.to_s }
         end
       end
 

--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -17,9 +17,6 @@ module Reek
     # the same names that are expected by three or more methods of a class.
     #
     class DataClump < SmellDetector
-      METHODS_KEY = 'methods'
-      OCCURRENCES_KEY = 'occurrences'
-      PARAMETERS_KEY = 'parameters'
       #
       # The name of the config field that sets the maximum allowed
       # copies of any clump. No group of common parameters will be
@@ -62,9 +59,9 @@ module Reek
                            lines: methods.map(&:line),
                            message: "takes parameters #{DataClump.print_clump(clump)} to #{methods.length} methods",
                            parameters: {
-                             PARAMETERS_KEY => clump.map(&:to_s),
-                             OCCURRENCES_KEY => methods.length,
-                             METHODS_KEY => methods.map(&:name)
+                             parameters: clump.map(&:to_s),
+                             count: methods.length,
+                             methods: methods.map(&:name)
                            }
         end
       end

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -17,8 +17,6 @@ module Reek
     #   end
     #
     class DuplicateMethodCall < SmellDetector
-      CALL_KEY = 'call'
-      OCCURRENCES_KEY = 'occurrences'
       # The name of the config field that sets the maximum number of
       # identical calls to be permitted within any single method.
       MAX_ALLOWED_CALLS_KEY = 'max_calls'
@@ -55,7 +53,7 @@ module Reek
                            context: ctx.full_name,
                            lines: found_call.lines,
                            message: "calls #{found_call.call} #{found_call.occurs} times",
-                           parameters: { CALL_KEY => found_call.call, OCCURRENCES_KEY => found_call.occurs }
+                           parameters: { name: found_call.call, count: found_call.occurs }
         end
       end
 

--- a/lib/reek/smells/feature_envy.rb
+++ b/lib/reek/smells/feature_envy.rb
@@ -32,8 +32,6 @@ module Reek
     #
     class FeatureEnvy < SmellDetector
       include ExcludeInitialize
-      RECEIVER_KEY = 'receiver'
-      REFERENCES_KEY = 'references'
 
       def self.smell_category
         'LowCohesion'
@@ -52,7 +50,7 @@ module Reek
                            context: method_ctx.full_name,
                            lines: [method_ctx.exp.line],
                            message: "refers to #{target} more than self",
-                           parameters: { RECEIVER_KEY => target, REFERENCES_KEY => occurs }
+                           parameters: { name: target, count: occurs }
         end
       end
     end

--- a/lib/reek/smells/irresponsible_module.rb
+++ b/lib/reek/smells/irresponsible_module.rb
@@ -9,8 +9,6 @@ module Reek
     # with a brief comment outlining its responsibilities.
     #
     class IrresponsibleModule < SmellDetector
-      MODULE_NAME_KEY = 'module_name'
-
       def self.contexts # :nodoc:
         [:class]
       end
@@ -31,7 +29,7 @@ module Reek
                           context: ctx.full_name,
                           lines: [ctx.exp.line],
                           message: 'has no descriptive comment',
-                          parameters: {  MODULE_NAME_KEY => ctx.exp.text_name })]
+                          parameters: {  name: ctx.exp.text_name })]
       end
     end
   end

--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -13,7 +13,6 @@ module Reek
     # many parameters.
     #
     class LongParameterList < SmellDetector
-      PARAMETER_COUNT_KEY = 'parameter_count'
       # The name of the config field that sets the maximum number of
       # parameters permitted in any method or block.
       MAX_ALLOWED_PARAMS_KEY = 'max_params'
@@ -41,7 +40,7 @@ module Reek
                           context: ctx.full_name,
                           lines: [ctx.exp.line],
                           message: "has #{count} parameters",
-                          parameters: { PARAMETER_COUNT_KEY => count })]
+                          parameters: { count: count })]
       end
     end
   end

--- a/lib/reek/smells/long_yield_list.rb
+++ b/lib/reek/smells/long_yield_list.rb
@@ -8,7 +8,6 @@ module Reek
     # passed to a block by a +yield+ call.
     #
     class LongYieldList < SmellDetector
-      PARAMETER_COUNT_KEY = 'parameter_count'
       # The name of the config field that sets the maximum number of
       # parameters permitted in any method or block.
       MAX_ALLOWED_PARAMS_KEY = 'max_params'
@@ -37,7 +36,7 @@ module Reek
                            context: method_ctx.full_name,
                            lines: [yield_node.line],
                            message: "yields #{count} parameters",
-                           parameters: { PARAMETER_COUNT_KEY => count }
+                           parameters: { count: count }
         end
       end
     end

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -9,7 +9,6 @@ module Reek
     # +NestedIterators+ reports failing methods only once.
     #
     class NestedIterators < SmellDetector
-      NESTING_DEPTH_KEY = 'depth'
       # The name of the config field that sets the maximum depth
       # of nested iterators to be permitted within any single method.
       MAX_ALLOWED_NESTING_KEY = 'max_allowed_nesting'
@@ -40,7 +39,7 @@ module Reek
                             context: ctx.full_name,
                             lines: [exp.line],
                             message: "contains iterators nested #{depth} deep",
-                            parameters: { NESTING_DEPTH_KEY => depth })]
+                            parameters: { count: depth })]
         else
           []
         end

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -56,7 +56,7 @@ module Reek
                            context: ctx.full_name,
                            lines: lines,
                            message: "tests #{expression} at least #{occurs} times",
-                           parameters: { 'expression' => expression, 'occurrences' => occurs }
+                           parameters: { name: expression, count: occurs }
         end
       end
 

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -11,7 +11,6 @@ module Reek
     # configurable number of instance variables.
     #
     class TooManyInstanceVariables < SmellDetector
-      IVAR_COUNT_KEY = 'ivar_count'
       # The name of the config field that sets the maximum number of instance
       # variables permitted in a class.
       MAX_ALLOWED_IVARS_KEY = 'max_instance_variables'
@@ -45,7 +44,7 @@ module Reek
                           context: ctx.full_name,
                           lines: [ctx.exp.line],
                           message: "has at least #{count} instance variables",
-                          parameters: { IVAR_COUNT_KEY => count })]
+                          parameters: { count: count })]
       end
     end
   end

--- a/lib/reek/smells/too_many_methods.rb
+++ b/lib/reek/smells/too_many_methods.rb
@@ -13,7 +13,6 @@ module Reek
     # modules.
     #
     class TooManyMethods < SmellDetector
-      METHOD_COUNT_KEY = 'method_count'
       # The name of the config field that sets the maximum number of methods
       # permitted in a class.
       MAX_ALLOWED_METHODS_KEY = 'max_methods'
@@ -47,7 +46,7 @@ module Reek
                           context: ctx.full_name,
                           lines: [ctx.exp.line],
                           message:  "has at least #{actual} methods",
-                          parameters: { METHOD_COUNT_KEY => actual })]
+                          parameters: { count: actual })]
       end
     end
   end

--- a/lib/reek/smells/too_many_statements.rb
+++ b/lib/reek/smells/too_many_statements.rb
@@ -9,7 +9,6 @@ module Reek
     # +TooManyStatements+ reports any method with more than 5 statements.
     #
     class TooManyStatements < SmellDetector
-      STATEMENT_COUNT_KEY = 'statement_count'
       # The name of the config field that sets the maximum number of
       # statements permitted in any method.
       MAX_ALLOWED_STATEMENTS_KEY = 'max_statements'
@@ -39,7 +38,7 @@ module Reek
                           context: ctx.full_name,
                           lines: [ctx.exp.line],
                           message: "has approx #{count} statements",
-                          parameters: { STATEMENT_COUNT_KEY => count })]
+                          parameters: { count: count })]
       end
     end
   end

--- a/lib/reek/smells/uncommunicative_method_name.rb
+++ b/lib/reek/smells/uncommunicative_method_name.rb
@@ -17,7 +17,6 @@ module Reek
     # * names ending with a number
     #
     class UncommunicativeMethodName < SmellDetector
-      METHOD_NAME_KEY = 'method_name'
       # The name of the config field that lists the regexps of
       # smelly names to be reported.
       REJECT_KEY = 'reject'
@@ -57,7 +56,7 @@ module Reek
                           context: ctx.full_name,
                           lines: [ctx.exp.line],
                           message: "has the name '#{name}'",
-                          parameters: { METHOD_NAME_KEY => name.to_s })]
+                          parameters: { name: name })]
       end
     end
   end

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -17,7 +17,6 @@ module Reek
     # * names ending with a number
     #
     class UncommunicativeModuleName < SmellDetector
-      MODULE_NAME_KEY = 'module_name'
       # The name of the config field that lists the regexps of
       # smelly names to be reported.
       REJECT_KEY = 'reject'
@@ -64,7 +63,7 @@ module Reek
                           context: full_name,
                           lines: [exp.line],
                           message: "has the name '#{name}'",
-                          parameters: { MODULE_NAME_KEY => name })]
+                          parameters: { name: name })]
       end
     end
   end

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -17,7 +17,6 @@ module Reek
     # * names ending with a number
     #
     class UncommunicativeParameterName < SmellDetector
-      PARAMETER_NAME_KEY = 'parameter_name'
       # The name of the config field that lists the regexps of
       # smelly names to be reported.
       REJECT_KEY = 'reject'
@@ -56,7 +55,7 @@ module Reek
                            context: ctx.full_name,
                            lines: [context_expression.line],
                            message: "has the parameter name '#{name}'",
-                           parameters: { PARAMETER_NAME_KEY => name.to_s })
+                           parameters: { name: name.to_s })
         end
       end
 

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -17,7 +17,6 @@ module Reek
     # * names ending with a number
     #
     class UncommunicativeVariableName < SmellDetector
-      VARIABLE_NAME_KEY = 'variable_name'
       # The name of the config field that lists the regexps of
       # smelly names to be reported.
       REJECT_KEY = 'reject'
@@ -59,7 +58,7 @@ module Reek
                            context: ctx.full_name,
                            lines: lines,
                            message: "has the variable name '#{name}'",
-                           parameters: { VARIABLE_NAME_KEY => name.to_s })
+                           parameters: { name: name.to_s })
         end
       end
 

--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -7,8 +7,6 @@ module Reek
     # Methods should use their parameters.
     #
     class UnusedParameters < SmellDetector
-      PARAMETER_KEY = 'parameter'
-
       def self.smell_category
         'UnusedCode'
       end
@@ -25,7 +23,7 @@ module Reek
                            context: method_ctx.full_name,
                            lines: [method_ctx.exp.line],
                            message: "has unused parameter '#{param.name}'",
-                           parameters: { PARAMETER_KEY => param.name.to_s })
+                           parameters: { name: param.name.to_s })
         end
       end
     end

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -38,7 +38,7 @@ describe Attribute do
       end
 
       it 'reports the attribute name' do
-        expect(@smells[0].parameters[Attribute::ATTRIBUTE_KEY]).to eq(@attr_name)
+        expect(@smells[0].parameters[:name]).to eq(@attr_name)
       end
 
       it 'reports the declaration line number' do

--- a/spec/reek/smells/boolean_parameter_spec.rb
+++ b/spec/reek/smells/boolean_parameter_spec.rb
@@ -9,34 +9,34 @@ describe BooleanParameter do
     context 'in a method' do
       it 'reports a parameter defaulted to true' do
         src = 'def cc(arga = true) end'
-        expect(src).to smell_of(BooleanParameter, BooleanParameter::PARAMETER_KEY => 'arga')
+        expect(src).to smell_of(BooleanParameter, name: 'arga')
       end
       it 'reports a parameter defaulted to false' do
         src = 'def cc(arga = false) end'
-        expect(src).to smell_of(BooleanParameter, BooleanParameter::PARAMETER_KEY => 'arga')
+        expect(src).to smell_of(BooleanParameter, name: 'arga')
       end
       it 'reports two parameters defaulted to booleans' do
         src = 'def cc(nowt, arga = true, argb = false, &blk) end'
         expect(src).to smell_of(BooleanParameter,
-                                { BooleanParameter::PARAMETER_KEY => 'arga' },
-                                BooleanParameter::PARAMETER_KEY => 'argb')
+                                { name: 'arga' },
+                                name: 'argb')
       end
     end
 
     context 'in a singleton method' do
       it 'reports a parameter defaulted to true' do
         src = 'def self.cc(arga = true) end'
-        expect(src).to smell_of(BooleanParameter, BooleanParameter::PARAMETER_KEY => 'arga')
+        expect(src).to smell_of(BooleanParameter, name: 'arga')
       end
       it 'reports a parameter defaulted to false' do
         src = 'def fred.cc(arga = false) end'
-        expect(src).to smell_of(BooleanParameter, BooleanParameter::PARAMETER_KEY => 'arga')
+        expect(src).to smell_of(BooleanParameter, name: 'arga')
       end
       it 'reports two parameters defaulted to booleans' do
         src = 'def Module.cc(nowt, arga = true, argb = false, &blk) end'
         expect(src).to smell_of(BooleanParameter,
-                                { BooleanParameter::PARAMETER_KEY => 'arga' },
-                                BooleanParameter::PARAMETER_KEY => 'argb')
+                                { name: 'arga' },
+                                name: 'argb')
       end
     end
   end
@@ -56,7 +56,7 @@ describe BooleanParameter do
       smells = @detector.smells_found.to_a
       expect(smells.length).to eq(1)
       expect(smells[0].smell_category).to eq(BooleanParameter.smell_category)
-      expect(smells[0].parameters[BooleanParameter::PARAMETER_KEY]).to eq('arga')
+      expect(smells[0].parameters[:name]).to eq('arga')
       expect(smells[0].source).to eq(@source_name)
       expect(smells[0].smell_type).to eq(BooleanParameter.smell_type)
       expect(smells[0].lines).to eq([1])

--- a/spec/reek/smells/class_variable_spec.rb
+++ b/spec/reek/smells/class_variable_spec.rb
@@ -36,7 +36,7 @@ describe ClassVariable do
         expect(@smells.length).to eq(1)
       end
       it 'records the variable name' do
-        expect(@smells[0].parameters[ClassVariable::VARIABLE_KEY]).to eq(@class_variable)
+        expect(@smells[0].parameters[:name]).to eq(@class_variable)
       end
     end
 
@@ -94,7 +94,7 @@ EOS
     expect(@warning.source).to eq(@source_name)
     expect(@warning.smell_category).to eq(ClassVariable.smell_category)
     expect(@warning.smell_type).to eq(ClassVariable.smell_type)
-    expect(@warning.parameters[ClassVariable::VARIABLE_KEY]).to eq(@class_variable)
+    expect(@warning.parameters[:name]).to eq(@class_variable)
     expect(@warning.lines).to eq([2])
   end
 end

--- a/spec/reek/smells/control_parameter_spec.rb
+++ b/spec/reek/smells/control_parameter_spec.rb
@@ -39,72 +39,72 @@ describe ControlParameter do
   context 'parameter only used to determine code path' do
     it 'reports a ternary check on a parameter' do
       src = 'def simple(arga) arga ? @ivar : 3 end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arga')
+      expect(src).to smell_of(ControlParameter, name: 'arga')
     end
 
     it 'reports a couple inside a block' do
       src = 'def blocks(arg) @text.map { |blk| arg ? blk : "#{blk}" } end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on an if statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => \'A\') if arg end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on an unless statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => \'A\') unless arg end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression' do
       src = 'def simple(arg) args = {}; if arg then args.merge(\'a\' => \'A\') end end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with &&' do
       src = 'def simple(arg) if arg && true then puts "arg" end end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with preceding &&' do
       src = 'def simple(arg) if true && arg then puts "arg" end end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with two && conditions' do
       src = 'def simple(a) ag = {}; if a && true && true then puts "2" end end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'a')
+      expect(src).to smell_of(ControlParameter, name: 'a')
     end
 
     it 'reports on if control expression with ||' do
       src = 'def simple(arg) args = {}; if arg || true then puts "arg" end end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with or' do
       src = 'def simple(arg) args = {}; if arg or true then puts "arg" end end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with if' do
       src = 'def simple(arg) args = {}; if (arg if true) then puts "arg" end end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on && notation' do
       src = 'def simple(arg) args = {}; arg && args.merge(\'a\' => \'A\') end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on || notation' do
       src = 'def simple(arg) args = {}; arg || args.merge(\'a\' => \'A\') end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on case statement' do
       src = 'def simple(arg) case arg when nil; nil when false; nil else nil end end'
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on nested if statements that are both control parameters' do
@@ -116,7 +116,7 @@ describe ControlParameter do
           end
         end
       EOS
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on nested if statements where the inner if is a control parameter' do
@@ -128,7 +128,7 @@ describe ControlParameter do
           end
         end
       EOS
-      expect(src).to smell_of(ControlParameter, ControlParameter::PARAMETER_KEY => 'arg')
+      expect(src).to smell_of(ControlParameter, name: 'arg')
     end
 
     it 'reports on explicit comparison in the condition' do
@@ -285,7 +285,7 @@ describe ControlParameter do
     it_should_behave_like 'common fields set correctly'
 
     it 'has the correct fields' do
-      expect(@warning.parameters[ControlParameter::PARAMETER_KEY]).to eq('arg')
+      expect(@warning.parameters[:name]).to eq('arg')
       expect(@warning.lines).to eq([3, 5])
     end
   end

--- a/spec/reek/smells/data_clump_spec.rb
+++ b/spec/reek/smells/data_clump_spec.rb
@@ -35,13 +35,13 @@ EOS
       expect(@smells.length).to eq(1)
     end
     it 'reports all parameters' do
-      expect(@smells[0].parameters[DataClump::PARAMETERS_KEY]).to eq(['pa', 'pb'])
+      expect(@smells[0].parameters[:parameters]).to eq(['pa', 'pb'])
     end
     it 'reports the number of occurrences' do
-      expect(@smells[0].parameters[DataClump::OCCURRENCES_KEY]).to eq(3)
+      expect(@smells[0].parameters[:count]).to eq(3)
     end
     it 'reports all methods' do
-      expect(@smells[0].parameters[DataClump::METHODS_KEY]).to eq(['first', 'second', 'third'])
+      expect(@smells[0].parameters[:methods]).to eq(['first', 'second', 'third'])
     end
     it 'reports the declaration line numbers' do
       expect(@smells[0].lines).to eq([2, 3, 4])
@@ -63,8 +63,8 @@ EOS
 end
 EOS
     expect(src).to smell_of(DataClump,
-                            DataClump::OCCURRENCES_KEY => 3,
-                            DataClump::PARAMETERS_KEY => ['pa', 'pb'])
+                            count: 3,
+                            parameters: ['pa', 'pb'])
   end
 
   it 'reports 3 identical parameter sets' do
@@ -76,8 +76,8 @@ EOS
 end
 EOS
     expect(src).to smell_of(DataClump,
-                            DataClump::OCCURRENCES_KEY => 3,
-                            DataClump::PARAMETERS_KEY => ['pa', 'pb', 'pc'])
+                            count: 3,
+                            parameters: ['pa', 'pb', 'pc'])
   end
 
   it 'reports re-ordered identical parameter sets' do
@@ -89,8 +89,8 @@ EOS
 end
 EOS
     expect(src).to smell_of(DataClump,
-                            DataClump::OCCURRENCES_KEY => 3,
-                            DataClump::PARAMETERS_KEY => ['pa', 'pb', 'pc'])
+                            count: 3,
+                            parameters: ['pa', 'pb', 'pc'])
   end
 
   it 'counts only identical parameter sets' do
@@ -114,7 +114,7 @@ EOS
   def c_raw_singleton (src, options) end
 end
 EOS
-    expect(src).to smell_of(DataClump, DataClump::OCCURRENCES_KEY => 5)
+    expect(src).to smell_of(DataClump, count: 5)
   end
 
   it 'correctly checks number of occurences' do
@@ -139,7 +139,7 @@ EOS
       end
     EOS
     expect(src).to smell_of(DataClump,
-                            DataClump::PARAMETERS_KEY => %w(p1 p2))
+                            parameters: %w(p1 p2))
   end
 
   it 'ignores anonymous parameters' do
@@ -151,7 +151,7 @@ EOS
       end
     EOS
     expect(src).to smell_of(DataClump,
-                            DataClump::PARAMETERS_KEY => %w(p1 p2))
+                            parameters: %w(p1 p2))
   end
 end
 

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -30,7 +30,7 @@ EOS
     it_should_behave_like 'common fields set correctly'
 
     it 'reports the call' do
-      expect(@warning.parameters[DuplicateMethodCall::CALL_KEY]).to eq('other[@thing]')
+      expect(@warning.parameters[:name]).to eq('other[@thing]')
     end
     it 'reports the correct lines' do
       expect(@warning.lines).to eq([2, 4])
@@ -40,20 +40,20 @@ EOS
   context 'with repeated method calls' do
     it 'reports repeated call' do
       src = 'def double_thing() @other.thing + @other.thing end'
-      expect(src).to smell_of(DuplicateMethodCall, DuplicateMethodCall::CALL_KEY => '@other.thing')
+      expect(src).to smell_of(DuplicateMethodCall, name: '@other.thing')
     end
     it 'reports repeated call to lvar' do
       src = 'def double_thing(other) other[@thing] + other[@thing] end'
-      expect(src).to smell_of(DuplicateMethodCall, DuplicateMethodCall::CALL_KEY => 'other[@thing]')
+      expect(src).to smell_of(DuplicateMethodCall, name: 'other[@thing]')
     end
     it 'reports call parameters' do
       src = 'def double_thing() @other.thing(2,3) + @other.thing(2,3) end'
-      expect(src).to smell_of(DuplicateMethodCall, DuplicateMethodCall::CALL_KEY => '@other.thing(2, 3)')
+      expect(src).to smell_of(DuplicateMethodCall, name: '@other.thing(2, 3)')
     end
     it 'should report nested calls' do
       src = 'def double_thing() @other.thing.foo + @other.thing.foo end'
-      expect(src).to smell_of(DuplicateMethodCall, { DuplicateMethodCall::CALL_KEY => '@other.thing' },
-                              DuplicateMethodCall::CALL_KEY => '@other.thing.foo')
+      expect(src).to smell_of(DuplicateMethodCall, { name: '@other.thing' },
+                              name: '@other.thing.foo')
     end
     it 'should ignore calls to new' do
       src = 'def double_thing() @other.new + @other.new end'
@@ -124,7 +124,7 @@ EOS
   context 'with repeated attribute assignment' do
     it 'reports repeated assignment' do
       src = 'def double_thing(thing) @other[thing] = true; @other[thing] = true; end'
-      expect(src).to smell_of(DuplicateMethodCall, DuplicateMethodCall::CALL_KEY => '@other[thing] = true')
+      expect(src).to smell_of(DuplicateMethodCall, name: '@other[thing] = true')
     end
     it 'does not report multi-assignments' do
       src = <<EOS
@@ -162,7 +162,7 @@ EOS
     end
     it 'reports quadruple calls' do
       src = 'def double_thing() @other.thing + @other.thing + @other.thing + @other.thing end'
-      expect(src).to smell_of(DuplicateMethodCall, DuplicateMethodCall::CALL_KEY => '@other.thing', DuplicateMethodCall::OCCURRENCES_KEY => 4).with_config(@config)
+      expect(src).to smell_of(DuplicateMethodCall, name: '@other.thing', count: 4).with_config(@config)
     end
   end
 
@@ -176,11 +176,11 @@ EOS
     end
     it 'reports calls to other methods' do
       src = 'def double_other_thing() @other.thing + @other.thing end'
-      expect(src).to smell_of(DuplicateMethodCall, DuplicateMethodCall::CALL_KEY => '@other.thing').with_config(@config)
+      expect(src).to smell_of(DuplicateMethodCall, name: '@other.thing').with_config(@config)
     end
     it 'does not report calls to methods specifed with a regular expression' do
       src = 'def double_puts() puts @other.thing; puts @other.thing end'
-      expect(src).to smell_of(DuplicateMethodCall, DuplicateMethodCall::CALL_KEY => '@other.thing').with_config(@config)
+      expect(src).to smell_of(DuplicateMethodCall, name: '@other.thing').with_config(@config)
     end
   end
 end

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -235,10 +235,10 @@ EOS
       expect(@smells[0].smell_type).to eq(FeatureEnvy.smell_type)
     end
     it 'reports the envious receiver' do
-      expect(@smells[0].parameters[FeatureEnvy::RECEIVER_KEY]).to eq(@receiver)
+      expect(@smells[0].parameters[:name]).to eq(@receiver)
     end
     it 'reports the number of references' do
-      expect(@smells[0].parameters[FeatureEnvy::REFERENCES_KEY]).to eq(3)
+      expect(@smells[0].parameters[:count]).to eq(3)
     end
     it 'reports the referring lines' do
       skip

--- a/spec/reek/smells/irresponsible_module_spec.rb
+++ b/spec/reek/smells/irresponsible_module_spec.rb
@@ -38,7 +38,7 @@ describe IrresponsibleModule do
     expect(smells[0].smell_category).to eq(IrresponsibleModule.smell_category)
     expect(smells[0].smell_type).to eq(IrresponsibleModule.smell_type)
     expect(smells[0].lines).to eq([1])
-    expect(smells[0].parameters[IrresponsibleModule::MODULE_NAME_KEY]).to eq(@bad_module_name)
+    expect(smells[0].parameters[:name]).to eq(@bad_module_name)
   end
 
   it 'reports a class with an empty comment' do
@@ -69,7 +69,7 @@ describe IrresponsibleModule do
     expect(smells.length).to eq(1)
     expect(smells[0].smell_category).to eq(IrresponsibleModule.smell_category)
     expect(smells[0].smell_type).to eq(IrresponsibleModule.smell_type)
-    expect(smells[0].parameters[IrresponsibleModule::MODULE_NAME_KEY]).to eq('Foo::Bar')
+    expect(smells[0].parameters[:name]).to eq('Foo::Bar')
     expect(smells[0].context).to match(/#{smells[0].parameters['name']}/)
   end
 end

--- a/spec/reek/smells/long_parameter_list_spec.rb
+++ b/spec/reek/smells/long_parameter_list_spec.rb
@@ -41,21 +41,21 @@ describe LongParameterList do
   describe 'for methods with too many parameters' do
     it 'should report 4 parameters' do
       src = 'def simple(arga, argb, argc, argd) f(3);true end'
-      expect(src).to smell_of(LongParameterList, LongParameterList::PARAMETER_COUNT_KEY => 4)
+      expect(src).to smell_of(LongParameterList, count: 4)
     end
     it 'should report 8 parameters' do
       src = 'def simple(arga, argb, argc, argd,arge, argf, argg, argh) f(3);true end'
-      expect(src).to smell_of(LongParameterList, LongParameterList::PARAMETER_COUNT_KEY => 8)
+      expect(src).to smell_of(LongParameterList, count: 8)
     end
 
     describe 'and default values' do
       it 'should report 3 with 1 defaulted' do
         src = 'def simple(polly, queue, yep, zero=nil) f(3);false end'
-        expect(src).to smell_of(LongParameterList, LongParameterList::PARAMETER_COUNT_KEY => 4)
+        expect(src).to smell_of(LongParameterList, count: 4)
       end
       it 'should report with 3 defaulted' do
         src = 'def simple(aarg, polly=2, yep=:truth, zero=nil) f(3);false end'
-        expect(src).to smell_of(LongParameterList, LongParameterList::PARAMETER_COUNT_KEY => 4)
+        expect(src).to smell_of(LongParameterList, count: 4)
       end
     end
   end
@@ -85,7 +85,7 @@ EOS
     it_should_behave_like 'common fields set correctly'
 
     it 'reports the number of parameters' do
-      expect(@warning.parameters[LongParameterList::PARAMETER_COUNT_KEY]).to eq(4)
+      expect(@warning.parameters[:count]).to eq(4)
     end
     it 'reports the line number of the method' do
       expect(@warning.lines).to eq([1])

--- a/spec/reek/smells/long_yield_list_spec.rb
+++ b/spec/reek/smells/long_yield_list_spec.rb
@@ -26,7 +26,7 @@ describe LongYieldList do
     end
     it 'should report yield with many parameters' do
       src = 'def simple(arga, argb, &blk) f(3);yield arga,argb,arga,argb; end'
-      expect(src).to smell_of(LongYieldList, LongYieldList::PARAMETER_COUNT_KEY => 4)
+      expect(src).to smell_of(LongYieldList, count: 4)
     end
     it 'should not report yield of a long expression' do
       src = 'def simple(arga, argb, &blk) f(3);yield(if @dec then argb else 5+3 end); end'
@@ -50,7 +50,7 @@ EOS
     it_should_behave_like 'common fields set correctly'
 
     it 'reports the correct values' do
-      expect(@warning.parameters[LongYieldList::PARAMETER_COUNT_KEY]).to eq(4)
+      expect(@warning.parameters[:count]).to eq(4)
       expect(@warning.lines).to eq([3])
     end
   end

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -85,7 +85,7 @@ EOS
         ) { |qux| qux.quuz }
       end
     EOS
-    expect(src).to smell_of(NestedIterators, NestedIterators::NESTING_DEPTH_KEY => 2)
+    expect(src).to smell_of(NestedIterators, count: 2)
   end
 
   it 'reports the deepest level of nesting only' do
@@ -98,7 +98,7 @@ EOS
         }
       end
     EOS
-    expect(src).to smell_of(NestedIterators, NestedIterators::NESTING_DEPTH_KEY => 3)
+    expect(src).to smell_of(NestedIterators, count: 3)
   end
 
   context 'when the allowed nesting depth is 3' do
@@ -151,17 +151,17 @@ EOS
 
     it 'should report nested iterators inside the ignored iterator' do
       src = 'def bad(fred) @fred.ignore_me {|item| item.each {|ting| ting.each {|other| other.other} } } end'
-      expect(src).to smell_of(NestedIterators, NestedIterators::NESTING_DEPTH_KEY => 2).with_config(@config)
+      expect(src).to smell_of(NestedIterators, count: 2).with_config(@config)
     end
 
     it 'should report nested iterators outside the ignored iterator' do
       src = 'def bad(fred) @fred.each {|item| item.each {|ting| ting.ignore_me {|other| other.other} } } end'
-      expect(src).to smell_of(NestedIterators, NestedIterators::NESTING_DEPTH_KEY => 2).with_config(@config)
+      expect(src).to smell_of(NestedIterators, count: 2).with_config(@config)
     end
 
     it 'should report nested iterators with the ignored iterator between them' do
       src = 'def bad(fred) @fred.each {|item| item.ignore_me {|ting| ting.ting {|other| other.other} } } end'
-      expect(src).to smell_of(NestedIterators, NestedIterators::NESTING_DEPTH_KEY => 2).with_config(@config)
+      expect(src).to smell_of(NestedIterators, count: 2).with_config(@config)
     end
   end
 end
@@ -190,7 +190,7 @@ EOS
     it_should_behave_like 'common fields set correctly'
 
     it 'reports correct values' do
-      expect(@warning.parameters[NestedIterators::NESTING_DEPTH_KEY]).to eq(2)
+      expect(@warning.parameters[:count]).to eq(2)
       expect(@warning.lines).to eq([3])
     end
   end

--- a/spec/reek/smells/too_many_instance_variables_spec.rb
+++ b/spec/reek/smells/too_many_instance_variables_spec.rb
@@ -82,7 +82,7 @@ describe TooManyInstanceVariables do
     expect(@warning.source).to eq(@source_name)
     expect(@warning.smell_category).to eq(TooManyInstanceVariables.smell_category)
     expect(@warning.smell_type).to eq(TooManyInstanceVariables.smell_type)
-    expect(@warning.parameters[TooManyInstanceVariables::IVAR_COUNT_KEY]).to eq(10)
+    expect(@warning.parameters[:count]).to eq(10)
     expect(@warning.lines).to eq([2])
   end
 end

--- a/spec/reek/smells/too_many_methods_spec.rb
+++ b/spec/reek/smells/too_many_methods_spec.rb
@@ -47,7 +47,7 @@ EOS
       smells = @detector.examine_context(ctx)
       expect(smells.length).to eq(1)
       expect(smells[0].smell_type).to eq(TooManyMethods.smell_type)
-      expect(smells[0].parameters[TooManyMethods::METHOD_COUNT_KEY]).to eq(26)
+      expect(smells[0].parameters[:count]).to eq(26)
     end
   end
 
@@ -84,7 +84,7 @@ EOS
     expect(@warning.source).to eq(@source_name)
     expect(@warning.smell_category).to eq(TooManyMethods.smell_category)
     expect(@warning.smell_type).to eq(TooManyMethods.smell_type)
-    expect(@warning.parameters[TooManyMethods::METHOD_COUNT_KEY]).to eq(26)
+    expect(@warning.parameters[:count]).to eq(26)
     expect(@warning.lines).to eq([1])
   end
 end

--- a/spec/reek/smells/too_many_statements_spec.rb
+++ b/spec/reek/smells/too_many_statements_spec.rb
@@ -265,7 +265,7 @@ describe TooManyStatements do
     end
 
     it 'reports the number of statements' do
-      expect(@smells[0].parameters[TooManyStatements::STATEMENT_COUNT_KEY]).to eq(@num_statements)
+      expect(@smells[0].parameters[:count]).to eq(@num_statements)
     end
 
     it 'reports the correct smell sub class' do

--- a/spec/reek/smells/uncommunicative_method_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_method_name_spec.rb
@@ -33,7 +33,7 @@ describe UncommunicativeMethodName do
       it_should_behave_like 'common fields set correctly'
 
       it 'reports the correct values' do
-        expect(@warning.parameters[UncommunicativeMethodName::METHOD_NAME_KEY]).to eq(method_name)
+        expect(@warning.parameters[:name]).to eq(method_name)
         expect(@warning.lines).to eq([1])
         expect(@warning.context).to eq(method_name)
       end

--- a/spec/reek/smells/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_module_name_spec.rb
@@ -35,8 +35,8 @@ describe UncommunicativeModuleName do
       expect(smells.length).to eq(1)
       expect(smells[0].smell_category).to eq(UncommunicativeModuleName.smell_category)
       expect(smells[0].smell_type).to eq(UncommunicativeModuleName.smell_type)
-      expect(smells[0].parameters[UncommunicativeModuleName::MODULE_NAME_KEY]).to eq('X')
-      expect(smells[0].context).to match(/#{smells[0].parameters[UncommunicativeModuleName::MODULE_NAME_KEY]}/)
+      expect(smells[0].parameters[:name]).to eq('X')
+      expect(smells[0].context).to match(/#{smells[0].parameters[:name]}/)
     end
   end
 
@@ -59,7 +59,7 @@ describe UncommunicativeModuleName do
     it_should_behave_like 'common fields set correctly'
 
     it 'reports the correct values' do
-      expect(@warning.parameters[UncommunicativeModuleName::MODULE_NAME_KEY]).to eq('Printer2')
+      expect(@warning.parameters[:name]).to eq('Printer2')
       expect(@warning.lines).to eq([1])
     end
   end

--- a/spec/reek/smells/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_parameter_name_spec.rb
@@ -25,7 +25,7 @@ describe UncommunicativeParameterName do
       it "reports parameter's name" do
         src = "def #{host}help(x) basics(x) end"
         expect(src).to smell_of(UncommunicativeParameterName,
-                                UncommunicativeParameterName::PARAMETER_NAME_KEY => 'x')
+                                name: 'x')
       end
 
       it 'does not report unused parameters' do
@@ -41,13 +41,13 @@ describe UncommunicativeParameterName do
       it 'reports names of the form "x2"' do
         src = "def #{host}help(x2) basics(x2) end"
         expect(src).to smell_of(UncommunicativeParameterName,
-                                UncommunicativeParameterName::PARAMETER_NAME_KEY => 'x2')
+                                name: 'x2')
       end
 
       it 'reports long name ending in a number' do
         src = "def #{host}help(param2) basics(param2) end"
         expect(src).to smell_of(UncommunicativeParameterName,
-                                UncommunicativeParameterName::PARAMETER_NAME_KEY => 'param2')
+                                name: 'param2')
       end
 
       it 'does not report unused anonymous parameter' do
@@ -78,7 +78,7 @@ describe UncommunicativeParameterName do
     it_should_behave_like 'common fields set correctly'
 
     it 'reports the correct values' do
-      expect(@warning.parameters[UncommunicativeParameterName::PARAMETER_NAME_KEY]).to eq('bad2')
+      expect(@warning.parameters[:name]).to eq('bad2')
       expect(@warning.lines).to eq([1])
     end
   end

--- a/spec/reek/smells/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_variable_name_spec.rb
@@ -38,20 +38,20 @@ describe UncommunicativeVariableName do
     it 'reports one-letter variable name' do
       src = 'def simple(fred) x = jim(45) end'
       expect(src).to smell_of(UncommunicativeVariableName,
-                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x')
+                              name: 'x')
     end
 
     it 'reports name of the form "x2"' do
       src = 'def simple(fred) x2 = jim(45) end'
       expect(src).to smell_of(UncommunicativeVariableName,
-                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x2')
+                              name: 'x2')
     end
 
     it 'reports long name ending in a number' do
       @bad_var = 'var123'
       src = "def simple(fred) #{@bad_var} = jim(45) end"
       expect(src).to smell_of(UncommunicativeVariableName,
-                              UncommunicativeVariableName::VARIABLE_NAME_KEY => @bad_var)
+                              name: @bad_var)
     end
 
     it 'reports variable name only once' do
@@ -60,14 +60,14 @@ describe UncommunicativeVariableName do
       smells = @detector.examine_context(ctx)
       expect(smells.length).to eq(1)
       expect(smells[0].smell_type).to eq(UncommunicativeVariableName.smell_type)
-      expect(smells[0].parameters[UncommunicativeVariableName::VARIABLE_NAME_KEY]).to eq('x')
+      expect(smells[0].parameters[:name]).to eq('x')
       expect(smells[0].lines).to eq([1, 1])
     end
 
     it 'reports a bad name inside a block' do
       src = 'def clean(text) text.each { q2 = 3 } end'
       expect(src).to smell_of(UncommunicativeVariableName,
-                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'q2')
+                              name: 'q2')
     end
 
     it 'reports variable name outside any method' do
@@ -85,7 +85,7 @@ describe UncommunicativeVariableName do
   end
 EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x')
+                              name: 'x')
     end
 
     it 'reports all relevant block parameters' do
@@ -95,8 +95,8 @@ EOS
         end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                              { UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x' },
-                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y')
+                              { name: 'x' },
+                              { name: 'y' })
     end
 
     it 'reports block parameters used outside of methods' do
@@ -106,7 +106,7 @@ EOS
       end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x')
+                              name: 'x')
     end
 
     it 'reports splatted block parameters correctly' do
@@ -116,7 +116,7 @@ EOS
         end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y')
+                              name: 'y')
     end
 
     it 'reports nested block parameters' do
@@ -126,8 +126,8 @@ EOS
         end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                              { UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x' },
-                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y')
+                              { name: 'x' },
+                              { name: 'y' })
     end
 
     it 'reports splatted nested block parameters' do
@@ -137,8 +137,8 @@ EOS
         end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                              { UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x' },
-                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y')
+                              { name: 'x' },
+                              { name: 'y' })
     end
 
     it 'reports deeply nested block parameters' do
@@ -148,9 +148,9 @@ EOS
         end
       EOS
       expect(src).to smell_of(UncommunicativeVariableName,
-                              { UncommunicativeVariableName::VARIABLE_NAME_KEY => 'x' },
-                              { UncommunicativeVariableName::VARIABLE_NAME_KEY => 'y' },
-                              UncommunicativeVariableName::VARIABLE_NAME_KEY => 'z')
+                              { name: 'x' },
+                              { name: 'y' },
+                              { name: 'z' })
     end
 
   end
@@ -174,7 +174,7 @@ EOS
     it_should_behave_like 'common fields set correctly'
 
     it 'reports the correct values' do
-      expect(@warning.parameters[UncommunicativeVariableName::VARIABLE_NAME_KEY]).to eq('x2')
+      expect(@warning.parameters[:name]).to eq('x2')
       expect(@warning.lines).to eq([3, 5])
     end
   end

--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -20,14 +20,14 @@ describe UnusedParameters do
     it 'reports for 1 used and 2 unused parameter' do
       src = 'def simple(num,sum,denum); sum end'
       expect(src).to smell_of(UnusedParameters,
-                              { UnusedParameters::PARAMETER_KEY => 'num' },
-                              UnusedParameters::PARAMETER_KEY => 'denum')
+                              { name: 'num' },
+                              { name: 'denum'})
     end
 
     it 'reports for 3 used and 1 unused parameter' do
       src = 'def simple(num,sum,denum,quotient); num + denum + sum end'
       expect(src).to smell_of(UnusedParameters,
-                              UnusedParameters::PARAMETER_KEY => 'quotient')
+                              name: 'quotient')
     end
 
     it 'reports nothing for used splatted parameter' do


### PR DESCRIPTION
This PR gets rid of all parameter constants in our smell detectors, fixes #332 but leaves the parameters itself there since they are used in our spec matcher and our yaml output.

This PR also makes the "parameters" names consistent. For instance, take a look at "UncommunicativeMethodName"  which contained:

> >  METHOD_NAME_KEY = 'method_name'

"method_name" is in fact a knowledge duplication - "name" is speaking enough since it is absolutely clear given the context. Most of the parameter names duplicated knowledge regarding the SmellDetector somehow.

So I replaced most of them with consistent naming:
- 90% of all parameter are now just "name" and / or "count"
- there are a couple of exceptions where it made sense to deviate from this schema, mostly "DataClump", "FeatureEnvy" and "NestedIterators".
