### PR TITLE
RuboCop setup and cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,8 +3,36 @@ AllCops:
     - 'spec/samples/**/*'
     - 'tmp/**/*'
 
+# FIXME: Lower the ABC size by fixing the biggest offenders
+Metrics/AbcSize:
+  Max: 25
+
+# FIXME: Make the class shorter
+Metrics/ClassLength:
+  Exclude:
+    - lib/reek/core/code_parser.rb
+
+# FIXME: Document these classes
+Style/Documentation:
+  Exclude:
+    - features/support/env.rb
+    - lib/reek/cli/report/formatter.rb
+    - lib/reek/smells/smell_detector.rb
+    - lib/reek/source/sexp_extensions.rb
+    - lib/reek/spec/should_reek_of.rb
+    - lib/reek/spec/should_reek_only_of.rb
+    - lib/reek/spec/should_reek.rb
+    - lib/reek/version.rb
+    - spec/matchers/smell_of_matcher.rb
+
+# FIXME: Lower the method length by fixing the biggest offenders
+Metrics/MethodLength:
+  Max: 46
+
 # Be a little more lenient with line length
 Metrics/LineLength:
+  Exclude:
+    - lib/reek/cli/options.rb
   Max: 100
 
 # Allow small arrays of words with quotes
@@ -18,6 +46,10 @@ Style/SingleLineMethods:
 # Always use raise to signal exceptions
 Style/SignalException:
   EnforcedStyle: only_raise
+
+# Allow multiple Hash parameters to look similar
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
 
 # Place . on the previous line
 Style/DotPosition:

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,4 @@ require 'bundler/gem_tasks'
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 
-task default: [:test]
+task default: [:test, :rubocop]

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,3 +1,4 @@
+require 'English'
 require 'tempfile'
 require 'fileutils'
 require 'open3'
@@ -8,7 +9,7 @@ class ReekWorld
     stderr_file = Tempfile.new('reek-world')
     stderr_file.close
     @last_stdout = `#{cmd} 2> #{stderr_file.path}`
-    @last_exit_status = $?.exitstatus
+    @last_exit_status = $CHILD_STATUS.exitstatus
     @last_stderr = IO.read(stderr_file.path)
   end
 

--- a/lib/reek/cli/report/formatter.rb
+++ b/lib/reek/cli/report/formatter.rb
@@ -10,7 +10,8 @@ module Reek
 
         def self.header(examiner)
           count = examiner.smells_count
-          result = Rainbow("#{examiner.description} -- ").cyan + Rainbow("#{count} warning").yellow
+          result = Rainbow("#{examiner.description} -- ").cyan +
+                   Rainbow("#{count} warning").yellow
           result += Rainbow('s').yellow unless count == 1
           result
         end
@@ -22,7 +23,8 @@ module Reek
         module_function
 
         def format(warning)
-          "#{WarningFormatterWithLineNumbers.format(warning)} [#{explanatory_link(warning)}]"
+          "#{WarningFormatterWithLineNumbers.format(warning)} " \
+          "[#{explanatory_link(warning)}]"
         end
 
         def explanatory_link(warning)
@@ -48,7 +50,8 @@ module Reek
 
       module SingleLineWarningFormatter
         def self.format(warning)
-          "#{warning.source}:#{warning.lines.first}: #{SimpleWarningFormatter.format(warning)}"
+          "#{warning.source}:#{warning.lines.first}: " \
+          "#{SimpleWarningFormatter.format(warning)}"
         end
       end
     end

--- a/lib/reek/cli/report/report.rb
+++ b/lib/reek/cli/report/report.rb
@@ -58,12 +58,13 @@ module Reek
         end
 
         def sort_examiners
-          @examiners.sort! { |first, second| second.smells_count <=> first.smells_count } if @sort_by_issue_count
+          @examiners.sort_by!(&:smells_count).reverse! if @sort_by_issue_count
         end
 
         def total_smell_count_message
           colour = smells? ? WARNINGS_COLOR : NO_WARNINGS_COLOR
-          Rainbow("#{@total_smell_count} total warning#{'s' unless @total_smell_count == 1 }\n").color(colour)
+          s = @total_smell_count == 1 ? '' : 's'
+          Rainbow("#{@total_smell_count} total warning#{s}\n").color(colour)
         end
       end
 
@@ -92,11 +93,11 @@ module Reek
 
         require 'erb'
 
-        TEMPLATE = File.read(File.expand_path('../../../../../assets/html_output.html.erb', __FILE__))
-
         def show
+          path = File.expand_path('../../../../../assets/html_output.html.erb',
+                                  __FILE__)
           File.open('reek.html', 'w+') do |file|
-            file.puts ERB.new(TEMPLATE).result(binding)
+            file.puts ERB.new(File.read(path)).result(binding)
           end
           print("Html file saved\n")
         end

--- a/lib/reek/cli/report/strategy.rb
+++ b/lib/reek/cli/report/strategy.rb
@@ -18,7 +18,8 @@ module Reek
           def summarize_single_examiner(examiner)
             result = report_formatter.header examiner
             if examiner.smelly?
-              formatted_list = report_formatter.format_list examiner.smells, warning_formatter
+              formatted_list = report_formatter.format_list(examiner.smells,
+                                                            warning_formatter)
               result += ":\n#{formatted_list}"
             end
             result
@@ -54,7 +55,7 @@ module Reek
         class Normal < Base
           def gather_results
             examiners.each_with_object([]) { |examiner, smells| smells << examiner.smells }.
-                             flatten
+              flatten
           end
         end
       end

--- a/lib/reek/core/sniffer.rb
+++ b/lib/reek/core/sniffer.rb
@@ -15,7 +15,9 @@ module Reek
         @source = src
 
         config_files = extra_config_files + @source.relevant_config_files
-        config_files.each { |cf| Reek::Source::ConfigFile.new(cf).configure(@smell_repository) }
+        config_files.each do |cf|
+          Reek::Source::ConfigFile.new(cf).configure(@smell_repository)
+        end
       end
 
       def report_on(listener)

--- a/lib/reek/rake/task.rb
+++ b/lib/reek/rake/task.rb
@@ -103,11 +103,11 @@ module Reek
 
       def cmd_words
         [Task.ruby_exe] +
-            ruby_options +
-            [%(reek)] +
-            [sort_option] +
-            config_file_list.map { |fn| ['-c', %("#{fn}")] }.flatten +
-            source_file_list.map { |fn| %("#{fn}") }
+          ruby_options +
+          [%(reek)] +
+          [sort_option] +
+          config_file_list.map { |fn| ['-c', %("#{fn}")] }.flatten +
+          source_file_list.map { |fn| %("#{fn}") }
       end
 
       def config_file_list

--- a/lib/reek/smell_warning.rb
+++ b/lib/reek/smell_warning.rb
@@ -18,7 +18,7 @@ module Reek
       self.parameters     = options.fetch(:parameters, {})
     end
 
-    def smell_classes()
+    def smell_classes
       [smell_detector.smell_category, smell_detector.smell_type]
     end
 

--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -54,10 +54,12 @@ module Reek
         @max_copies = value(MAX_COPIES_KEY, ctx, DEFAULT_MAX_COPIES)
         @min_clump_size = value(MIN_CLUMP_SIZE_KEY, ctx, DEFAULT_MIN_CLUMP_SIZE)
         MethodGroup.new(ctx, @min_clump_size, @max_copies).clumps.map do |clump, methods|
+          print_clump = DataClump.print_clump(clump)
           SmellWarning.new self,
                            context: ctx.full_name,
                            lines: methods.map(&:line),
-                           message: "takes parameters #{DataClump.print_clump(clump)} to #{methods.length} methods",
+                           message: "takes parameters #{print_clump} " \
+                                    "to #{methods.length} methods",
                            parameters: {
                              parameters: clump.map(&:to_s),
                              count: methods.length,

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -48,7 +48,8 @@ module Reek
         max_allowed_calls = value(MAX_ALLOWED_CALLS_KEY, ctx, DEFAULT_MAX_CALLS)
         allow_calls = value(ALLOW_CALLS_KEY, ctx, DEFAULT_ALLOW_CALLS)
 
-        CallCollector.new(ctx, max_allowed_calls, allow_calls).smelly_calls.map do |found_call|
+        collector = CallCollector.new(ctx, max_allowed_calls, allow_calls)
+        collector.smelly_calls.map do |found_call|
           SmellWarning.new self,
                            context: ctx.full_name,
                            lines: found_call.lines,

--- a/lib/reek/smells/long_yield_list.rb
+++ b/lib/reek/smells/long_yield_list.rb
@@ -27,7 +27,9 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(method_ctx)
-        @max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, method_ctx, DEFAULT_MAX_ALLOWED_PARAMS)
+        @max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY,
+                                    method_ctx,
+                                    DEFAULT_MAX_ALLOWED_PARAMS)
         method_ctx.local_nodes(:yield).select do |yield_node|
           yield_node.args.length > @max_allowed_params
         end.map do |yield_node|

--- a/lib/reek/smells/module_initialize.rb
+++ b/lib/reek/smells/module_initialize.rb
@@ -22,7 +22,9 @@ module Reek
         module_ctx.local_nodes(:def) do |node| # FIXME: also search for :defs?
           if node.name.to_s == 'initialize'
             return [
-              SmellWarning.new(self, context: module_ctx.full_name, lines: [module_ctx.exp.line], message: 'has initialize method')
+              SmellWarning.new(self, context: module_ctx.full_name,
+                                     lines:   [module_ctx.exp.line],
+                                     message: 'has initialize method')
             ]
           end
         end

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -64,7 +64,7 @@ module Reek
       def find_iters_for_iter_node(exp, depth)
         ignored = ignored_iterator? exp
         result = find_iters(exp.call, depth) +
-          find_iters(exp.block, depth + (ignored ? 0 : 1))
+                 find_iters(exp.block, depth + (ignored ? 0 : 1))
         result << [exp, depth] unless ignored
         result
       end

--- a/lib/reek/smells/nil_check.rb
+++ b/lib/reek/smells/nil_check.rb
@@ -52,10 +52,10 @@ module Reek
         end
 
         def nil_comparison?(call)
-          is_comparison_call?(call) && involves_nil?(call)
+          comparison_call?(call) && involves_nil?(call)
         end
 
-        def is_comparison_call?(call)
+        def comparison_call?(call)
           comparison_methods.include? call.method_name
         end
 

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -6,8 +6,10 @@ module Reek
     #
     # Simulated Polymorphism occurs when
     # * code uses a case statement (especially on a type field);
-    # * or code has several if statements in a row (especially if they're comparing against the same value);
-    # * or code uses instance_of?, kind_of?, is_a?, or === to decide what type it's working with;
+    # * or code has several if statements in a row
+    #   (especially if they're comparing against the same value);
+    # * or code uses instance_of?, kind_of?, is_a?, or ===
+    #   to decide what type it's working with;
     # * or multiple conditionals in different places test the same value.
     #
     # Conditional code is hard to read and understand, because the reader must

--- a/lib/reek/smells/too_many_statements.rb
+++ b/lib/reek/smells/too_many_statements.rb
@@ -31,7 +31,9 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        @max_allowed_statements = value(MAX_ALLOWED_STATEMENTS_KEY, ctx, DEFAULT_MAX_STATEMENTS)
+        @max_allowed_statements = value(MAX_ALLOWED_STATEMENTS_KEY,
+                                        ctx,
+                                        DEFAULT_MAX_STATEMENTS)
         count = ctx.num_statements
         return [] if count <= @max_allowed_statements
         [SmellWarning.new(self,

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -62,7 +62,9 @@ module Reek
       def examine_context(method_ctx)
         return [] if method_ctx.num_statements == 0
         return [] if depends_on_instance?(method_ctx.exp)
-        return [] if num_helper_methods(method_ctx) <= value(HELPER_CALLS_LIMIT_KEY, method_ctx, DEFAULT_HELPER_CALLS_LIMIT)
+        return [] if num_helper_methods(method_ctx) <= value(HELPER_CALLS_LIMIT_KEY,
+                                                             method_ctx,
+                                                             DEFAULT_HELPER_CALLS_LIMIT)
 
         [SmellWarning.new(self,
                           context: method_ctx.full_name,

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.executables = ['reek']
   s.extra_rdoc_files = ['CHANGELOG', 'License.txt']
   s.files = Dir['.yardopts', 'CHANGELOG', 'License.txt', 'README.md',
-                'Rakefile', 'assets/html_output.html.erb', 'bin/reek', 'config/defaults.reek',
-                '{features,lib,spec,tasks}/**/*',
+                'Rakefile', 'assets/html_output.html.erb', 'bin/reek',
+                'config/defaults.reek', '{features,lib,spec,tasks}/**/*',
                 'reek.gemspec'] & `git ls-files -z`.split("\0")
   s.homepage = 'http://wiki.github.com/troessner/reek'
   s.rdoc_options = ['--main', 'README.md',
@@ -40,4 +40,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', ['~> 3.0'])
   s.add_development_dependency('yard', ['>= 0.8.7', '< 0.9'])
   s.add_development_dependency('factory_girl', ['~> 4.0'])
+  s.add_development_dependency('rubocop', ['~> 0.28.0'])
 end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -4,22 +4,22 @@ FactoryGirl.define do
     transient do
       smell_type 'FeatureEnvy'
     end
-    source           'dummy_file'
+    source 'dummy_file'
 
     initialize_with do
       # The odd looking const_get is necessary for ruby 1.9.3 compatibility.
-      Kernel.const_get("Reek")
-            .const_get("Smells")
-            .const_get(smell_type).new(source)
+      Kernel.const_get('Reek').
+        const_get('Smells').
+        const_get(smell_type).new(source)
     end
   end
 
   factory :smell_warning, class: Reek::SmellWarning do
     skip_create
     smell_detector
-    context        'self'
-    lines          [42]
-    message         'smell warning message'
+    context 'self'
+    lines [42]
+    message 'smell warning message'
     parameters     {}
 
     initialize_with do

--- a/spec/matchers/smell_of_matcher.rb
+++ b/spec/matchers/smell_of_matcher.rb
@@ -58,7 +58,8 @@ module SmellOfMatcher
       return false if @expected_smells.empty?
       return false if expected_number_of_smells == actual_number_of_smells
 
-      @reason = "expected #{expected_number_of_smells} smell(s), found #{actual_number_of_smells}"
+      @reason = "expected #{expected_number_of_smells} smell(s), " \
+                "found #{actual_number_of_smells}"
       true
     end
 

--- a/spec/reek/cli/report_spec.rb
+++ b/spec/reek/cli/report_spec.rb
@@ -118,7 +118,8 @@ describe Report::TextReport, ' when empty' do
         end
 
         it 'has a header in color' do
-          expect(@result.first).to start_with "\e[36mstring -- \e[0m\e[33m2 warning\e[0m\e[33ms\e[0m"
+          expect(@result.first).
+            to start_with "\e[36mstring -- \e[0m\e[33m2 warning\e[0m\e[33ms\e[0m"
         end
 
         it 'has a footer in color' do

--- a/spec/reek/core/module_context_spec.rb
+++ b/spec/reek/core/module_context_spec.rb
@@ -6,7 +6,11 @@ include Reek::Core
 
 describe ModuleContext do
   it 'should report module name for smell in method' do
-    expect('module Fred; def simple(x) x + 1; end; end').to reek_of(:UncommunicativeParameterName, /x/, /simple/)
+    expect('
+      module Fred
+        def simple(x) x + 1; end
+      end
+    ').to reek_of(:UncommunicativeParameterName, /x/, /simple/)
   end
 
   it 'should not report module with empty class' do

--- a/spec/reek/core/smell_configuration_spec.rb
+++ b/spec/reek/core/smell_configuration_spec.rb
@@ -12,8 +12,8 @@ describe SmellConfiguration do
   context 'when overriding default configs' do
     before(:each) do
       @base_config = { 'enabled' => true, 'exclude' => [],
-                      'reject' => [/^.$/, /[0-9]$/, /[A-Z]/],
-                      'accept' => ['_'] }
+                       'reject' => [/^.$/, /[0-9]$/, /[A-Z]/],
+                       'accept' => ['_'] }
       @smell_config = SmellConfiguration.new(@base_config)
     end
 
@@ -21,27 +21,35 @@ describe SmellConfiguration do
     it { expect(@smell_config.merge!('enabled' => true)).to eq(@base_config) }
     it { expect(@smell_config.merge!('exclude' => [])).to eq(@base_config) }
     it { expect(@smell_config.merge!('accept' => ['_'])).to eq(@base_config) }
-    it { expect(@smell_config.merge!('reject' => [/^.$/, /[0-9]$/, /[A-Z]/])).to eq(@base_config) }
-    it { expect(@smell_config.merge!('enabled' => true, 'accept' => ['_'])).to eq(@base_config) }
+    it do
+      @smell_config = @smell_config.merge!('reject' => [/^.$/, /[0-9]$/, /[A-Z]/])
+      expect(@smell_config).to eq(@base_config)
+    end
+    it do
+      @smell_config = @smell_config.merge!('enabled' => true, 'accept' => ['_'])
+      expect(@smell_config).to eq(@base_config)
+    end
 
     it 'should override single values' do
-      expect(@smell_config.merge!('enabled' => false)).to eq('enabled' => false, 'exclude' => [],
-                                                          'reject' => [/^.$/, /[0-9]$/, /[A-Z]/],
-                                                          'accept' => ['_'])
+      @smell_config = @smell_config.merge!('enabled' => false)
+      expect(@smell_config).to eq('enabled' => false, 'exclude' => [],
+                                  'reject' => [/^.$/, /[0-9]$/, /[A-Z]/],
+                                  'accept' => ['_'])
     end
 
     it 'should override arrays of values' do
-      expect(@smell_config.merge!('reject' => [/^.$/, /[3-9]$/])).to eq('enabled' => true,
-                                                                        'exclude' => [],
-                                                                        'reject' => [/^.$/, /[3-9]$/],
-                                                                        'accept' => ['_'])
+      @smell_config = @smell_config.merge!('reject' => [/^.$/, /[3-9]$/])
+      expect(@smell_config).to eq('enabled' => true,
+                                  'exclude' => [],
+                                  'reject' => [/^.$/, /[3-9]$/],
+                                  'accept' => ['_'])
     end
 
     it 'should override multiple values' do
       expect(@smell_config.merge!('enabled' => false, 'accept' => [/[A-Z]$/])).to eq(
                            'enabled' => false, 'exclude' => [],
-                            'reject' => [/^.$/, /[0-9]$/, /[A-Z]/],
-                            'accept' => [/[A-Z]$/]
+                           'reject' => [/^.$/, /[0-9]$/, /[A-Z]/],
+                           'accept' => [/[A-Z]$/]
       )
     end
   end

--- a/spec/reek/core/warning_collector_spec.rb
+++ b/spec/reek/core/warning_collector_spec.rb
@@ -17,7 +17,10 @@ describe WarningCollector do
 
   context 'with one warning' do
     before :each do
-      @warning = Reek::SmellWarning.new Reek::Smells::FeatureEnvy.new(''), context: 'fred', lines: [1, 2, 3], message: 'hello'
+      @warning = Reek::SmellWarning.new(Reek::Smells::FeatureEnvy.new(''),
+                                        context: 'fred',
+                                        lines:   [1, 2, 3],
+                                        message: 'hello')
       @collector.found_smell(@warning)
     end
     it 'reports that warning' do

--- a/spec/reek/smell_warning_spec.rb
+++ b/spec/reek/smell_warning_spec.rb
@@ -4,9 +4,9 @@ require 'reek/smell_warning'
 include Reek
 
 describe SmellWarning do
-  let(:duplication_detector)      { build(:smell_detector, smell_type: 'DuplicateMethodCall')}
-  let(:feature_envy_detector)     { build(:smell_detector, smell_type: 'FeatureEnvy')}
-  let(:utility_function_detector) { build(:smell_detector, smell_type: 'UtilityFunction')}
+  let(:duplication_detector)  { build(:smell_detector, smell_type: 'DuplicateMethodCall') }
+  let(:feature_envy_detector) { build(:smell_detector, smell_type: 'FeatureEnvy') }
+  let(:utility_function_detector) { build(:smell_detector, smell_type: 'UtilityFunction') }
 
   context 'sort order' do
     shared_examples_for 'first sorts ahead of second' do
@@ -36,8 +36,10 @@ describe SmellWarning do
 
     context 'smells differing only by context' do
       before :each do
-        @first  = build(:smell_warning, smell_detector: duplication_detector, context: 'first')
-        @second = build(:smell_warning, smell_detector: duplication_detector, context: 'second')
+        @first  = build(:smell_warning, smell_detector: duplication_detector,
+                                        context: 'first')
+        @second = build(:smell_warning, smell_detector: duplication_detector,
+                                        context: 'second')
       end
 
       it_should_behave_like 'first sorts ahead of second'
@@ -45,8 +47,12 @@ describe SmellWarning do
 
     context 'smells differing only by message' do
       before :each do
-        @first  = build(:smell_warning, smell_detector: duplication_detector, context: 'ctx', message: 'first message')
-        @second = build(:smell_warning, smell_detector: duplication_detector, context: 'ctx', message: 'second message')
+        @first  = build(:smell_warning, smell_detector: duplication_detector,
+                                        context: 'ctx',
+                                        message: 'first message')
+        @second = build(:smell_warning, smell_detector: duplication_detector,
+                                        context: 'ctx',
+                                        message: 'second message')
       end
 
       it_should_behave_like 'first sorts ahead of second'
@@ -54,8 +60,10 @@ describe SmellWarning do
 
     context 'message takes precedence over smell name' do
       before :each do
-        @first  = build(:smell_warning, smell_detector: utility_function_detector, message: 'first message')
-        @second = build(:smell_warning, smell_detector: feature_envy_detector,     message: 'second message')
+        @first  = build(:smell_warning, smell_detector: utility_function_detector,
+                                        message: 'first message')
+        @second = build(:smell_warning, smell_detector: feature_envy_detector,
+                                        message: 'second message')
       end
 
       it_should_behave_like 'first sorts ahead of second'
@@ -63,8 +71,12 @@ describe SmellWarning do
 
     context 'smells differing everywhere' do
       before :each do
-        uncommunicative_name_detector = build(:smell_detector, smell_type: 'UncommunicativeVariableName', source: true)
-        duplication_detector =          build(:smell_detector, smell_type: 'DuplicateMethodCall',         source: false)
+        uncommunicative_name_detector = build(:smell_detector,
+                                              smell_type: 'UncommunicativeVariableName',
+                                              source: true)
+        duplication_detector = build(:smell_detector,
+                                     smell_type: 'DuplicateMethodCall',
+                                     source: false)
         @first  = build(:smell_warning, smell_detector: uncommunicative_name_detector,
                                         context: 'Dirty',
                                         message: "has the variable name '@s'")
@@ -109,8 +121,10 @@ describe SmellWarning do
         @smell_type = 'FeatureEnvy'
         @parameters = { 'one' => 34, 'two' => 'second' }
         @detector = Reek::Smells::FeatureEnvy.new @source
-        @warning = SmellWarning.new(@detector, context: @context_name, lines: @lines, message: @message,
-                                    parameters: @parameters)
+        @warning = SmellWarning.new(@detector, context: @context_name,
+                                               lines: @lines,
+                                               message: @message,
+                                               parameters: @parameters)
         @yaml = @warning.to_yaml
       end
 

--- a/spec/reek/smells/boolean_parameter_spec.rb
+++ b/spec/reek/smells/boolean_parameter_spec.rb
@@ -19,7 +19,7 @@ describe BooleanParameter do
         src = 'def cc(nowt, arga = true, argb = false, &blk) end'
         expect(src).to smell_of(BooleanParameter,
                                 { name: 'arga' },
-                                name: 'argb')
+                                { name: 'argb' })
       end
     end
 
@@ -36,7 +36,7 @@ describe BooleanParameter do
         src = 'def Module.cc(nowt, arga = true, argb = false, &blk) end'
         expect(src).to smell_of(BooleanParameter,
                                 { name: 'arga' },
-                                name: 'argb')
+                                { name: 'argb' })
       end
     end
   end

--- a/spec/reek/smells/class_variable_spec.rb
+++ b/spec/reek/smells/class_variable_spec.rb
@@ -67,7 +67,12 @@ describe ClassVariable do
 
       context "declared and used in a #{scope}" do
         before :each do
-          @src = "#{scope} Fred; #{@class_variable} = {}; def jim() #{@class_variable} = {}; end; end"
+          @src = "
+            #{scope} Fred
+              #{@class_variable} = {}
+              def jim() #{@class_variable} = {}; end
+            end
+          "
         end
 
         it_should_behave_like 'one variable found'
@@ -75,7 +80,12 @@ describe ClassVariable do
 
       context "used twice in a #{scope}" do
         before :each do
-          @src = "#{scope} Fred; def jeff() #{@class_variable} = {}; end; def jim() #{@class_variable} = {}; end; end"
+          @src = "
+            #{scope} Fred
+              def jeff() #{@class_variable} = {}; end
+              def jim()  #{@class_variable} = {}; end
+            end
+          "
         end
 
         it_should_behave_like 'one variable found'

--- a/spec/reek/smells/control_parameter_spec.rb
+++ b/spec/reek/smells/control_parameter_spec.rb
@@ -12,7 +12,6 @@ describe ControlParameter do
 
   it_should_behave_like 'SmellDetector'
 
-
   context 'parameter not used to determine code path' do
     it 'does not report a ternary check on an ivar' do
       src = 'def simple(arga) @ivar ? arga : 3 end'
@@ -34,7 +33,6 @@ describe ControlParameter do
       expect(src).not_to smell_of(ControlParameter)
     end
   end
-
 
   context 'parameter only used to determine code path' do
     it 'reports a ternary check on a parameter' do

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -8,7 +8,6 @@ include Reek
 include Reek::Smells
 
 describe DuplicateMethodCall do
-
   context 'when a smell is reported' do
     before :each do
       @source_name = 'copy-cat'
@@ -53,7 +52,7 @@ EOS
     it 'should report nested calls' do
       src = 'def double_thing() @other.thing.foo + @other.thing.foo end'
       expect(src).to smell_of(DuplicateMethodCall, { name: '@other.thing' },
-                              name: '@other.thing.foo')
+                              { name: '@other.thing.foo' })
     end
     it 'should ignore calls to new' do
       src = 'def double_thing() @other.new + @other.new end'
@@ -161,8 +160,13 @@ EOS
       expect(src).not_to smell_of(DuplicateMethodCall).with_config(@config)
     end
     it 'reports quadruple calls' do
-      src = 'def double_thing() @other.thing + @other.thing + @other.thing + @other.thing end'
-      expect(src).to smell_of(DuplicateMethodCall, name: '@other.thing', count: 4).with_config(@config)
+      src = '
+        def double_thing()
+          @other.thing + @other.thing + @other.thing + @other.thing
+        end
+      '
+      expect(src).to smell_of(DuplicateMethodCall, name: '@other.thing', count: 4).
+        with_config(@config)
     end
   end
 
@@ -176,11 +180,13 @@ EOS
     end
     it 'reports calls to other methods' do
       src = 'def double_other_thing() @other.thing + @other.thing end'
-      expect(src).to smell_of(DuplicateMethodCall, name: '@other.thing').with_config(@config)
+      expect(src).to smell_of(DuplicateMethodCall, name: '@other.thing').
+        with_config(@config)
     end
     it 'does not report calls to methods specifed with a regular expression' do
       src = 'def double_puts() puts @other.thing; puts @other.thing end'
-      expect(src).to smell_of(DuplicateMethodCall, name: '@other.thing').with_config(@config)
+      expect(src).to smell_of(DuplicateMethodCall, name: '@other.thing').
+        with_config(@config)
     end
   end
 end

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -69,7 +69,11 @@ EOS
 
   context 'with 2 calls to a parameter' do
     it 'reports the smell' do
-      expect('def envy(arga) arga.b(arga) + arga.c(@fred) end').to reek_only_of(:FeatureEnvy, /arga/)
+      expect('
+        def envy(arga)
+          arga.b(arga) + arga.c(@fred)
+        end
+      ').to reek_only_of(:FeatureEnvy, /arga/)
     end
   end
 
@@ -100,15 +104,30 @@ EOS
   end
 
   it 'should not be fooled by duplication' do
-    expect('def feed(thing) @cow.feed_to(thing.pig); @duck.feed_to(thing.pig) end').to reek_only_of(:Duplication, /thing.pig/)
+    expect('
+      def feed(thing)
+        @cow.feed_to(thing.pig)
+        @duck.feed_to(thing.pig)
+      end
+    ').to reek_only_of(:Duplication, /thing.pig/)
   end
 
   it 'should count local calls' do
-    expect('def feed(thing) cow.feed_to(thing.pig); duck.feed_to(thing.pig) end').to reek_only_of(:Duplication, /thing.pig/)
+    expect('
+      def feed(thing)
+        cow.feed_to(thing.pig)
+        duck.feed_to(thing.pig)
+      end
+    ').to reek_only_of(:Duplication, /thing.pig/)
   end
 
   it 'should report many calls to lvar' do
-    expect('def envy() lv = @item; lv.price + lv.tax; end').to reek_only_of(:FeatureEnvy, /lv/)
+    expect('
+      def envy()
+        lv = @item
+        lv.price + lv.tax
+      end
+    ').to reek_only_of(:FeatureEnvy, /lv/)
     #
     # def moved_version
     #   price + tax

--- a/spec/reek/smells/long_parameter_list_spec.rb
+++ b/spec/reek/smells/long_parameter_list_spec.rb
@@ -6,7 +6,6 @@ include Reek
 include Reek::Smells
 
 describe LongParameterList do
-
   context 'for methods with few parameters' do
     it 'should report nothing for no parameters' do
       expect('def simple; f(3);true; end').not_to smell_of(LongParameterList)
@@ -18,10 +17,15 @@ describe LongParameterList do
       expect('def simple(yep,zero) f(3);true end').not_to smell_of(LongParameterList)
     end
     it 'should not count an optional block' do
-      expect('def simple(alpha, yep, zero, &opt) f(3);true end').not_to smell_of(LongParameterList)
+      src = 'def simple(alpha, yep, zero, &opt) f(3); true end'
+      expect(src).not_to smell_of(LongParameterList)
     end
     it 'should not report inner block with too many parameters' do
-      src = 'def simple(yep,zero); m[3]; rand(34); f.each { |arga, argb, argc, argd| true}; end'
+      src = '
+        def simple(yep,zero)
+          m[3]; rand(34); f.each { |arga, argb, argc, argd| true}
+        end
+      '
       expect(src).not_to smell_of(LongParameterList)
     end
 
@@ -30,10 +34,12 @@ describe LongParameterList do
         expect('def simple(zero=nil) f(3);false end').not_to smell_of(LongParameterList)
       end
       it 'should report nothing for 2 parameters with 1 default' do
-        expect('def simple(yep, zero=nil) f(3);false end').not_to smell_of(LongParameterList)
+        source = 'def simple(yep, zero=nil) f(3); false end'
+        expect(source).not_to smell_of(LongParameterList)
       end
       it 'should report nothing for 2 defaulted parameters' do
-        expect('def simple(yep=4, zero=nil) f(3);false end').not_to smell_of(LongParameterList)
+        source = 'def simple(yep=4, zero=nil) f(3); false end'
+        expect(source).not_to smell_of(LongParameterList)
       end
     end
   end

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -5,7 +5,6 @@ require 'reek/smells/smell_detector_shared'
 include Reek::Smells
 
 describe NestedIterators do
-
   context 'with no iterators' do
     it 'reports no smells' do
       src = 'def fred() nothing = true; end'
@@ -150,17 +149,29 @@ EOS
     end
 
     it 'should report nested iterators inside the ignored iterator' do
-      src = 'def bad(fred) @fred.ignore_me {|item| item.each {|ting| ting.each {|other| other.other} } } end'
+      src = '
+        def bad(fred)
+          @fred.ignore_me {|item| item.each {|ting| ting.each {|other| other.other} } }
+        end
+      '
       expect(src).to smell_of(NestedIterators, count: 2).with_config(@config)
     end
 
     it 'should report nested iterators outside the ignored iterator' do
-      src = 'def bad(fred) @fred.each {|item| item.each {|ting| ting.ignore_me {|other| other.other} } } end'
+      src = '
+        def bad(fred)
+          @fred.each {|item| item.each {|ting| ting.ignore_me {|other| other.other} } }
+        end
+      '
       expect(src).to smell_of(NestedIterators, count: 2).with_config(@config)
     end
 
     it 'should report nested iterators with the ignored iterator between them' do
-      src = 'def bad(fred) @fred.each {|item| item.ignore_me {|ting| ting.ting {|other| other.other} } } end'
+      src = '
+        def bad(fred)
+          @fred.each {|item| item.ignore_me {|ting| ting.ting {|other| other.other} } }
+        end
+      '
       expect(src).to smell_of(NestedIterators, count: 2).with_config(@config)
     end
   end

--- a/spec/reek/smells/nil_check_spec.rb
+++ b/spec/reek/smells/nil_check_spec.rb
@@ -6,9 +6,7 @@ include Reek
 include Reek::Smells
 
 describe NilCheck do
-
   context 'for methods' do
-
     it 'reports the correct line number' do
       src = <<-EOS
       def nilcheck foo

--- a/spec/reek/smells/too_many_methods_spec.rb
+++ b/spec/reek/smells/too_many_methods_spec.rb
@@ -16,7 +16,6 @@ describe TooManyMethods do
   it_should_behave_like 'SmellDetector'
 
   context 'counting methods' do
-
     it 'should not report 25 methods' do
       src = <<EOS
 # smelly class for testing purposes
@@ -59,7 +58,13 @@ class Full
   def me11x()3 end;def me12x()3 end;def me13x()3 end;def me14x()3 end;def me15x()3 end
   def me21x()3 end;def me22x()3 end;def me23x()3 end;def me24x()3 end;def me25x()3 end
   def me31x()3 end;def me32x()3 end;def me33x()3 end;def me34x()3 end;def me35x()3 end
-  module Hidden; def me41x()3 end;def me42x()3 end;def me43x()3 end;def me44x()3 end;def me45x()3 end; end
+  module Hidden
+    def me41x()3 end
+    def me42x()3 end
+    def me43x()3 end
+    def me44x()3 end
+    def me45x()3 end
+  end
   def me51x()3 end
 end
 EOS

--- a/spec/reek/smells/too_many_statements_spec.rb
+++ b/spec/reek/smells/too_many_statements_spec.rb
@@ -31,7 +31,11 @@ describe TooManyStatements do
   end
 
   it 'should not report initialize' do
-    src = 'def initialize(arga) alf = f(1);@bet = 2;@cut = 3;@dit = 4; @emp = 5;@fry = 6;end'
+    src = '
+      def initialize(arga)
+        alf = f(1); @bet = 2; @cut = 3; @dit = 4; @emp = 5; @fry = 6
+      end
+    '
     expect(src).not_to smell_of(TooManyStatements)
   end
 
@@ -134,7 +138,15 @@ describe TooManyStatements, 'does not count control statements' do
   end
 
   it 'counts 3 statements in an else' do
-    method = process_method('def one() if val == 4; callee(); callee(); callee(); else; callee(); callee(); callee(); end; end')
+    method = process_method('
+      def one()
+        if val == 4
+          callee(); callee(); callee()
+        else
+          callee(); callee(); callee()
+        end
+      end
+    ')
     expect(method.num_statements).to eq(6)
   end
 
@@ -159,8 +171,8 @@ describe TooManyStatements, 'does not count control statements' do
   end
 
   it 'counts 3 statements in a while loop' do
-    method = process_method('def one() while val < 4; callee(); callee(); callee(); end; end')
-    expect(method.num_statements).to eq(3)
+    source = 'def one() while val < 4; callee(); callee(); callee(); end; end'
+    expect(process_method(source).num_statements).to eq(3)
   end
 
   it 'counts extra statements in a while condition' do
@@ -174,8 +186,8 @@ describe TooManyStatements, 'does not count control statements' do
   end
 
   it 'counts 3 statements in a until loop' do
-    method = process_method('def one() until val < 4; callee(); callee(); callee(); end; end')
-    expect(method.num_statements).to eq(3)
+    source = 'def one() until val < 4; callee(); callee(); callee(); end; end'
+    expect(process_method(source).num_statements).to eq(3)
   end
 
   it 'counts 1 statement in a for loop' do
@@ -184,8 +196,8 @@ describe TooManyStatements, 'does not count control statements' do
   end
 
   it 'counts 3 statements in a for loop' do
-    method = process_method('def one() for i in 0..4; callee(); callee(); callee(); end; end')
-    expect(method.num_statements).to eq(3)
+    source = 'def one() for i in 0..4; callee(); callee(); callee(); end; end'
+    expect(process_method(source).num_statements).to eq(3)
   end
 
   it 'counts 1 statement in a rescue' do
@@ -194,7 +206,15 @@ describe TooManyStatements, 'does not count control statements' do
   end
 
   it 'counts 3 statements in a rescue' do
-    method = process_method('def one() begin; callee(); callee(); callee(); rescue; callee(); callee(); callee(); end; end')
+    method = process_method('
+      def one()
+        begin
+          callee(); callee(); callee()
+        rescue
+          callee(); callee(); callee()
+        end
+      end
+    ')
     expect(method.num_statements).to eq(6)
   end
 
@@ -204,17 +224,31 @@ describe TooManyStatements, 'does not count control statements' do
   end
 
   it 'counts 3 statements in a when' do
-    method = process_method('def one() case fred; when "hi"; callee(); callee(); when "lo"; callee(); end; end')
+    method = process_method('
+      def one()
+        case fred
+        when "hi" then callee(); callee()
+        when "lo" then callee()
+        end
+      end
+    ')
     expect(method.num_statements).to eq(3)
   end
 
   it 'counts 1 statement in a case else' do
-    method = process_method('def one() case fred; when "hi"; callee(); else; callee(); end; end')
-    expect(method.num_statements).to eq(2)
+    source = 'def one() case fred; when "hi"; callee(); else; callee(); end; end'
+    expect(process_method(source).num_statements).to eq(2)
   end
 
   it 'counts 3 statements in a case else' do
-    method = process_method('def one() case fred; when "hi"; callee(); callee(); callee(); else; callee(); callee(); callee(); end; end')
+    method = process_method('
+      def one()
+        case fred
+        when "hi" then callee(); callee(); callee()
+        else           callee(); callee(); callee()
+        end
+      end
+    ')
     expect(method.num_statements).to eq(6)
   end
 
@@ -234,8 +268,8 @@ describe TooManyStatements, 'does not count control statements' do
   end
 
   it 'counts 4 statements in an iterator' do
-    method = process_method('def one() fred.each do; callee(); callee(); callee(); end; end')
-    expect(method.num_statements).to eq(4)
+    source = 'def one() fred.each do; callee(); callee(); callee(); end; end'
+    expect(process_method(source).num_statements).to eq(4)
   end
 
   it 'counts 1 statement in a singleton method' do

--- a/spec/reek/smells/uncommunicative_method_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_method_name_spec.rb
@@ -17,7 +17,8 @@ describe UncommunicativeMethodName do
 
   ['help', '+', '-', '/', '*'].each do |method_name|
     it "accepts the method name '#{method_name}'" do
-      expect("def #{method_name}(fred) basics(17) end").not_to smell_of(UncommunicativeMethodName)
+      src = "def #{method_name}(fred) basics(17) end"
+      expect(src).not_to smell_of(UncommunicativeMethodName)
     end
   end
 

--- a/spec/reek/smells/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_variable_name_spec.rb
@@ -28,7 +28,8 @@ describe UncommunicativeVariableName do
 
   context 'local variable name' do
     it 'does not report one-word variable name' do
-      expect('def help(fred) simple = jim(45) end').not_to smell_of(UncommunicativeVariableName)
+      expect('def help(fred) simple = jim(45) end').
+        not_to smell_of(UncommunicativeVariableName)
     end
 
     it 'does not report single underscore as a variable name' do
@@ -152,7 +153,6 @@ EOS
                               { name: 'y' },
                               { name: 'z' })
     end
-
   end
 
   context 'when a smell is reported' do

--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -6,9 +6,7 @@ include Reek
 include Reek::Smells
 
 describe UnusedParameters do
-
   context 'for methods' do
-
     it 'reports nothing for no parameters' do
       expect('def simple; true end').not_to smell_of(UnusedParameters)
     end
@@ -21,7 +19,7 @@ describe UnusedParameters do
       src = 'def simple(num,sum,denum); sum end'
       expect(src).to smell_of(UnusedParameters,
                               { name: 'num' },
-                              { name: 'denum'})
+                              { name: 'denum' })
     end
 
     it 'reports for 3 used and 1 unused parameter' do

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -59,7 +59,8 @@ describe UtilityFunction do
 
   context 'with two or more calls' do
     it 'reports two calls' do
-      expect('def simple(arga) arga.to_s + arga.to_i end').to reek_of(:UtilityFunction, /simple/)
+      src = 'def simple(arga) arga.to_s + arga.to_i end'
+      expect(src).to reek_of(:UtilityFunction, /simple/)
     end
     it 'counts a local call in a param initializer' do
       expect('def simple(arga=local) arga.to_s end').not_to reek_of(:UtilityFunction)

--- a/spec/reek/source/code_comment_spec.rb
+++ b/spec/reek/source/code_comment_spec.rb
@@ -45,7 +45,10 @@ describe CodeComment do
       expect(config['NestedIterators']['enabled']).to be_truthy
     end
     it 'parses multiple hashed options' do
-      config = CodeComment.new("# :reek:Duplication: { enabled: false }\n:reek:nested_iterators: { enabled: true }").config
+      config = CodeComment.new('
+        # :reek:Duplication: { enabled: false }
+        :reek:nested_iterators: { enabled: true }
+      ').config
       expect(config).to include('Duplication', 'NestedIterators')
       expect(config['Duplication']).to include('enabled')
       expect(config['Duplication']['enabled']).to be_falsey
@@ -53,7 +56,9 @@ describe CodeComment do
       expect(config['NestedIterators']['enabled']).to be_truthy
     end
     it 'parses multiple hashed options on the same line' do
-      config = CodeComment.new('# :reek:Duplication: { enabled: false } and :reek:nested_iterators: { enabled: true }').config
+      config = CodeComment.new('
+        #:reek:Duplication: { enabled: false } and :reek:nested_iterators: { enabled: true }
+      ').config
       expect(config).to include('Duplication', 'NestedIterators')
       expect(config['Duplication']).to include('enabled')
       expect(config['Duplication']['enabled']).to be_falsey

--- a/spec/reek/source/reference_collector_spec.rb
+++ b/spec/reek/source/reference_collector_spec.rb
@@ -4,7 +4,6 @@ require 'reek/source/reference_collector'
 include Reek::Source
 
 describe ReferenceCollector do
-
   context 'counting refs to self' do
     def refs_to_self(src)
       ReferenceCollector.new(src.to_reek_source.syntax_tree).num_refs_to_self

--- a/spec/reek/source/sexp_extensions_spec.rb
+++ b/spec/reek/source/sexp_extensions_spec.rb
@@ -24,7 +24,6 @@ describe SexpExtensions::DefNode do
     it 'includes no marker in its full name with empty outer scope' do
       expect(@node.full_name('')).to eq 'hello'
     end
-
   end
 
   context 'with 1 parameter' do
@@ -48,7 +47,6 @@ describe SexpExtensions::DefNode do
     it 'includes no marker in its full name with empty outer scope' do
       expect(@node.full_name('')).to eq 'hello'
     end
-
   end
 
   context 'with a block parameter' do
@@ -74,7 +72,6 @@ describe SexpExtensions::DefNode do
     it 'includes no marker in its full name with empty outer scope' do
       expect(@node.full_name('')).to eq 'hello'
     end
-
   end
 
   context 'with 1 defaulted parameter' do
@@ -99,7 +96,6 @@ describe SexpExtensions::DefNode do
     it 'includes no marker in its full name with empty outer scope' do
       expect(@node.full_name('')).to eq 'hello'
     end
-
   end
 
   context 'with a body with 2 statements' do
@@ -160,7 +156,6 @@ describe SexpExtensions::DefsNode do
     it 'includes no marker in its full name with empty outer scope' do
       expect(@node.full_name('')).to eq 'obj.hello'
     end
-
   end
 
   context 'with 1 parameter' do
@@ -184,7 +179,6 @@ describe SexpExtensions::DefsNode do
     it 'includes no marker in its full name with empty outer scope' do
       expect(@node.full_name('')).to eq 'obj.hello'
     end
-
   end
 
   context 'with a block' do
@@ -210,7 +204,6 @@ describe SexpExtensions::DefsNode do
     it 'includes no marker in its full name with empty outer scope' do
       expect(@node.full_name('')).to eq 'obj.hello'
     end
-
   end
 
   context 'with 1 defaulted parameter' do
@@ -235,7 +228,6 @@ describe SexpExtensions::DefsNode do
     it 'includes no marker in its full name with empty outer scope' do
       expect(@node.full_name('')).to eq 'obj.hello'
     end
-
   end
 
   context 'with a body with 2 statements' do
@@ -254,9 +246,7 @@ describe SexpExtensions::DefsNode do
       b = @node.body
       expect(b.class.included_modules.first).to eq SexpNode
     end
-
   end
-
 end
 
 describe SexpExtensions::SendNode do
@@ -268,7 +258,6 @@ describe SexpExtensions::SendNode do
     it 'has no argument names' do
       expect(@node.arg_names).to eq []
     end
-
   end
 
   context 'with 1 literal parameter' do
@@ -279,7 +268,6 @@ describe SexpExtensions::SendNode do
     it 'has 1 argument name' do
       expect(@node.arg_names).to eq [:param]
     end
-
   end
 
   context 'with 2 literal parameters' do
@@ -290,9 +278,7 @@ describe SexpExtensions::SendNode do
     it 'has 2 argument names' do
       expect(@node.arg_names).to eq [:x, :y]
     end
-
   end
-
 end
 
 describe SexpExtensions::BlockNode do
@@ -304,7 +290,6 @@ describe SexpExtensions::BlockNode do
     it 'has no parameter names' do
       expect(@node.parameter_names).to eq []
     end
-
   end
 
   context 'with 1 parameter' do

--- a/spec/reek/spec/should_reek_only_of_spec.rb
+++ b/spec/reek/spec/should_reek_only_of_spec.rb
@@ -41,7 +41,7 @@ describe ShouldReekOnlyOf do
   end
 
   context 'with 1 non-matching smell' do
-    let(:control_couple_detector) { build(:smell_detector, smell_type: 'ControlParameter')}
+    let(:control_couple_detector) { build(:smell_detector, smell_type: 'ControlParameter') }
 
     def smells
       [build(:smell_warning, smell_detector: control_couple_detector)]
@@ -51,8 +51,8 @@ describe ShouldReekOnlyOf do
   end
 
   context 'with 2 non-matching smells' do
-    let(:control_couple_detector) { build(:smell_detector, smell_type: 'ControlParameter')}
-    let(:feature_envy_detector) { build(:smell_detector, smell_type: 'FeatureEnvy')}
+    let(:control_couple_detector) { build(:smell_detector, smell_type: 'ControlParameter') }
+    let(:feature_envy_detector) { build(:smell_detector, smell_type: 'FeatureEnvy') }
 
     def smells
       [
@@ -65,13 +65,14 @@ describe ShouldReekOnlyOf do
   end
 
   context 'with 1 non-matching and 1 matching smell' do
-    let(:control_couple_detector) { build(:smell_detector, smell_type: 'ControlParameter')}
+    let(:control_couple_detector) { build(:smell_detector, smell_type: 'ControlParameter') }
 
     def smells
       detector = build(:smell_detector, smell_type: @expected_smell_type.to_s)
       [
         build(:smell_warning, smell_detector: control_couple_detector),
-        build(:smell_warning, smell_detector: detector, message: "message mentioning #{@expected_context_name}")
+        build(:smell_warning, smell_detector: detector,
+                              message: "message mentioning #{@expected_context_name}")
       ]
     end
 
@@ -82,7 +83,8 @@ describe ShouldReekOnlyOf do
     def smells
       detector = build(:smell_detector, smell_type: @expected_smell_type.to_s)
 
-      [build(:smell_warning, smell_detector: detector, message: "message mentioning #{@expected_context_name}")]
+      [build(:smell_warning, smell_detector: detector,
+                             message: "message mentioning #{@expected_context_name}")]
     end
     it 'matches' do
       expect(@match).to be_truthy

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require 'factory_girl'
 begin
   require 'pry'
   require 'byebug'
-rescue LoadError
+rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
 FactoryGirl.find_definitions

--- a/tasks/rubocop.rake
+++ b/tasks/rubocop.rake
@@ -1,0 +1,5 @@
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new do |task|
+  task.options << '--display-cop-names'
+end


### PR DESCRIPTION
This sets up RuboCop as part of the default `rake` task and cleans up the codebase.

Some offences (`Metrics/AbcSize`, `Metrics/ClassLength`, `Style/Documentation` and `Metrics/MethodLength`) are to be addressed in later commits, as they require non-trivial changes.

This should fix #348.
