### PR TITLE
Support Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
   - jruby-19mode
   - rbx-2
 matrix:

--- a/lib/reek/smells/smell_detector.rb
+++ b/lib/reek/smells/smell_detector.rb
@@ -14,7 +14,7 @@ module Reek
     # Shared responsibilities of all smell detectors.
     #
     class SmellDetector
-      attr_reader :source, :smell_category, :smell_type
+      attr_reader :source
 
       # The name of the config field that lists the names of code contexts
       # that should not be checked. Add this field to the config for each

--- a/lib/reek/source/ast_node.rb
+++ b/lib/reek/source/ast_node.rb
@@ -5,8 +5,6 @@ module Reek
     # Base class for AST nodes extended with utility methods. Contains some
     # methods to ease the transition from Sexp to AST::Node.
     class AstNode < Parser::AST::Node
-      attr_reader :comments
-
       def initialize(type, children = [], options = {})
         @comments = options.fetch(:comments, [])
         super

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -31,12 +31,12 @@ Gem::Specification.new do |s|
   s.summary = 'Code smell detector for Ruby'
 
   s.add_runtime_dependency('parser', ['~> 2.2.0.pre.7'])
-  s.add_runtime_dependency('unparser', ['= 0.1.16'])
+  s.add_runtime_dependency('unparser', ['~> 0.2.2'])
   s.add_runtime_dependency('rainbow', ['>= 1.99', '< 3.0'])
 
   s.add_development_dependency('bundler', ['~> 1.1'])
   s.add_development_dependency('rake', ['~> 10.0'])
-  s.add_development_dependency('cucumber', ['~> 1.3'])
+  s.add_development_dependency('cucumber', ['~> 1.3', '>= 1.3.18'])
   s.add_development_dependency('rspec', ['~> 3.0'])
   s.add_development_dependency('yard', ['>= 0.8.7', '< 0.9'])
   s.add_development_dependency('factory_girl', ['~> 4.0'])

--- a/spec/reek/cli/report_spec.rb
+++ b/spec/reek/cli/report_spec.rb
@@ -55,8 +55,8 @@ describe Report::TextReport, ' when empty' do
     context 'when output format is yaml' do
       it 'prints empty yaml' do
         yaml_report = report(Report::YamlReport.new(report_options))
-        output = capture_output_stream { yaml_report.show }
-        expect(output).to match(/^--- \[\]\n.*$/)
+        result = capture_output_stream { yaml_report.show }
+        expect(result).to match(/^--- \[\]\n.*$/)
       end
     end
 
@@ -104,8 +104,8 @@ describe Report::TextReport, ' when empty' do
         end
 
         it 'has a footer in color' do
-          output = capture_output_stream { @rpt.show }
-          expect(output).to end_with "\e[32m0 total warnings\n\e[0m"
+          result = capture_output_stream { @rpt.show }
+          expect(result).to end_with "\e[32m0 total warnings\n\e[0m"
         end
       end
 
@@ -123,8 +123,8 @@ describe Report::TextReport, ' when empty' do
         end
 
         it 'has a footer in color' do
-          output = capture_output_stream { @rpt.show }
-          expect(output).to end_with "\e[31m4 total warnings\n\e[0m"
+          result = capture_output_stream { @rpt.show }
+          expect(result).to end_with "\e[31m4 total warnings\n\e[0m"
         end
       end
     end

--- a/spec/reek/core/code_context_spec.rb
+++ b/spec/reek/core/code_context_spec.rb
@@ -33,9 +33,9 @@ describe CodeContext do
     end
 
     context 'when there is an outer' do
+      let(:outer) { double('outer') }
       before :each do
         @outer_name = 'another_random sting'
-        outer = double('outer')
         allow(outer).to receive(:full_name).at_least(:once).and_return(@outer_name)
         allow(outer).to receive(:config).and_return({})
         @ctx = CodeContext.new(outer, @exp)
@@ -158,19 +158,19 @@ EOS
   end
 
   describe '#config_for' do
-    let(:exp) { double('exp') }
+    let(:expression) { double('exp') }
     let(:outer) { nil }
-    let(:ctx) { CodeContext.new(outer, exp) }
+    let(:context) { CodeContext.new(outer, expression) }
     let(:sniffer) { double('sniffer') }
 
     before :each do
       allow(sniffer).to receive(:smell_type).and_return('DuplicateMethodCall')
-      allow(exp).to receive(:comments).and_return(
+      allow(expression).to receive(:comments).and_return(
         ':reek:DuplicateMethodCall: { allow_calls: [ puts ] }')
     end
 
-    it 'gets its configuration from the exp comments' do
-      expect(ctx.config_for(sniffer)).to eq('allow_calls' => ['puts'])
+    it 'gets its configuration from the expression comments' do
+      expect(context.config_for(sniffer)).to eq('allow_calls' => ['puts'])
     end
 
     context 'when there is an outer' do
@@ -182,8 +182,8 @@ EOS
       end
 
       it 'merges the outer config with its own configuration' do
-        expect(ctx.config_for(sniffer)).to eq('allow_calls' => ['puts'],
-                                              'max_calls' => 2)
+        expect(context.config_for(sniffer)).to eq('allow_calls' => ['puts'],
+                                                  'max_calls' => 2)
       end
     end
   end


### PR DESCRIPTION
- Add 2.2 to the Travis CI configuration
- Fix warnings
- Depend on unparser version that supports all relevant rubies

(#357).