### PR TITLE
Add integration test for configuration loading.

### DIFF
--- a/features/configuration_loading.feature
+++ b/features/configuration_loading.feature
@@ -1,0 +1,62 @@
+Feature: Offer different ways how to load configuration
+
+  There are 3 ways of passing reek a configuration file:
+  - Using the cli "-c" switch
+  - Having a file ending with .reek either in your current working directory or in a parent directory
+  - Having a file ending with .reek in your HOME directory
+  The order in which reek tries to find such a configuration file should exactly be like above:
+  First reek should check if we have given it a configuration file explicitly via CLI.
+  Then it should check the current working directory for a file and if it can't find one,
+  it should traverse up the directories until it hits the root directory.
+  And finally, it should check your HOME directory.
+
+  Scenario: No configuration
+    When I run reek spec/samples/configuration_loading/minimal_dirty.rb
+    Then the exit status indicates smells
+    And it reports:
+      """
+      spec/samples/configuration_loading/minimal_dirty.rb -- 3 warnings:
+        [1]:C has no descriptive comment (IrresponsibleModule)
+        [1]:C has the name 'C' (UncommunicativeModuleName)
+        [2]:C#m has the name 'm' (UncommunicativeMethodName)
+      """
+
+  Scenario: Configuration via CLI
+    When I run reek -c spec/samples/minimal_smelly_and_masked/config.reek spec/samples/minimal_smelly_and_masked/minimal_dirty.rb
+    Then it reports no errors
+    And it succeeds
+
+  @remove-disable-smell-config-from-current-dir
+  Scenario: Configuration file in working directory
+    Given "spec/samples/configuration_loading/reek-test-run-disable_smells.reek" exists in the working directory
+    When I run reek spec/samples/configuration_loading/minimal_dirty.rb
+    Then it reports no errors
+    And it succeeds
+
+  @remove-disable-smell-config-from-parent-dir
+  Scenario: Configuration file in the parent directory of the working directory
+    Given "spec/samples/configuration_loading/reek-test-run-disable_smells.reek" exists in the parent directory of the working directory
+    When I run reek spec/samples/configuration_loading/minimal_dirty.rb
+    Then it reports no errors
+    And it succeeds
+
+  @remove-disable-smell-config-from-home-dir
+  Scenario: Configuration file in the HOME directory
+    Given "spec/samples/configuration_loading/reek-test-run-disable_smells.reek" exists in the HOME directory
+    When I run reek spec/samples/configuration_loading/minimal_dirty.rb
+    Then it reports no errors
+    And it succeeds
+
+  @remove-enable-smell-config-from-current-dir @remove-disable-smell-config-from-parent-dir
+  Scenario: Two opposing configuration files and we stop after the first one
+    Given "spec/samples/configuration_loading/reek-test-run-enable_smells.reek" exists in the working directory
+    And "spec/samples/configuration_loading/reek-test-run-disable_smells.reek" exists in the parent directory of the working directory
+    When I run reek spec/samples/configuration_loading/minimal_dirty.rb
+    Then the exit status indicates smells
+    And it reports:
+      """
+      spec/samples/configuration_loading/minimal_dirty.rb -- 3 warnings:
+        [1]:C has no descriptive comment (IrresponsibleModule)
+        [1]:C has the name 'C' (UncommunicativeModuleName)
+        [2]:C#m has the name 'm' (UncommunicativeMethodName)
+      """

--- a/features/step_definitions/reek_steps.rb
+++ b/features/step_definitions/reek_steps.rb
@@ -67,3 +67,15 @@ end
 Then /^it reports the current version$/ do
   expect(@last_stdout).to eq "reek #{Reek::VERSION}\n"
 end
+
+Given(/^"(.*?)" exists in the working directory$/) do |path|
+  FileUtils.cp path, Pathname.pwd
+end
+
+Given(/^"(.*?)" exists in the parent directory of the working directory$/) do |path|
+  FileUtils.cp path, Pathname.pwd.parent
+end
+
+Given(/^"(.*?)" exists in the HOME directory$/) do |path|
+  FileUtils.cp path, Pathname.new(Dir.home)
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,15 @@
+After('@remove-disable-smell-config-from-current-dir') do
+  Pathname.pwd.join('reek-test-run-disable_smells.reek').delete
+end
+
+After('@remove-disable-smell-config-from-parent-dir') do
+  Pathname.pwd.parent.join('reek-test-run-disable_smells.reek').delete
+end
+
+After('@remove-disable-smell-config-from-home-dir') do
+  Pathname.new(Dir.home).join('reek-test-run-disable_smells.reek').delete
+end
+
+After('@remove-enable-smell-config-from-current-dir') do
+  Pathname.pwd.join('reek-test-run-enable_smells.reek').delete
+end

--- a/spec/samples/configuration_loading/minimal_dirty.rb
+++ b/spec/samples/configuration_loading/minimal_dirty.rb
@@ -1,0 +1,4 @@
+class C
+  def m
+  end
+end

--- a/spec/samples/configuration_loading/reek-test-run-disable_smells.reek
+++ b/spec/samples/configuration_loading/reek-test-run-disable_smells.reek
@@ -1,0 +1,7 @@
+---
+IrresponsibleModule:
+  enabled: false
+UncommunicativeModuleName:
+  enabled: false
+UncommunicativeMethodName:
+  enabled: false

--- a/spec/samples/configuration_loading/reek-test-run-enable_smells.reek
+++ b/spec/samples/configuration_loading/reek-test-run-enable_smells.reek
@@ -1,0 +1,7 @@
+---
+IrresponsibleModule:
+  enabled: true
+UncommunicativeModuleName:
+  enabled: true
+UncommunicativeMethodName:
+  enabled: true


### PR DESCRIPTION
After we had merged #356 I realized that while the new way of configuration loading was tested with unit tests, there certainly was an integration spec missing. This PR introduces a proper integration which I believe covers most if not all use cases.