### PR TITLE
Run on working directory when no source is given.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== Not yet released
+
+* (troessner) Run on working directory when no source is given.
+
 == 1.6.1
 
 * (mvz) Fix regression in rake task: Provide alias for backward compatibility

--- a/README.md
+++ b/README.md
@@ -54,6 +54,43 @@ spec/samples/demo/demo.rb -- 6 warnings:
   Dirty#awful has unused parameter 'y' (UnusedParameters)
 ```
 
+## Sources
+
+There are multiple ways you can have `reek` work on sources, the most common one just being
+
+```Bash
+reek lib/
+```
+
+If you don't pass any source arguments to `reek` it just takes the current working directory as source.
+
+So
+
+```Bash
+reek
+```
+
+is the exact same thing like being explicit:
+
+```Bash
+reek .
+```
+
+Additionally can you pipe code to reek like this:
+
+```Bash
+echo "class C; def m; end; end" | reek
+```
+
+This would print out:
+
+```Bash
+$stdin -- 3 warnings:
+  [1]:C has no descriptive comment (IrresponsibleModule)
+  [1]:C has the name 'C' (UncommunicativeModuleName)
+  [1]:C#m has the name 'm' (UncommunicativeMethodName)
+```
+
 ## Code smells
 
 `reek` currently includes checks for some aspects of [Control Couple](https://github.com/troessner/reek/wiki/Control-Couple), [Data Clump](https://github.com/troessner/reek/wiki/Data-Clump), [Feature Envy](https://github.com/troessner/reek/wiki/Feature-Envy), [Large Class](https://github.com/troessner/reek/wiki/Large-Class), [Long Parameter List](https://github.com/troessner/reek/wiki/Long-Parameter-List), [Simulated Polymorphism](https://github.com/troessner/reek/wiki/Simulated-Polymorphism), [Too Many Statements](https://github.com/troessner/reek/wiki/Too-Many-Statements), [Uncommunicative Name](https://github.com/troessner/reek/wiki/Uncommunicative-Name), [Unused Parameters](https://github.com/troessner/reek/wiki/Unused-Parameters) and more. See the [Code Smells](https://github.com/troessner/reek/wiki/Code-Smells) for up to date details of exactly what `reek` will check in your code.

--- a/lib/reek/cli/input.rb
+++ b/lib/reek/cli/input.rb
@@ -1,0 +1,46 @@
+require 'reek/source'
+
+module Reek
+  module CLI
+    #
+    # CLI Input utility
+    #
+    module Input
+      def sources
+        if input_was_piped?
+          source_from_pipe
+        else
+          if no_source_files_given?
+            working_directory_as_source
+          else
+            sources_from_argv
+          end
+        end
+      end
+
+      private
+
+      def input_was_piped?
+        !$stdin.tty?
+      end
+
+      def no_source_files_given?
+        # At this point we have deleted all options from @argv. The only remaining entries
+        # are paths to the source files. If @argv is empty, this means that no files were given.
+        @argv.empty?
+      end
+
+      def working_directory_as_source
+        Source::SourceLocator.new(['.']).all_sources
+      end
+
+      def sources_from_argv
+        Source::SourceLocator.new(@argv).all_sources
+      end
+
+      def source_from_pipe
+        [$stdin.to_reek_source('$stdin')]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implement #222 
The changes for this feature were pretty minimal, but then rubocop rightfully complained about "class too long" so I had to refactor the options class in this PR to get it green on travis.