### PR TITLE
Fix unparser issue with ruby 1.9.3. by pinning unparser to 0.1.16.

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.summary = 'Code smell detector for Ruby'
 
   s.add_runtime_dependency('parser', ['~> 2.2.0.pre.7'])
-  s.add_runtime_dependency('unparser', ['~> 0.1.16'])
+  s.add_runtime_dependency('unparser', ['= 0.1.16'])
   s.add_runtime_dependency('rainbow', ['>= 1.99', '< 3.0'])
 
   s.add_development_dependency('bundler', ['~> 1.1'])


### PR DESCRIPTION
The current unparser version 0.1.17 doesn't work with ruby 1.9.3 anymore:

Gem::InstallError: unparser requires Ruby version >= 2.0.0.
An error occurred while installing unparser (0.1.17), and Bundler cannot continue.
Make sure that `gem install unparser -v '0.1.17'` succeeds before bundling.