### PR TITLE
Make NestedIterator not break if iterator is called on super

### DIFF
--- a/lib/reek/source/sexp_extensions.rb
+++ b/lib/reek/source/sexp_extensions.rb
@@ -304,6 +304,12 @@ module Reek
           args.map { |arg| arg[1] }
         end
       end
+
+      module ZsuperNode
+        def method_name
+          :super
+        end
+      end
     end
   end
 end

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -187,13 +187,13 @@ describe NestedIterators do
 
   context 'when a smell is reported' do
     before :each do
-      src = <<EOS
-def fred()
-  nothing.each do |item|
-    again.each {|thing| item }
-  end
-end
-EOS
+      src = <<-EOS
+        def fred()
+          nothing.each do |item|
+            again.each {|thing| item }
+          end
+        end
+      EOS
       ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
       @warning = @detector.examine_context(ctx)[0]
     end
@@ -204,5 +204,22 @@ EOS
       expect(@warning.parameters[:count]).to eq(2)
       expect(@warning.lines).to eq([3])
     end
+  end
+
+  context 'super recieves a block' do
+    before :each do
+      src = <<-EOS
+        def super_call_with_block
+          super do |k|
+            nothing.each { |thing| item }
+          end
+        end
+      EOS
+
+      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      @warning = @detector.examine_context(ctx)[0]
+    end
+
+    it_should_behave_like 'common fields set correctly'
   end
 end


### PR DESCRIPTION
Reek fails when super receives a block:

 NoMethodError:
       undefined method `method_name' for (zsuper):#<Class:0x00000003e18f90>
     Shared Example Group: "common fields set correctly" called from ./spec/reek/smells/nested_iterators_spec.rb:222
     # ./lib/reek/smells/nested_iterators.rb:73:in `ignored_iterator?'
     # ./lib/reek/smells/nested_iterators.rb:65:in `find_iters_for_iter_node'
     # ./lib/reek/smells/nested_iterators.rb:60:in `block in find_iters'
     # ./lib/reek/smells/nested_iterators.rb:59:in `each'
     # ./lib/reek/smells/nested_iterators.rb:59:in `flat_map'
     # ./lib/reek/smells/nested_iterators.rb:59:in `find_iters'
     # ./lib/reek/smells/nested_iterators.rb:54:in `find_deepest_iterator'
     # ./lib/reek/smells/nested_iterators.rb:35:in `examine_context'
     # ./spec/reek/smells/nested_iterators_spec.rb:219:in `block (3 levels) in <top (required)>'
