### PR TITLE
Do not provide -c option if no config file is found

### DIFF
--- a/lib/reek/rake/task.rb
+++ b/lib/reek/rake/task.rb
@@ -115,8 +115,16 @@ module Reek
           ruby_options +
           [%(reek)] +
           [sort_option] +
-          ['-c', config_file] +
+          config_option +
           source_file_list.map { |fn| %("#{fn}") }
+      end
+
+      def config_option
+        if config_file
+          ['-c', config_file]
+        else
+          []
+        end
       end
 
       def config_file


### PR DESCRIPTION
Avoids problem if rake task cannot find any config files.