### PR TITLE
Force use of Psych for YAML serialization

### DIFF
--- a/lib/reek/smell_warning.rb
+++ b/lib/reek/smell_warning.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'psych'
 
 module Reek
   #

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('parser', ['~> 2.2.0.pre.7'])
   s.add_runtime_dependency('unparser', ['~> 0.2.2'])
   s.add_runtime_dependency('rainbow', ['>= 1.99', '< 3.0'])
+  s.add_runtime_dependency('psych', ['~> 2.0'])
 
   s.add_development_dependency('bundler', ['~> 1.1'])
   s.add_development_dependency('rake', ['~> 10.0'])

--- a/spec/reek/smell_warning_spec.rb
+++ b/spec/reek/smell_warning_spec.rb
@@ -93,7 +93,6 @@ describe SmellWarning do
     before :each do
       @message = 'test message'
       @lines = [24, 513]
-      @class = 'FeatureEnvy'
       @context_name = 'Module::Class#method/block'
       # Use a random string and a random bool
     end


### PR DESCRIPTION
This ensures the `#encode_with` method is used and YAML output is the same
on all platforms.