### PR TITLE
Fix for running reek on a build server

### DIFF
--- a/lib/reek/cli/input.rb
+++ b/lib/reek/cli/input.rb
@@ -7,14 +7,14 @@ module Reek
     #
     module Input
       def sources
-        if input_was_piped?
-          source_from_pipe
-        else
-          if no_source_files_given?
-            working_directory_as_source
+        if no_source_files_given?
+          if input_was_piped?
+            source_from_pipe
           else
-            sources_from_argv
+            working_directory_as_source
           end
+        else
+          sources_from_argv
         end
       end
 


### PR DESCRIPTION
We use reek on Jenkins like this: `reek .`

We upgraded to the latest version and noticed that reek was suddenly not reporting anything anymore. After a lot of debugging we figured out that reek ignores the `.` we pass because it assumes we are piping Ruby code in.

I gave files given as arguments higher priority so reek only reads from `$stdin` when it is given no files. 