### PR TITLE
Fix YAML export on JRuby

### DIFF
--- a/lib/reek/cli/report/report.rb
+++ b/lib/reek/cli/report/report.rb
@@ -78,7 +78,7 @@ module Reek
         end
 
         def show
-          print(smells.to_yaml)
+          print smells.map(&:yaml_hash).to_yaml
         end
       end
 

--- a/lib/reek/smell_warning.rb
+++ b/lib/reek/smell_warning.rb
@@ -1,5 +1,4 @@
 require 'forwardable'
-require 'psych'
 
 module Reek
   #
@@ -43,17 +42,19 @@ module Reek
       listener.found_smell(self)
     end
 
-    def encode_with(coder)
-      coder.tag = nil
-      coder['smell_category']  = smell_detector.smell_category
-      coder['smell_type']      = smell_detector.smell_type
-      coder['source']          = smell_detector.source
-      coder['context']         = context
-      coder['lines']           = lines
-      coder['message']         = message
+    def yaml_hash
+      result = {
+        'smell_category' => smell_detector.smell_category,
+        'smell_type'     => smell_detector.smell_type,
+        'source'         => smell_detector.source,
+        'context'        => context,
+        'lines'          => lines,
+        'message'        => message
+      }
       parameters.each do |key, value|
-        coder[key.to_s] = value
+        result[key.to_s] = value
       end
+      result
     end
 
     protected

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('parser', ['~> 2.2.0.pre.7'])
   s.add_runtime_dependency('unparser', ['~> 0.2.2'])
   s.add_runtime_dependency('rainbow', ['>= 1.99', '< 3.0'])
-  s.add_runtime_dependency('psych', ['~> 2.0'])
 
   s.add_development_dependency('bundler', ['~> 1.1'])
   s.add_development_dependency('rake', ['~> 10.0'])

--- a/spec/reek/smell_warning_spec.rb
+++ b/spec/reek/smell_warning_spec.rb
@@ -89,28 +89,27 @@ describe SmellWarning do
     end
   end
 
-  context 'YAML representation' do
+  context '#yaml_hash' do
     before :each do
       @message = 'test message'
       @lines = [24, 513]
+      @class = 'FeatureEnvy'
       @context_name = 'Module::Class#method/block'
       # Use a random string and a random bool
     end
 
     shared_examples_for 'common fields' do
       it 'includes the smell type' do
-        expect(@yaml).to match(/smell_type:\s*FeatureEnvy/)
+        expect(@yaml['smell_type']).to eq 'FeatureEnvy'
       end
       it 'includes the context' do
-        expect(@yaml).to match(/context:\s*#{@context_name}/)
+        expect(@yaml['context']).to eq @context_name
       end
       it 'includes the message' do
-        expect(@yaml).to match(/message:\s*#{@message}/)
+        expect(@yaml['message']).to eq @message
       end
       it 'includes the line numbers' do
-        @lines.each do |line|
-          expect(@yaml).to match(/lines:[\s\d-]*- #{line}/)
-        end
+        expect(@yaml['lines']).to match_array @lines
       end
     end
 
@@ -124,20 +123,20 @@ describe SmellWarning do
                                                lines: @lines,
                                                message: @message,
                                                parameters: @parameters)
-        @yaml = @warning.to_yaml
+        @yaml = @warning.yaml_hash
       end
 
       it_should_behave_like 'common fields'
 
       it 'includes the smell type' do
-        expect(@yaml).to match(/smell_type:\s*#{@smell_type}/)
+        expect(@yaml['smell_type']).to eq @smell_type
       end
       it 'includes the source' do
-        expect(@yaml).to match(/source:\s*#{@source}/)
+        expect(@yaml['source']).to eq @source
       end
       it 'includes the parameters' do
         @parameters.each do |key, value|
-          expect(@yaml).to match(/#{key}:\s*#{value}/)
+          expect(@yaml[key]).to eq value
         end
       end
     end


### PR DESCRIPTION
So, Psych doesn't actually install on JRuby, so my previous fix didn't work for that.

Solution: Decide we're not writing a two-way converter between yaml and SmellWarning, but that instead we're writing an exporter. The result: This PR lets each SmellWarning convert to a hash with `#yaml_hash` and then calls `#to_yaml` on the resulting array.