### PR TITLE
Support more Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ rvm:
   - 2.1
   - 2.2
   - jruby-19mode
-  - jruby-head
   - rbx-2
+  - ruby-head
+  - jruby-head
 matrix:
   allow_failures:
-    - rvm: jruby-19mode
     - rvm: jruby-head
-    - rvm: rbx-2
+    - rvm: ruby-head
 notifications:
   recipients:
     - timo.roessner@googlemail.com

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,5 @@ require 'bundler/gem_tasks'
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 
-task default: [:test, :rubocop]
+task default: :test
+task default: :rubocop unless RUBY_ENGINE == 'rbx'


### PR DESCRIPTION
- Do not run rubocop task on Rubinius by default
- Add CRuby head to Travis CI config
- No longer allow build failures on Rubinius and JRuby