### PR TITLE
Refactor smell specs.

### DIFF
--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -3,13 +3,10 @@ require 'reek/smells/attribute'
 require 'reek/core/module_context'
 require 'reek/smells/smell_detector_shared'
 
-include Reek::Core
-include Reek::Smells
-
-describe Attribute do
+describe Reek::Smells::Attribute do
   before :each do
-    @source_name = 'ticker'
-    @detector = Attribute.new(@source_name)
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector, smell_type: :Attribute, source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -17,7 +14,7 @@ describe Attribute do
   context 'with no attributes' do
     it 'records nothing in the module' do
       src = 'module Fred; end'
-      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
       expect(@detector.examine_context(ctx)).to be_empty
     end
   end
@@ -29,7 +26,7 @@ describe Attribute do
 
     shared_examples_for 'one attribute found' do
       before :each do
-        ctx = CodeContext.new(nil, @src.to_reek_source.syntax_tree)
+        ctx = Reek::Core::CodeContext.new(nil, @src.to_reek_source.syntax_tree)
         @smells = @detector.examine_context(ctx)
       end
 
@@ -46,7 +43,7 @@ describe Attribute do
       end
 
       it 'reports the correct smell class' do
-        expect(@smells[0].smell_category).to eq(Attribute.smell_category)
+        expect(@smells[0].smell_category).to eq(described_class.smell_category)
       end
 
       it 'reports the context fq name' do

--- a/spec/reek/smells/boolean_parameter_spec.rb
+++ b/spec/reek/smells/boolean_parameter_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 require 'reek/smells/boolean_parameter'
 require 'reek/smells/smell_detector_shared'
 
-include Reek::Smells
-
-describe BooleanParameter do
+describe Reek::Smells::BooleanParameter do
   context 'parameter defaulted with boolean' do
     context 'in a method' do
       it 'reports a parameter defaulted to true' do
@@ -14,51 +12,51 @@ describe BooleanParameter do
 
       it 'reports a parameter defaulted to false' do
         src = 'def cc(arga = false) end'
-        expect(src).to reek_of(BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
       end
 
       it 'reports two parameters defaulted to booleans' do
         src = 'def cc(nowt, arga = true, argb = false, &blk) end'
-        expect(src).to reek_of(BooleanParameter, name: 'arga')
-        expect(src).to reek_of(BooleanParameter, name: 'argb')
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, name: 'argb')
       end
     end
 
     context 'in a singleton method' do
       it 'reports a parameter defaulted to true' do
         src = 'def self.cc(arga = true) end'
-        expect(src).to reek_of(BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
       end
       it 'reports a parameter defaulted to false' do
         src = 'def fred.cc(arga = false) end'
-        expect(src).to reek_of(BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
       end
       it 'reports two parameters defaulted to booleans' do
         src = 'def Module.cc(nowt, arga = true, argb = false, &blk) end'
-        expect(src).to reek_of(BooleanParameter, name: 'arga')
-        expect(src).to reek_of(BooleanParameter, name: 'argb')
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, name: 'argb')
       end
     end
   end
 
   context 'when a smell is reported' do
     before(:each) do
-      @source_name = 'smokin'
-      @detector = BooleanParameter.new(@source_name)
+      @source_name = 'dummy_source'
+      @detector = build(:smell_detector, smell_type: :BooleanParameter, source: @source_name)
     end
 
     it_should_behave_like 'SmellDetector'
 
     it 'reports the fields correctly' do
       src = 'def cc(arga = true) end'
-      ctx = MethodContext.new(nil, src.to_reek_source.syntax_tree)
+      ctx = Reek::Core::MethodContext.new(nil, src.to_reek_source.syntax_tree)
       @detector.examine(ctx)
       smells = @detector.smells_found.to_a
       expect(smells.length).to eq(1)
-      expect(smells[0].smell_category).to eq(BooleanParameter.smell_category)
+      expect(smells[0].smell_category).to eq(described_class.smell_category)
       expect(smells[0].parameters[:name]).to eq('arga')
       expect(smells[0].source).to eq(@source_name)
-      expect(smells[0].smell_type).to eq(BooleanParameter.smell_type)
+      expect(smells[0].smell_type).to eq(described_class.smell_type)
       expect(smells[0].lines).to eq([1])
     end
   end

--- a/spec/reek/smells/control_parameter_spec.rb
+++ b/spec/reek/smells/control_parameter_spec.rb
@@ -2,12 +2,10 @@ require 'spec_helper'
 require 'reek/smells/control_parameter'
 require 'reek/smells/smell_detector_shared'
 
-include Reek::Smells
-
-describe ControlParameter do
+describe Reek::Smells::ControlParameter do
   before(:each) do
-    @source_name = 'lets get married'
-    @detector = ControlParameter.new(@source_name)
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector, smell_type: :ControlParameter, source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -15,94 +13,94 @@ describe ControlParameter do
   context 'parameter not used to determine code path' do
     it 'does not report a ternary check on an ivar' do
       src = 'def simple(arga) @ivar ? arga : 3 end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report a ternary check on a lvar' do
       src = 'def simple(arga) lvar = 27; lvar ? arga : @ivar end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report when parameter is unused' do
       src = 'def simple(arg) test = 1 end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report when parameter is used inside conditional' do
       src = 'def simple(arg) if true then puts arg end end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
   end
 
   context 'parameter only used to determine code path' do
     it 'reports a ternary check on a parameter' do
       src = 'def simple(arga) arga ? @ivar : 3 end'
-      expect(src).to reek_of(ControlParameter, name: 'arga')
+      expect(src).to reek_of(:ControlParameter, name: 'arga')
     end
 
     it 'reports a couple inside a block' do
       src = 'def blocks(arg) @text.map { |blk| arg ? blk : "#{blk}" } end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on an if statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => \'A\') if arg end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on an unless statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => \'A\') unless arg end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression' do
       src = 'def simple(arg) args = {}; if arg then args.merge(\'a\' => \'A\') end end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with &&' do
       src = 'def simple(arg) if arg && true then puts "arg" end end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with preceding &&' do
       src = 'def simple(arg) if true && arg then puts "arg" end end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with two && conditions' do
       src = 'def simple(a) ag = {}; if a && true && true then puts "2" end end'
-      expect(src).to reek_of(ControlParameter, name: 'a')
+      expect(src).to reek_of(:ControlParameter, name: 'a')
     end
 
     it 'reports on if control expression with ||' do
       src = 'def simple(arg) args = {}; if arg || true then puts "arg" end end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with or' do
       src = 'def simple(arg) args = {}; if arg or true then puts "arg" end end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with if' do
       src = 'def simple(arg) args = {}; if (arg if true) then puts "arg" end end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on && notation' do
       src = 'def simple(arg) args = {}; arg && args.merge(\'a\' => \'A\') end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on || notation' do
       src = 'def simple(arg) args = {}; arg || args.merge(\'a\' => \'A\') end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on case statement' do
       src = 'def simple(arg) case arg when nil; nil when false; nil else nil end end'
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on nested if statements that are both control parameters' do
@@ -114,7 +112,7 @@ describe ControlParameter do
           end
         end
       EOS
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on nested if statements where the inner if is a control parameter' do
@@ -126,32 +124,32 @@ describe ControlParameter do
           end
         end
       EOS
-      expect(src).to reek_of(ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on explicit comparison in the condition' do
       src = 'def simple(arg) if arg == :foo then :foo else :bar end end'
-      expect(src).to reek_of(ControlParameter)
+      expect(src).to reek_of(:ControlParameter)
     end
 
     it 'reports on explicit negative comparison in the condition' do
       src = 'def simple(arg) if arg != :foo then :bar else :foo end end'
-      expect(src).to reek_of(ControlParameter)
+      expect(src).to reek_of(:ControlParameter)
     end
 
     it 'reports when the argument is compared to a regexp' do
       src = 'def simple(arg) if arg =~ /foo/ then :foo else :bar end end'
-      expect(src).to reek_of(ControlParameter)
+      expect(src).to reek_of(:ControlParameter)
     end
 
     it 'reports when the argument is reverse-compared to a regexp' do
       src = 'def simple(arg) if /foo/ =~ arg then :foo else :bar end end'
-      expect(src).to reek_of(ControlParameter)
+      expect(src).to reek_of(:ControlParameter)
     end
 
     it 'reports when the argument is used in a complex regexp' do
       src = 'def simple(arg) if /foo#{arg}/ =~ bar then :foo else :bar end end'
-      expect(src).to reek_of(ControlParameter)
+      expect(src).to reek_of(:ControlParameter)
     end
 
     it 'reports when the argument is a block parameter' do
@@ -160,64 +158,64 @@ describe ControlParameter do
           bar(blk || proc {})
         end
       EOS
-      expect(src).to reek_of(ControlParameter)
+      expect(src).to reek_of(:ControlParameter)
     end
   end
 
   context 'parameter used besides determining code path' do
     it 'does not report on if conditional expression' do
       src = 'def simple(arg) if arg then use(arg) else use(@other) end end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report on an if statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => arg) if arg end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report on an unless statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => arg) unless arg end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report on if control expression' do
       src = 'def simple(arg) args = {}; if arg then args.merge(\'a\' => arg) end end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report on if control expression with &&' do
       src = 'def simple(arg) if arg && true then puts arg end end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report on && notation' do
       src = 'def simple(arg) args = {}; arg && args.merge(\'a\' => arg) end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report on || notation' do
       src = 'def simple(arg) args = {}; arg || args.merge(\'a\' => arg) end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report when parameter is used outside conditional' do
       src = 'def simple(arg) puts arg; if arg then @a = 1 end end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report when parameter is used as a method call argument in a condition' do
       src = 'def simple(arg) if foo(arg) then @a = 1 end end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report when parameter is used as a method call receiver in a condition' do
       src = 'def simple(arg) if arg.foo? then @a = 1 end end'
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report when the argument is a hash on which we access a key' do
       src = 'def simple(arg) if arg[\'a\'] then puts \'a\' else puts \'b\' end end'
-      expect(src).not_to reek_of ControlParameter
+      expect(src).not_to reek_of :ControlParameter
     end
 
     it 'does not report when used in first conditional but not second' do
@@ -231,7 +229,7 @@ describe ControlParameter do
           end
         end
       EOS
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report when used in second conditional but not first' do
@@ -245,7 +243,7 @@ describe ControlParameter do
           end
         end
       EOS
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
 
     it 'does not report when used in body of control flow operator' do
@@ -260,7 +258,7 @@ describe ControlParameter do
           qux or quuz(arg)
         end
       EOS
-      expect(src).not_to reek_of(ControlParameter)
+      expect(src).not_to reek_of(:ControlParameter)
     end
   end
 
@@ -274,7 +272,7 @@ describe ControlParameter do
           puts "hello" if arg
         end
       EOS
-      ctx = MethodContext.new(nil, src.to_reek_source.syntax_tree)
+      ctx = Reek::Core::MethodContext.new(nil, src.to_reek_source.syntax_tree)
       smells = @detector.examine(ctx)
       expect(smells.length).to eq(1)
       @warning = smells[0]

--- a/spec/reek/smells/data_clump_spec.rb
+++ b/spec/reek/smells/data_clump_spec.rb
@@ -2,119 +2,124 @@ require 'spec_helper'
 require 'reek/smells/data_clump'
 require 'reek/smells/smell_detector_shared'
 
-include Reek::Smells
-
 shared_examples_for 'a data clump detector' do
   it 'does not report small parameter sets' do
-    src = <<EOS
-# test module
-#{@context} Scrunch
-  def first(pa) @field == :sym ? 0 : 3; end
-  def second(pa) @field == :sym; end
-  def third(pa) pa - pb + @fred; end
-end
-EOS
-    expect(src).not_to reek_of(DataClump)
+    src = <<-EOS
+      # test module
+      #{@context} Scrunch
+        def first(pa) @field == :sym ? 0 : 3; end
+        def second(pa) @field == :sym; end
+        def third(pa) pa - pb + @fred; end
+      end
+    EOS
+    expect(src).not_to reek_of(:DataClump)
   end
 
   context 'with 3 identical pairs' do
     before :each do
       @module_name = 'Scrunch'
-      @src = <<EOS
-#{@context} #{@module_name}
-  def first(pa, pb) @field == :sym ? 0 : 3; end
-  def second(pa, pb) @field == :sym; end
-  def third(pa, pb) pa - pb + @fred; end
-end
-EOS
-      ctx = ModuleContext.new(nil, @src.to_reek_source.syntax_tree)
-      detector = DataClump.new('newt')
+      @src = <<-EOS
+        #{@context} #{@module_name}
+          def first(pa, pb) @field == :sym ? 0 : 3; end
+          def second(pa, pb) @field == :sym; end
+          def third(pa, pb) pa - pb + @fred; end
+        end
+      EOS
+      ctx = Reek::Core::ModuleContext.new(nil, @src.to_reek_source.syntax_tree)
+      detector = build(:smell_detector, smell_type: :DataClump)
       @smells = detector.examine_context(ctx)
     end
+
     it 'records only the one smell' do
       expect(@smells.length).to eq(1)
     end
+
     it 'reports all parameters' do
       expect(@smells[0].parameters[:parameters]).to eq(['pa', 'pb'])
     end
+
     it 'reports the number of occurrences' do
       expect(@smells[0].parameters[:count]).to eq(3)
     end
+
     it 'reports all methods' do
       expect(@smells[0].parameters[:methods]).to eq(['first', 'second', 'third'])
     end
+
     it 'reports the declaration line numbers' do
       expect(@smells[0].lines).to eq([2, 3, 4])
     end
+
     it 'reports the correct smell class' do
-      expect(@smells[0].smell_category).to eq(DataClump.smell_category)
+      expect(@smells[0].smell_category).to eq(Reek::Smells::DataClump.smell_category)
     end
+
     it 'reports the context fq name' do
       expect(@smells[0].context).to eq(@module_name)
     end
   end
 
   it 'reports 3 swapped pairs' do
-    src = <<EOS
-#{@context} Scrunch
-  def one(pa, pb) @field == :sym ? 0 : 3; end
-  def two(pb, pa) @field == :sym; end
-  def tri(pa, pb) pa - pb + @fred; end
-end
-EOS
-    expect(src).to reek_of(DataClump,
+    src = <<-EOS
+      #{@context} Scrunch
+        def one(pa, pb) @field == :sym ? 0 : 3; end
+        def two(pb, pa) @field == :sym; end
+        def tri(pa, pb) pa - pb + @fred; end
+      end
+    EOS
+    expect(src).to reek_of(:DataClump,
                            count: 3,
                            parameters: ['pa', 'pb'])
   end
 
   it 'reports 3 identical parameter sets' do
-    src = <<EOS
-#{@context} Scrunch
-  def first(pa, pb, pc) @field == :sym ? 0 : 3; end
-  def second(pa, pb, pc) @field == :sym; end
-  def third(pa, pb, pc) pa - pb + @fred; end
-end
-EOS
-    expect(src).to reek_of(DataClump,
+    src = <<-EOS
+      #{@context} Scrunch
+        def first(pa, pb, pc) @field == :sym ? 0 : 3; end
+        def second(pa, pb, pc) @field == :sym; end
+        def third(pa, pb, pc) pa - pb + @fred; end
+      end
+    EOS
+    expect(src).to reek_of(:DataClump,
                            count: 3,
                            parameters: ['pa', 'pb', 'pc'])
   end
 
   it 'reports re-ordered identical parameter sets' do
-    src = <<EOS
-#{@context} Scrunch
-  def first(pb, pa, pc) @field == :sym ? 0 : 3; end
-  def second(pc, pb, pa) @field == :sym; end
-  def third(pa, pb, pc) pa - pb + @fred; end
-end
-EOS
-    expect(src).to reek_of(DataClump,
+    src = <<-EOS
+      #{@context} Scrunch
+        def first(pb, pa, pc) @field == :sym ? 0 : 3; end
+        def second(pc, pb, pa) @field == :sym; end
+        def third(pa, pb, pc) pa - pb + @fred; end
+      end
+    EOS
+    expect(src).to reek_of(:DataClump,
                            count: 3,
                            parameters: ['pa', 'pb', 'pc'])
   end
 
   it 'counts only identical parameter sets' do
-    src = <<EOS
-#{@context} RedCloth
-  def fa(p1, p2, p3, conten) end
-  def fb(p1, p2, p3, conten) end
-  def fc(name, windowW, windowH) end
-end
-EOS
-    expect(src).not_to reek_of(DataClump)
+    src = <<-EOS
+      #{@context} RedCloth
+        def fa(p1, p2, p3, conten) end
+        def fb(p1, p2, p3, conten) end
+        def fc(name, windowW, windowH) end
+      end
+    EOS
+    expect(src).not_to reek_of(:DataClump)
   end
 
   it 'gets a real example right' do
-    src = <<EOS
-#{@context} Inline
-  def generate(src, options) end
-  def c (src, options) end
-  def c_singleton (src, options) end
-  def c_raw (src, options) end
-  def c_raw_singleton (src, options) end
-end
-EOS
-    expect(src).to reek_of(DataClump, count: 5)
+    src = <<-EOS
+      #{@context} Inline
+        def generate(src, options) end
+        def c (src, options) end
+        def c_singleton (src, options) end
+        def c_raw (src, options) end
+        def c_raw_singleton (src, options) end
+      end
+    EOS
+    expect(src).to reek_of(:DataClump, count: 5)
   end
 
   it 'correctly checks number of occurences' do
@@ -127,7 +132,7 @@ EOS
         def fe(p5, p1, p2) end
       end
     EOS
-    expect(src).not_to reek_of(DataClump)
+    expect(src).not_to reek_of(:DataClump)
   end
 
   it 'detects clumps smaller than the total number of arguments' do
@@ -138,7 +143,7 @@ EOS
         def fc(p4, p1, p2) end
       end
     EOS
-    expect(src).to reek_of(DataClump,
+    expect(src).to reek_of(:DataClump,
                            parameters: %w(p1 p2))
   end
 
@@ -150,14 +155,14 @@ EOS
         def fc(p1, p2, *) end
       end
     EOS
-    expect(src).to reek_of(DataClump,
+    expect(src).to reek_of(:DataClump,
                            parameters: %w(p1 p2))
   end
 end
 
-describe DataClump do
+describe Reek::Smells::DataClump do
   before(:each) do
-    @detector = DataClump.new('newt')
+    @detector = build(:smell_detector, smell_type: :DataClump)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -177,6 +182,4 @@ describe DataClump do
 
     it_should_behave_like 'a data clump detector'
   end
-
-  # TODO: include singleton methods in the calcs
 end

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -1,17 +1,15 @@
 require 'spec_helper'
 require 'reek/smells/duplicate_method_call'
+require 'reek/core/code_context'
 require 'reek/core/code_parser'
 require 'reek/core/sniffer'
 require 'reek/smells/smell_detector_shared'
 
-include Reek
-include Reek::Smells
-
-describe DuplicateMethodCall do
+describe Reek::Smells::DuplicateMethodCall do
   context 'when a smell is reported' do
     before :each do
-      @source_name = 'copy-cat'
-      @detector = DuplicateMethodCall.new(@source_name)
+      @source_name = 'dummy_source'
+      @detector = build(:smell_detector, smell_type: :DuplicateMethodCall, source: @source_name)
       src = <<-EOS
         def double_thing(other)
           other[@thing]
@@ -19,7 +17,7 @@ describe DuplicateMethodCall do
           other[@thing]
         end
       EOS
-      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
       smells = @detector.examine_context(ctx)
       expect(smells.length).to eq(1)
       @warning = smells[0]
@@ -31,6 +29,7 @@ describe DuplicateMethodCall do
     it 'reports the call' do
       expect(@warning.parameters[:name]).to eq('other[@thing]')
     end
+
     it 'reports the correct lines' do
       expect(@warning.lines).to eq([2, 4])
     end
@@ -39,28 +38,28 @@ describe DuplicateMethodCall do
   context 'with repeated method calls' do
     it 'reports repeated call' do
       src = 'def double_thing() @other.thing + @other.thing end'
-      expect(src).to reek_of(DuplicateMethodCall, name: '@other.thing')
+      expect(src).to reek_of(:DuplicateMethodCall, name: '@other.thing')
     end
 
     it 'reports repeated call to lvar' do
       src = 'def double_thing(other) other[@thing] + other[@thing] end'
-      expect(src).to reek_of(DuplicateMethodCall, name: 'other[@thing]')
+      expect(src).to reek_of(:DuplicateMethodCall, name: 'other[@thing]')
     end
 
     it 'reports call parameters' do
       src = 'def double_thing() @other.thing(2,3) + @other.thing(2,3) end'
-      expect(src).to reek_of(DuplicateMethodCall, name: '@other.thing(2, 3)')
+      expect(src).to reek_of(:DuplicateMethodCall, name: '@other.thing(2, 3)')
     end
 
     it 'should report nested calls' do
       src = 'def double_thing() @other.thing.foo + @other.thing.foo end'
-      expect(src).to reek_of(DuplicateMethodCall, name: '@other.thing')
-      expect(src).to reek_of(DuplicateMethodCall, name: '@other.thing.foo')
+      expect(src).to reek_of(:DuplicateMethodCall, name: '@other.thing')
+      expect(src).to reek_of(:DuplicateMethodCall, name: '@other.thing.foo')
     end
 
     it 'should ignore calls to new' do
       src = 'def double_thing() @other.new + @other.new end'
-      expect(src).not_to reek_of(DuplicateMethodCall)
+      expect(src).not_to reek_of(:DuplicateMethodCall)
     end
   end
 
@@ -76,7 +75,7 @@ describe DuplicateMethodCall do
           end
         end
       EOS
-      expect(src).not_to reek_of(DuplicateMethodCall)
+      expect(src).not_to reek_of(:DuplicateMethodCall)
     end
   end
 
@@ -88,7 +87,7 @@ describe DuplicateMethodCall do
           bar { baz }
         end
       EOS
-      expect(src).to reek_of(DuplicateMethodCall)
+      expect(src).to reek_of(:DuplicateMethodCall)
     end
 
     it 'reports no smell if the blocks are different' do
@@ -98,7 +97,7 @@ describe DuplicateMethodCall do
           bar { qux }
         end
       EOS
-      expect(src).not_to reek_of(DuplicateMethodCall)
+      expect(src).not_to reek_of(:DuplicateMethodCall)
     end
   end
 
@@ -110,7 +109,7 @@ describe DuplicateMethodCall do
           bar.qux { baz }
         end
       EOS
-      expect(src).to reek_of(DuplicateMethodCall)
+      expect(src).to reek_of(:DuplicateMethodCall)
     end
 
     it 'reports a smell if the blocks are different' do
@@ -120,53 +119,55 @@ describe DuplicateMethodCall do
           bar.qux { qux }
         end
       EOS
-      expect(src).to reek_of(DuplicateMethodCall)
+      expect(src).to reek_of(:DuplicateMethodCall)
     end
   end
 
   context 'with repeated attribute assignment' do
     it 'reports repeated assignment' do
       src = 'def double_thing(thing) @other[thing] = true; @other[thing] = true; end'
-      expect(src).to reek_of(DuplicateMethodCall, name: '@other[thing] = true')
+      expect(src).to reek_of(:DuplicateMethodCall, name: '@other[thing] = true')
     end
     it 'does not report multi-assignments' do
-      src = <<EOS
-def _parse ctxt
-  ctxt.index, result = @ind, @result
-  error, ctxt.index = @err, @err_ind
-end
-EOS
-      expect(src).not_to reek_of(DuplicateMethodCall)
+      src = <<-EOS
+        def _parse ctxt
+          ctxt.index, result = @ind, @result
+          error, ctxt.index = @err, @err_ind
+        end
+      EOS
+      expect(src).not_to reek_of(:DuplicateMethodCall)
     end
   end
 
   context 'non-repeated method calls' do
     it 'should not report similar calls' do
       src = 'def equals(other) other.thing == self.thing end'
-      expect(src).not_to reek_of(DuplicateMethodCall)
+      expect(src).not_to reek_of(:DuplicateMethodCall)
     end
+
     it 'should respect call parameters' do
       src = 'def double_thing() @other.thing(3) + @other.thing(2) end'
-      expect(src).not_to reek_of(DuplicateMethodCall)
+      expect(src).not_to reek_of(:DuplicateMethodCall)
     end
   end
 
   context 'allowing up to 3 calls' do
     before :each do
-      @config = { DuplicateMethodCall: { DuplicateMethodCall::MAX_ALLOWED_CALLS_KEY => 3 } }
+      @config = { DuplicateMethodCall:
+                  { Reek::Smells::DuplicateMethodCall::MAX_ALLOWED_CALLS_KEY => 3 } }
     end
 
     it 'does not report double calls' do
       src = 'def double_thing() @other.thing + @other.thing end'
       with_test_config(@config) do
-        expect(src).not_to reek_of(DuplicateMethodCall)
+        expect(src).not_to reek_of(:DuplicateMethodCall)
       end
     end
 
     it 'does not report triple calls' do
       src = 'def double_thing() @other.thing + @other.thing + @other.thing end'
       with_test_config(@config) do
-        expect(src).not_to reek_of(DuplicateMethodCall)
+        expect(src).not_to reek_of(:DuplicateMethodCall)
       end
     end
 
@@ -177,7 +178,7 @@ EOS
         end
       '
       with_test_config(@config) do
-        expect(src).to reek_of(DuplicateMethodCall, name: '@other.thing', count: 4)
+        expect(src).to reek_of(:DuplicateMethodCall, name: '@other.thing', count: 4)
       end
     end
   end
@@ -185,14 +186,15 @@ EOS
   context 'allowing calls to some methods' do
     before :each do
       @config = { DuplicateMethodCall:
-                  { DuplicateMethodCall::ALLOW_CALLS_KEY => ['@some.thing', /puts/] } }
+                  { Reek::Smells::DuplicateMethodCall::ALLOW_CALLS_KEY =>
+                    ['@some.thing', /puts/] } }
     end
 
     it 'does not report calls to some methods' do
       src = 'def double_some_thing() @some.thing + @some.thing end'
 
       with_test_config(@config) do
-        expect(src).not_to reek_of(DuplicateMethodCall)
+        expect(src).not_to reek_of(:DuplicateMethodCall)
       end
     end
 
@@ -200,7 +202,7 @@ EOS
       src = 'def double_other_thing() @other.thing + @other.thing end'
 
       with_test_config(@config) do
-        expect(src).to reek_of(DuplicateMethodCall, name: '@other.thing')
+        expect(src).to reek_of(:DuplicateMethodCall, name: '@other.thing')
       end
     end
 
@@ -208,7 +210,7 @@ EOS
       src = 'def double_puts() puts @other.thing; puts @other.thing end'
 
       with_test_config(@config) do
-        expect(src).to reek_of(DuplicateMethodCall, name: '@other.thing')
+        expect(src).to reek_of(:DuplicateMethodCall, name: '@other.thing')
       end
     end
   end

--- a/spec/reek/smells/irresponsible_module_spec.rb
+++ b/spec/reek/smells/irresponsible_module_spec.rb
@@ -1,12 +1,13 @@
 require 'spec_helper'
+require 'reek/core/code_context'
 require 'reek/smells/irresponsible_module'
 require 'reek/smells/smell_detector_shared'
-include Reek::Smells
 
-describe IrresponsibleModule do
+describe Reek::Smells::IrresponsibleModule do
   before(:each) do
     @bad_module_name = 'WrongUn'
-    @detector = IrresponsibleModule.new('yoof')
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector, smell_type: :IrresponsibleModule, source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -26,17 +27,17 @@ describe IrresponsibleModule do
       # test class
       class Responsible; end
     EOS
-    ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+    ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
     expect(@detector.examine_context(ctx)).to be_empty
   end
 
   it 'reports a class without a comment' do
     src = "class #{@bad_module_name}; end"
-    ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+    ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
     smells = @detector.examine_context(ctx)
     expect(smells.length).to eq(1)
-    expect(smells[0].smell_category).to eq(IrresponsibleModule.smell_category)
-    expect(smells[0].smell_type).to eq(IrresponsibleModule.smell_type)
+    expect(smells[0].smell_category).to eq(Reek::Smells::IrresponsibleModule.smell_category)
+    expect(smells[0].smell_type).to eq(Reek::Smells::IrresponsibleModule.smell_type)
     expect(smells[0].lines).to eq([1])
     expect(smells[0].parameters[:name]).to eq(@bad_module_name)
   end
@@ -48,7 +49,7 @@ describe IrresponsibleModule do
       #
       class #{@bad_module_name}; end
     EOS
-    expect(src).to reek_of IrresponsibleModule
+    expect(src).to reek_of :IrresponsibleModule
   end
 
   it 'reports a class with a preceding comment with intermittent material' do
@@ -64,11 +65,11 @@ describe IrresponsibleModule do
 
   it 'reports a fq module name correctly' do
     src = 'class Foo::Bar; end'
-    ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+    ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
     smells = @detector.examine_context(ctx)
     expect(smells.length).to eq(1)
-    expect(smells[0].smell_category).to eq(IrresponsibleModule.smell_category)
-    expect(smells[0].smell_type).to eq(IrresponsibleModule.smell_type)
+    expect(smells[0].smell_category).to eq(described_class.smell_category)
+    expect(smells[0].smell_type).to eq(described_class.smell_type)
     expect(smells[0].parameters[:name]).to eq('Foo::Bar')
     expect(smells[0].context).to match(/#{smells[0].parameters['name']}/)
   end

--- a/spec/reek/smells/long_parameter_list_spec.rb
+++ b/spec/reek/smells/long_parameter_list_spec.rb
@@ -1,45 +1,49 @@
 require 'spec_helper'
+require 'reek/core/code_context'
 require 'reek/smells/long_parameter_list'
 require 'reek/smells/smell_detector_shared'
 
-include Reek
-include Reek::Smells
-
-describe LongParameterList do
+describe Reek::Smells::LongParameterList do
   context 'for methods with few parameters' do
     it 'should report nothing for no parameters' do
-      expect('def simple; f(3);true; end').not_to reek_of(LongParameterList)
+      expect('def simple; f(3);true; end').not_to reek_of(:LongParameterList)
     end
+
     it 'should report nothing for 1 parameter' do
-      expect('def simple(yep) f(3);true end').not_to reek_of(LongParameterList)
+      expect('def simple(yep) f(3);true end').not_to reek_of(:LongParameterList)
     end
+
     it 'should report nothing for 2 parameters' do
-      expect('def simple(yep,zero) f(3);true end').not_to reek_of(LongParameterList)
+      expect('def simple(yep,zero) f(3);true end').not_to reek_of(:LongParameterList)
     end
+
     it 'should not count an optional block' do
       src = 'def simple(alpha, yep, zero, &opt) f(3); true end'
-      expect(src).not_to reek_of(LongParameterList)
+      expect(src).not_to reek_of(:LongParameterList)
     end
+
     it 'should not report inner block with too many parameters' do
       src = '
         def simple(yep,zero)
           m[3]; rand(34); f.each { |arga, argb, argc, argd| true}
         end
       '
-      expect(src).not_to reek_of(LongParameterList)
+      expect(src).not_to reek_of(:LongParameterList)
     end
 
     describe 'and default values' do
       it 'should report nothing for 1 parameter' do
-        expect('def simple(zero=nil) f(3);false end').not_to reek_of(LongParameterList)
+        expect('def simple(zero=nil) f(3);false end').not_to reek_of(:LongParameterList)
       end
+
       it 'should report nothing for 2 parameters with 1 default' do
         source = 'def simple(yep, zero=nil) f(3); false end'
-        expect(source).not_to reek_of(LongParameterList)
+        expect(source).not_to reek_of(:LongParameterList)
       end
+
       it 'should report nothing for 2 defaulted parameters' do
         source = 'def simple(yep=4, zero=nil) f(3); false end'
-        expect(source).not_to reek_of(LongParameterList)
+        expect(source).not_to reek_of(:LongParameterList)
       end
     end
   end
@@ -47,43 +51,45 @@ describe LongParameterList do
   describe 'for methods with too many parameters' do
     it 'should report 4 parameters' do
       src = 'def simple(arga, argb, argc, argd) f(3);true end'
-      expect(src).to reek_of(LongParameterList, count: 4)
+      expect(src).to reek_of(:LongParameterList, count: 4)
     end
+
     it 'should report 8 parameters' do
       src = 'def simple(arga, argb, argc, argd,arge, argf, argg, argh) f(3);true end'
-      expect(src).to reek_of(LongParameterList, count: 8)
+      expect(src).to reek_of(:LongParameterList, count: 8)
     end
 
     describe 'and default values' do
       it 'should report 3 with 1 defaulted' do
         src = 'def simple(polly, queue, yep, zero=nil) f(3);false end'
-        expect(src).to reek_of(LongParameterList, count: 4)
+        expect(src).to reek_of(:LongParameterList, count: 4)
       end
+
       it 'should report with 3 defaulted' do
         src = 'def simple(aarg, polly=2, yep=:truth, zero=nil) f(3);false end'
-        expect(src).to reek_of(LongParameterList, count: 4)
+        expect(src).to reek_of(:LongParameterList, count: 4)
       end
     end
   end
 end
 
-describe LongParameterList do
+describe Reek::Smells::LongParameterList do
   before(:each) do
-    @source_name = 'smokin'
-    @detector = LongParameterList.new(@source_name)
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector, smell_type: :LongParameterList, source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
 
   context 'when a smell is reported' do
     before :each do
-      src = <<EOS
-def badguy(arga, argb, argc, argd)
-  f(3)
-  true
-end
-EOS
-      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      src = <<-EOS
+        def badguy(arga, argb, argc, argd)
+          f(3)
+          true
+        end
+      EOS
+      ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
       @smells = @detector.examine_context(ctx)
       @warning = @smells[0]
     end
@@ -93,6 +99,7 @@ EOS
     it 'reports the number of parameters' do
       expect(@warning.parameters[:count]).to eq(4)
     end
+
     it 'reports the line number of the method' do
       expect(@warning.lines).to eq([1])
     end

--- a/spec/reek/smells/long_yield_list_spec.rb
+++ b/spec/reek/smells/long_yield_list_spec.rb
@@ -1,16 +1,12 @@
 require 'spec_helper'
+require 'reek/core/code_context'
 require 'reek/smells/long_yield_list'
 require 'reek/smells/smell_detector_shared'
 
-include Reek
-include Reek::Smells
-
-describe LongYieldList do
+describe Reek::Smells::LongYieldList do
   before(:each) do
-    @source_name = 'oo la la'
-    @detector = LongYieldList.new(@source_name)
-    # SMELL: can't use the default config, because that contains an override,
-    # which causes the mocked matches?() method to be called twice!!
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector, smell_type: :LongYieldList, source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -18,31 +14,31 @@ describe LongYieldList do
   context 'yield' do
     it 'should not report yield with no parameters' do
       src = 'def simple(arga, argb, &blk) f(3);yield; end'
-      expect(src).not_to reek_of(LongYieldList)
+      expect(src).not_to reek_of(:LongYieldList)
     end
     it 'should not report yield with few parameters' do
       src = 'def simple(arga, argb, &blk) f(3);yield a,b; end'
-      expect(src).not_to reek_of(LongYieldList)
+      expect(src).not_to reek_of(:LongYieldList)
     end
     it 'should report yield with many parameters' do
       src = 'def simple(arga, argb, &blk) f(3);yield arga,argb,arga,argb; end'
-      expect(src).to reek_of(LongYieldList, count: 4)
+      expect(src).to reek_of(:LongYieldList, count: 4)
     end
     it 'should not report yield of a long expression' do
       src = 'def simple(arga, argb, &blk) f(3);yield(if @dec then argb else 5+3 end); end'
-      expect(src).not_to reek_of(LongYieldList)
+      expect(src).not_to reek_of(:LongYieldList)
     end
   end
 
   context 'when a smells is reported' do
     before :each do
-      src = <<EOS
-def simple(arga, argb, &blk)
-  f(3)
-  yield(arga,argb,arga,argb)
-  end
-EOS
-      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      src = <<-EOS
+        def simple(arga, argb, &blk)
+          f(3)
+          yield(arga,argb,arga,argb)
+          end
+      EOS
+      ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
       @smells = @detector.examine_context(ctx)
       @warning = @smells[0]
     end

--- a/spec/reek/smells/module_initialize_spec.rb
+++ b/spec/reek/smells/module_initialize_spec.rb
@@ -2,9 +2,7 @@ require 'spec_helper'
 require 'reek/smells/module_initialize'
 require 'reek/smells/smell_detector_shared'
 
-include Reek::Smells
-
-describe ModuleInitialize do
+describe Reek::Smells::ModuleInitialize do
   context 'module' do
     context 'with method named initialize' do
       it 'smells' do
@@ -13,7 +11,7 @@ describe ModuleInitialize do
             def initialize; end
           end
         EOF
-        expect(src).to reek_of(ModuleInitialize)
+        expect(src).to reek_of(:ModuleInitialize)
       end
     end
 
@@ -26,7 +24,7 @@ describe ModuleInitialize do
             end
           end
         EOF
-        expect(src).not_to reek_of(ModuleInitialize)
+        expect(src).not_to reek_of(:ModuleInitialize)
       end
     end
 
@@ -39,7 +37,7 @@ describe ModuleInitialize do
             end
           end
         EOF
-        expect(src).not_to reek_of(ModuleInitialize)
+        expect(src).not_to reek_of(:ModuleInitialize)
       end
     end
   end

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -2,26 +2,24 @@ require 'spec_helper'
 require 'reek/smells/nested_iterators'
 require 'reek/smells/smell_detector_shared'
 
-include Reek::Smells
-
-describe NestedIterators do
+describe Reek::Smells::NestedIterators do
   context 'with no iterators' do
     it 'reports no smells' do
       src = 'def fred() nothing = true; end'
-      expect(src).not_to reek_of(NestedIterators)
+      expect(src).not_to reek_of(:NestedIterators)
     end
   end
 
   context 'with one iterator' do
     it 'reports no smells' do
       src = 'def fred() nothing.each {|item| item}; end'
-      expect(src).not_to reek_of(NestedIterators)
+      expect(src).not_to reek_of(:NestedIterators)
     end
   end
 
   it 'should report nested iterators in a method' do
     src = 'def bad(fred) @fred.each {|item| item.each {|ting| ting.ting} } end'
-    expect(src).to reek_of(NestedIterators)
+    expect(src).to reek_of(:NestedIterators)
   end
 
   it 'should not report method with successive iterators' do
@@ -31,7 +29,7 @@ describe NestedIterators do
         @jim.each {|ting| ting.each }
       end
     EOS
-    expect(src).not_to reek_of(NestedIterators)
+    expect(src).not_to reek_of(:NestedIterators)
   end
 
   it 'should not report method with chained iterators' do
@@ -40,7 +38,7 @@ describe NestedIterators do
         @sig.keys.sort_by { |xray| xray.to_s }.each { |min| md5 << min.to_s }
       end
     EOS
-    expect(src).not_to reek_of(NestedIterators)
+    expect(src).not_to reek_of(:NestedIterators)
   end
 
   it 'detects an iterator with an empty block' do
@@ -49,7 +47,7 @@ describe NestedIterators do
         bar { baz { } }
       end
     EOS
-    expect(src).to reek_of(NestedIterators)
+    expect(src).to reek_of(:NestedIterators)
   end
 
   it 'should report nested iterators only once per method' do
@@ -59,7 +57,7 @@ describe NestedIterators do
         @jim.each {|ting| ting.each {|piece| @hal.send} }
       end
     EOS
-    expect(src).to reek_of(NestedIterators)
+    expect(src).to reek_of(:NestedIterators)
   end
 
   it 'reports nested iterators only once per method even if levels are different' do
@@ -69,7 +67,7 @@ describe NestedIterators do
         @jim.each {|ting| ting.each {|piece| piece.each {|atom| atom.foo } } }
       end
     EOS
-    expect(src).to reek_of(NestedIterators)
+    expect(src).to reek_of(:NestedIterators)
   end
 
   it 'reports nesting inside iterator arguments' do
@@ -84,7 +82,7 @@ describe NestedIterators do
         ) { |qux| qux.quuz }
       end
     EOS
-    expect(src).to reek_of(NestedIterators, count: 2)
+    expect(src).to reek_of(:NestedIterators, count: 2)
   end
 
   it 'reports the deepest level of nesting only' do
@@ -97,12 +95,13 @@ describe NestedIterators do
         }
       end
     EOS
-    expect(src).to reek_of(NestedIterators, count: 3)
+    expect(src).to reek_of(:NestedIterators, count: 3)
   end
 
   context 'when the allowed nesting depth is 3' do
     before :each do
-      @config = { NestedIterators: { NestedIterators::MAX_ALLOWED_NESTING_KEY => 3 } }
+      @config = { NestedIterators:
+                  { Reek::Smells::NestedIterators::MAX_ALLOWED_NESTING_KEY => 3 } }
     end
 
     it 'should not report nested iterators 2 levels deep' do
@@ -113,7 +112,7 @@ describe NestedIterators do
       EOS
 
       with_test_config(@config) do
-        expect(src).not_to reek_of(NestedIterators)
+        expect(src).not_to reek_of(:NestedIterators)
       end
     end
 
@@ -125,7 +124,7 @@ describe NestedIterators do
       EOS
 
       with_test_config(@config) do
-        expect(src).not_to reek_of(NestedIterators)
+        expect(src).not_to reek_of(:NestedIterators)
       end
     end
 
@@ -137,27 +136,28 @@ describe NestedIterators do
       EOS
 
       with_test_config(@config) do
-        expect(src).to reek_of(NestedIterators)
+        expect(src).to reek_of(:NestedIterators)
       end
     end
   end
 
   context 'when ignoring iterators' do
     before :each do
-      @config = { NestedIterators: { NestedIterators::IGNORE_ITERATORS_KEY => ['ignore_me'] } }
+      @config = { NestedIterators:
+                  { Reek::Smells::NestedIterators::IGNORE_ITERATORS_KEY => ['ignore_me'] } }
     end
 
     it 'should not report nesting the ignored iterator inside another' do
       src = 'def bad(fred) @fred.each {|item| item.ignore_me {|ting| ting.ting} } end'
       with_test_config(@config) do
-        expect(src).not_to reek_of(NestedIterators)
+        expect(src).not_to reek_of(:NestedIterators)
       end
     end
 
     it 'should not report nesting inside the ignored iterator' do
       src = 'def bad(fred) @fred.ignore_me {|item| item.each {|ting| ting.ting} } end'
       with_test_config(@config) do
-        expect(src).not_to reek_of(NestedIterators)
+        expect(src).not_to reek_of(:NestedIterators)
       end
     end
 
@@ -168,7 +168,7 @@ describe NestedIterators do
         end
       '
       with_test_config(@config) do
-        expect(src).to reek_of(NestedIterators, count: 2)
+        expect(src).to reek_of(:NestedIterators, count: 2)
       end
     end
 
@@ -179,7 +179,7 @@ describe NestedIterators do
         end
       '
       with_test_config(@config) do
-        expect(src).to reek_of(NestedIterators, count: 2)
+        expect(src).to reek_of(:NestedIterators, count: 2)
       end
     end
 
@@ -190,16 +190,16 @@ describe NestedIterators do
         end
       '
       with_test_config(@config) do
-        expect(src).to reek_of(NestedIterators, count: 2)
+        expect(src).to reek_of(:NestedIterators, count: 2)
       end
     end
   end
 end
 
-describe NestedIterators do
+describe Reek::Smells::NestedIterators do
   before(:each) do
-    @source_name = 'cuckoo'
-    @detector = NestedIterators.new(@source_name)
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector, smell_type: :NestedIterators, source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -213,7 +213,7 @@ describe NestedIterators do
           end
         end
       EOS
-      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
       @warning = @detector.examine_context(ctx)[0]
     end
 
@@ -235,7 +235,7 @@ describe NestedIterators do
         end
       EOS
 
-      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
       @warning = @detector.examine_context(ctx)[0]
     end
 

--- a/spec/reek/smells/nil_check_spec.rb
+++ b/spec/reek/smells/nil_check_spec.rb
@@ -1,11 +1,9 @@
 require 'spec_helper'
+require 'reek/core/code_context'
 require 'reek/smells/nil_check'
 require 'reek/smells/smell_detector_shared'
 
-include Reek
-include Reek::Smells
-
-describe NilCheck do
+describe Reek::Smells::NilCheck do
   context 'for methods' do
     it 'reports the correct line number' do
       src = <<-EOS
@@ -13,43 +11,43 @@ describe NilCheck do
         foo.nil?
       end
       EOS
-      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
-      detector = NilCheck.new('source_name')
+      ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      detector = build(:smell_detector, smell_type: :NilCheck, source: 'source_name')
       smells = detector.examine_context(ctx)
       expect(smells[0].lines).to eq [2]
     end
 
     it 'reports nothing when scope includes no nil checks' do
-      expect('def no_nils; end').not_to reek_of(NilCheck)
+      expect('def no_nils; end').not_to reek_of(:NilCheck)
     end
 
     it 'reports when scope uses multiple nil? methods' do
-      src = <<-eos
+      src = <<-EOS
       def chk_multi_nil(para)
         para.nil?
         puts "Hello"
         \"\".nil?
       end
-      eos
-      expect(src).to reek_of(NilCheck)
+      EOS
+      expect(src).to reek_of(:NilCheck)
     end
 
     it 'reports twice when scope uses == nil and === nil' do
-      src = <<-eos
+      src = <<-EOS
       def chk_eq_nil(para)
         para == nil
         para === nil
       end
-      eos
-      expect(src).to reek_of(NilCheck)
+      EOS
+      expect(src).to reek_of(:NilCheck)
     end
 
     it 'reports when scope uses nil ==' do
-      expect('def chk_eq_nil_rev(para); nil == para; end').to reek_of(NilCheck)
+      expect('def chk_eq_nil_rev(para); nil == para; end').to reek_of(:NilCheck)
     end
 
     it 'reports when scope uses multiple case-clauses checking nil' do
-      src = <<-eos
+      src = <<-EOS
       def case_nil
         case @inst_var
         when nil then puts "Nil"
@@ -60,19 +58,19 @@ describe NilCheck do
         when nil then puts nil.inspect
         end
       end
-      eos
-      expect(src).to reek_of(NilCheck)
+      EOS
+      expect(src).to reek_of(:NilCheck)
     end
 
     it 'reports a when clause that checks nil and other values' do
-      src = <<-eos
+      src = <<-EOS
       def case_nil
         case @inst_var
         when nil, false then puts "Hello"
         end
       end
-      eos
-      expect(src).to reek_of(NilCheck)
+      EOS
+      expect(src).to reek_of(:NilCheck)
     end
   end
 end

--- a/spec/reek/smells/prima_donna_method_spec.rb
+++ b/spec/reek/smells/prima_donna_method_spec.rb
@@ -1,23 +1,20 @@
 require 'spec_helper'
-
+require 'reek/core/module_context'
 require 'reek/smells/smell_detector_shared'
 
-include Reek
-include Reek::Smells
-
-describe PrimaDonnaMethod do
+describe Reek::Smells::PrimaDonnaMethod do
   it 'should report nothing when method and bang counterpart exist' do
-    expect('class C; def m; end; def m!; end; end').not_to reek_of(PrimaDonnaMethod)
+    expect('class C; def m; end; def m!; end; end').not_to reek_of(:PrimaDonnaMethod)
   end
 
   it 'should report PrimaDonnaMethod when only bang method exists' do
-    expect('class C; def m!; end; end').to reek_of(PrimaDonnaMethod)
+    expect('class C; def m!; end; end').to reek_of(:PrimaDonnaMethod)
   end
 
   describe 'the right smell' do
-    let(:detector) { PrimaDonnaMethod.new('dummy_source') }
+    let(:detector) { build(:smell_detector, smell_type: :PrimaDonnaMethod, source: 'source_name') }
     let(:src)      { 'class C; def m!; end; end' }
-    let(:ctx)      { ModuleContext.new(nil, src.to_reek_source.syntax_tree) }
+    let(:ctx)      { Reek::Core::ModuleContext.new(nil, src.to_reek_source.syntax_tree) }
 
     it 'should be reported' do
       smells = detector.examine_context(ctx)

--- a/spec/reek/smells/repeated_conditional_spec.rb
+++ b/spec/reek/smells/repeated_conditional_spec.rb
@@ -3,13 +3,10 @@ require 'reek/smells/repeated_conditional'
 require 'reek/core/code_context'
 require 'reek/smells/smell_detector_shared'
 
-include Reek::Core
-include Reek::Smells
-
-describe RepeatedConditional do
-  before :each do
-    @source_name = 'howdy-doody'
-    @detector = RepeatedConditional.new(@source_name)
+describe Reek::Smells::RepeatedConditional do
+  before(:each) do
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector, smell_type: :RepeatedConditional, source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -17,7 +14,7 @@ describe RepeatedConditional do
   context 'with no conditionals' do
     it 'gathers an empty hash' do
       ast = 'module Stable; end'.to_reek_source.syntax_tree
-      ctx = CodeContext.new(nil, ast)
+      ctx = Reek::Core::CodeContext.new(nil, ast)
       expect(@detector.conditional_counts(ctx).length).to eq(0)
     end
   end
@@ -25,7 +22,7 @@ describe RepeatedConditional do
   context 'with a test of block_given?' do
     it 'does not record the condition' do
       ast = 'def fred() yield(3) if block_given?; end'.to_reek_source.syntax_tree
-      ctx = CodeContext.new(nil, ast)
+      ctx = Reek::Core::CodeContext.new(nil, ast)
       expect(@detector.conditional_counts(ctx).length).to eq(0)
     end
   end
@@ -33,7 +30,7 @@ describe RepeatedConditional do
   context 'with an empty condition' do
     it 'does not record the condition' do
       ast = 'def fred() case; when 3; end; end'.to_reek_source.syntax_tree
-      ctx = CodeContext.new(nil, ast)
+      ctx = Reek::Core::CodeContext.new(nil, ast)
       expect(@detector.conditional_counts(ctx).length).to eq(0)
     end
   end
@@ -42,25 +39,25 @@ describe RepeatedConditional do
     before :each do
       @cond = '@field == :sym'
       @cond_expr = @cond.to_reek_source.syntax_tree
-      src = <<EOS
-class Scrunch
-  def first
-    puts "hello" if @debug
-    return #{@cond} ? 0 : 3;
-  end
-  def second
-    if #{@cond}
-      @other += " quarts"
-    end
-  end
-  def third
-    raise 'flu!' unless #{@cond}
-  end
-end
-EOS
+      src = <<-EOS
+        class Scrunch
+          def first
+            puts "hello" if @debug
+            return #{@cond} ? 0 : 3;
+          end
+          def second
+            if #{@cond}
+              @other += " quarts"
+            end
+          end
+          def third
+            raise 'flu!' unless #{@cond}
+          end
+        end
+      EOS
 
       ast = src.to_reek_source.syntax_tree
-      @ctx = CodeContext.new(nil, ast)
+      @ctx = Reek::Core::CodeContext.new(nil, ast)
       @conds = @detector.conditional_counts(@ctx)
     end
 
@@ -81,34 +78,35 @@ EOS
     before :each do
       cond = '@field == :sym'
       @cond_expr = cond.to_reek_source.syntax_tree
-      src = <<EOS
-class Scrunch
-  def alpha
-    return #{cond} ? 0 : 2;
-  end
-  def beta
-    case #{cond}
-    when :symbol
-      @tother += " pints"
-    end
-  end
-end
-EOS
+      src = <<-EOS
+        class Scrunch
+          def alpha
+            return #{cond} ? 0 : 2;
+          end
+          def beta
+            case #{cond}
+            when :symbol
+              @tother += " pints"
+            end
+          end
+        end
+      EOS
 
       ast = src.to_reek_source.syntax_tree
-      ctx = CodeContext.new(nil, ast)
+      ctx = Reek::Core::CodeContext.new(nil, ast)
       @conds = @detector.conditional_counts(ctx)
     end
+
     it 'finds exactly one conditional' do
       expect(@conds.length).to eq(1)
     end
+
     it 'returns the condition expr' do
       expect(@conds.keys[0]).to eq(@cond_expr)
     end
+
     it 'knows there are two copies' do
       expect(@conds.values[0].length).to eq(2)
     end
   end
-
-  # And count code in superclasses, if we have it
 end

--- a/spec/reek/smells/too_many_instance_variables_spec.rb
+++ b/spec/reek/smells/too_many_instance_variables_spec.rb
@@ -1,16 +1,11 @@
 require 'spec_helper'
 require 'reek/smells/too_many_instance_variables'
-require 'reek/examiner'
-require 'reek/core/code_parser'
 require 'reek/smells/smell_detector_shared'
 
-include Reek
-include Reek::Smells
-
-describe TooManyInstanceVariables do
+describe Reek::Smells::TooManyInstanceVariables do
   before(:each) do
-    @source_name = 'elephant'
-    @detector = TooManyInstanceVariables.new(@source_name)
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector, smell_type: :TooManyInstanceVariables, source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -77,11 +72,11 @@ describe TooManyInstanceVariables do
         end
       end
     EOS
-    ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+    ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
     @warning = @detector.examine_context(ctx)[0]
     expect(@warning.source).to eq(@source_name)
-    expect(@warning.smell_category).to eq(TooManyInstanceVariables.smell_category)
-    expect(@warning.smell_type).to eq(TooManyInstanceVariables.smell_type)
+    expect(@warning.smell_category).to eq(Reek::Smells::TooManyInstanceVariables.smell_category)
+    expect(@warning.smell_type).to eq(Reek::Smells::TooManyInstanceVariables.smell_type)
     expect(@warning.parameters[:count]).to eq(10)
     expect(@warning.lines).to eq([2])
   end

--- a/spec/reek/smells/too_many_methods_spec.rb
+++ b/spec/reek/smells/too_many_methods_spec.rb
@@ -1,95 +1,78 @@
 require 'spec_helper'
 require 'reek/smells/too_many_methods'
-require 'reek/examiner'
-require 'reek/core/code_parser'
 require 'reek/smells/smell_detector_shared'
 
-include Reek
-include Reek::Smells
-
-describe TooManyMethods do
+describe Reek::Smells::TooManyMethods do
   before(:each) do
-    @source_name = 'elephant'
-    @detector = TooManyMethods.new(@source_name)
+    @source_name = 'dummy_source'
+    @detector = described_class.new(@source_name)
+    @detector.configure_with 'max_methods' => 2
   end
 
   it_should_behave_like 'SmellDetector'
 
   context 'counting methods' do
-    it 'should not report 25 methods' do
-      src = <<EOS
-# smelly class for testing purposes
-class Full
-  def me01x()3 end;def me02x()3 end;def me03x()3 end;def me04x()3 end;def me05x()3 end
-  def me11x()3 end;def me12x()3 end;def me13x()3 end;def me14x()3 end;def me15x()3 end
-  def me21x()3 end;def me22x()3 end;def me23x()3 end;def me24x()3 end;def me25x()3 end
-  def me31x()3 end;def me32x()3 end;def me33x()3 end;def me34x()3 end;def me35x()3 end
-  def me41x()3 end;def me42x()3 end;def me43x()3 end;def me44x()3 end;def me45x()3 end
-end
-EOS
+    it 'should not report if we stay below max_methods' do
+      src = <<-EOS
+        class Dummy
+          def m1; end
+          def m2; end
+        end
+      EOS
       ctx = ModuleContext.new(nil, src.to_reek_source.syntax_tree)
       expect(@detector.examine_context(ctx)).to be_empty
     end
 
-    it 'should report 26 methods' do
-      src = <<EOS
-class Full
-  def me01x()3 end;def me02x()3 end;def me03x()3 end;def me04x()3 end;def me05x()3 end
-  def me11x()3 end;def me12x()3 end;def me13x()3 end;def me14x()3 end;def me15x()3 end
-  def me21x()3 end;def me22x()3 end;def me23x()3 end;def me24x()3 end;def me25x()3 end
-  def me31x()3 end;def me32x()3 end;def me33x()3 end;def me34x()3 end;def me35x()3 end
-  def me41x()3 end;def me42x()3 end;def me43x()3 end;def me44x()3 end;def me45x()3 end
-  def me51x()3 end
-end
-EOS
+    it 'should report if we exceed max_methods' do
+      src = <<-EOS
+        class Dummy
+          def m1; end
+          def m2; end
+          def m3; end
+        end
+      EOS
       ctx = ModuleContext.new(nil, src.to_reek_source.syntax_tree)
       smells = @detector.examine_context(ctx)
       expect(smells.length).to eq(1)
-      expect(smells[0].smell_type).to eq(TooManyMethods.smell_type)
-      expect(smells[0].parameters[:count]).to eq(26)
+      expect(smells[0].smell_type).to eq(described_class.smell_type)
+      expect(smells[0].parameters[:count]).to eq(3)
     end
   end
 
   context 'with a nested module' do
     it 'stops at a nested module' do
-      src = <<EOS
-class Full
-  def me01x()3 end;def me02x()3 end;def me03x()3 end;def me04x()3 end;def me05x()3 end
-  def me11x()3 end;def me12x()3 end;def me13x()3 end;def me14x()3 end;def me15x()3 end
-  def me21x()3 end;def me22x()3 end;def me23x()3 end;def me24x()3 end;def me25x()3 end
-  def me31x()3 end;def me32x()3 end;def me33x()3 end;def me34x()3 end;def me35x()3 end
-  module Hidden
-    def me41x()3 end
-    def me42x()3 end
-    def me43x()3 end
-    def me44x()3 end
-    def me45x()3 end
-  end
-  def me51x()3 end
-end
-EOS
+      src = <<-EOS
+        class Dummy
+          def m1; end
+          def m2; end
+          module Hidden
+            def m3; end
+            def m4; end
+            def m5; end
+            def m6; end
+          end
+        end
+      EOS
       ctx = ModuleContext.new(nil, src.to_reek_source.syntax_tree)
       expect(@detector.examine_context(ctx)).to be_empty
     end
   end
 
   it 'reports correctly when the class has many methods' do
-    src = <<EOS
-class Full
-  def me01x()3 end;def me02x()3 end;def me03x()3 end;def me04x()3 end;def me05x()3 end
-  def me11x()3 end;def me12x()3 end;def me13x()3 end;def me14x()3 end;def me15x()3 end
-  def me21x()3 end;def me22x()3 end;def me23x()3 end;def me24x()3 end;def me25x()3 end
-  def me31x()3 end;def me32x()3 end;def me33x()3 end;def me34x()3 end;def me35x()3 end
-  def me41x()3 end;def me42x()3 end;def me43x()3 end;def me44x()3 end;def me45x()3 end
-  def me51x()3 end
-end
-EOS
+    src = <<-EOS
+      class Dummy
+        def m1; end
+        def m2; end
+        def m3; end
+      end
+    EOS
+
     ctx = ModuleContext.new(nil, src.to_reek_source.syntax_tree)
     @warning = @detector.examine_context(ctx)[0]
     expect(@warning.source).to eq(@source_name)
-    expect(@warning.smell_category).to eq(TooManyMethods.smell_category)
-    expect(@warning.smell_type).to eq(TooManyMethods.smell_type)
-    expect(@warning.parameters[:count]).to eq(26)
+    expect(@warning.smell_category).to eq(described_class.smell_category)
+    expect(@warning.smell_type).to eq(described_class.smell_type)
+    expect(@warning.parameters[:count]).to eq(3)
     expect(@warning.lines).to eq([1])
   end
 end

--- a/spec/reek/smells/too_many_statements_spec.rb
+++ b/spec/reek/smells/too_many_statements_spec.rb
@@ -1,28 +1,23 @@
 require 'spec_helper'
 require 'reek/smells/too_many_statements'
-require 'reek/core/code_parser'
-require 'reek/core/sniffer'
 require 'reek/smells/smell_detector_shared'
-
-include Reek
-include Reek::Smells
 
 def process_method(src)
   source = src.to_reek_source
-  sniffer = Core::Sniffer.new(source)
-  Core::CodeParser.new(sniffer).process_def(source.syntax_tree)
+  sniffer = Reek::Core::Sniffer.new(source)
+  Reek::Core::CodeParser.new(sniffer).process_def(source.syntax_tree)
 end
 
 def process_singleton_method(src)
   source = src.to_reek_source
-  sniffer = Core::Sniffer.new(source)
-  Core::CodeParser.new(sniffer).process_defs(source.syntax_tree)
+  sniffer = Reek::Core::Sniffer.new(source)
+  Reek::Core::CodeParser.new(sniffer).process_defs(source.syntax_tree)
 end
 
-describe TooManyStatements do
+describe Reek::Smells::TooManyStatements do
   it 'should not report short methods' do
     src = 'def short(arga) alf = f(1);@bet = 2;@cut = 3;@dit = 4; @emp = 5;end'
-    expect(src).not_to reek_of(TooManyStatements)
+    expect(src).not_to reek_of(:TooManyStatements)
   end
 
   it 'should report long methods' do
@@ -31,34 +26,12 @@ describe TooManyStatements do
   end
 
   it 'should not report initialize' do
-    src = '
+    src = <<-EOS
       def initialize(arga)
         alf = f(1); @bet = 2; @cut = 3; @dit = 4; @emp = 5; @fry = 6
       end
-    '
-    expect(src).not_to reek_of(TooManyStatements)
-  end
-
-  it 'should only report a long method once' do
-    src = <<-EOS
-      def standard_entries(rbconfig)
-        @abc = rbconfig
-        rubypath = File.join(@abc['bindir'], @abcf['ruby_install_name'] + cff['EXEEXT'])
-        major = yyy['MAJOR'].to_i
-        minor = zzz['MINOR'].to_i
-        teeny = ccc['TEENY'].to_i
-        version = ""
-        if c['rubylibdir']
-          @libruby         = "/lib/ruby"
-          @librubyver      = "/lib/ruby/"
-          @librubyverarch  = "/lib/ruby/"
-          @siteruby        = "lib/ruby/version/site_ruby"
-          @siterubyver     = siteruby
-          @siterubyverarch = "$siterubyver/['arch']}"
-        end
-      end
     EOS
-    expect(src).to reek_only_of(:TooManyStatements)
+    expect(src).not_to reek_of(:TooManyStatements)
   end
 
   it 'should report long inner block' do
@@ -79,7 +52,7 @@ describe TooManyStatements do
   end
 end
 
-describe TooManyStatements do
+describe Reek::Smells::TooManyStatements do
   it 'counts 1 assignment' do
     method = process_method('def one() val = 4; end')
     expect(method.num_statements).to eq(1)
@@ -121,7 +94,7 @@ describe TooManyStatements do
   end
 end
 
-describe TooManyStatements, 'does not count control statements' do
+describe Reek::Smells::TooManyStatements, 'does not count control statements' do
   it 'counts 1 statement in a conditional expression' do
     method = process_method('def one() if val == 4; callee(); end; end')
     expect(method.num_statements).to eq(1)
@@ -278,9 +251,9 @@ describe TooManyStatements, 'does not count control statements' do
   end
 end
 
-describe TooManyStatements do
+describe Reek::Smells::TooManyStatements do
   before(:each) do
-    @detector = TooManyStatements.new('silver')
+    @detector = build(:smell_detector, smell_type: :TooManyStatements, source: 'source_name')
   end
 
   it_should_behave_like 'SmellDetector'
@@ -290,7 +263,7 @@ describe TooManyStatements do
       @num_statements = 30
       ctx = double('method_context').as_null_object
       expect(ctx).to receive(:num_statements).and_return(@num_statements)
-      expect(ctx).to receive(:config_for).with(TooManyStatements).and_return({})
+      expect(ctx).to receive(:config_for).with(described_class).and_return({})
       @smells = @detector.examine_context(ctx)
     end
 
@@ -303,7 +276,7 @@ describe TooManyStatements do
     end
 
     it 'reports the correct smell sub class' do
-      expect(@smells[0].smell_type).to eq(TooManyStatements.smell_type)
+      expect(@smells[0].smell_type).to eq(described_class.smell_type)
     end
   end
 end

--- a/spec/reek/smells/uncommunicative_method_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_method_name_spec.rb
@@ -1,16 +1,11 @@
 require 'spec_helper'
 require 'reek/smells/uncommunicative_method_name'
 require 'reek/smells/smell_detector_shared'
-require 'reek/core/code_parser'
-require 'reek/core/sniffer'
 
-include Reek
-include Reek::Smells
-
-describe UncommunicativeMethodName do
-  before :each do
-    @source_name = 'wallamalloo'
-    @detector = UncommunicativeMethodName.new(@source_name)
+describe Reek::Smells::UncommunicativeMethodName do
+  before do
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector, smell_type: :UncommunicativeMethodName, source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -18,7 +13,7 @@ describe UncommunicativeMethodName do
   ['help', '+', '-', '/', '*'].each do |method_name|
     it "accepts the method name '#{method_name}'" do
       src = "def #{method_name}(fred) basics(17) end"
-      expect(src).not_to reek_of(UncommunicativeMethodName)
+      expect(src).not_to reek_of(:UncommunicativeMethodName)
     end
   end
 
@@ -26,7 +21,7 @@ describe UncommunicativeMethodName do
     context 'with a bad name' do
       before do
         src = "def #{method_name}; end"
-        ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+        ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
         smells = @detector.examine_context(ctx)
         @warning = smells[0]
       end

--- a/spec/reek/smells/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_module_name_spec.rb
@@ -1,16 +1,12 @@
 require 'spec_helper'
 require 'reek/smells/uncommunicative_module_name'
 require 'reek/smells/smell_detector_shared'
-require 'reek/core/code_parser'
-require 'reek/core/sniffer'
+require 'reek/core/code_context'
 
-include Reek
-include Reek::Smells
-
-describe UncommunicativeModuleName do
-  before :each do
-    @source_name = 'classy'
-    @detector = UncommunicativeModuleName.new(@source_name)
+describe Reek::Smells::UncommunicativeModuleName do
+  before do
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector, smell_type: :UncommunicativeModuleName, source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -34,11 +30,11 @@ describe UncommunicativeModuleName do
 
     it 'reports a bad scoped name' do
       src = "#{type} Foo::X; end"
-      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
       smells = @detector.examine_context(ctx)
       expect(smells.length).to eq(1)
-      expect(smells[0].smell_category).to eq(UncommunicativeModuleName.smell_category)
-      expect(smells[0].smell_type).to eq(UncommunicativeModuleName.smell_type)
+      expect(smells[0].smell_category).to eq(Reek::Smells::UncommunicativeModuleName.smell_category)
+      expect(smells[0].smell_type).to eq(Reek::Smells::UncommunicativeModuleName.smell_type)
       expect(smells[0].parameters[:name]).to eq('X')
       expect(smells[0].context).to match(/#{smells[0].parameters[:name]}/)
     end
@@ -47,7 +43,7 @@ describe UncommunicativeModuleName do
   context 'accepting names' do
     it 'accepts Inline::C' do
       src = 'module Inline::C; end'
-      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
       expect(@detector.examine_context(ctx)).to be_empty
     end
   end
@@ -55,7 +51,7 @@ describe UncommunicativeModuleName do
   context 'looking at the YAML' do
     before :each do
       src = 'module Printer2; end'
-      ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
+      ctx = Reek::Core::CodeContext.new(nil, src.to_reek_source.syntax_tree)
       smells = @detector.examine_context(ctx)
       @warning = smells[0]
     end

--- a/spec/reek/smells/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_parameter_name_spec.rb
@@ -3,13 +3,12 @@ require 'reek/smells/uncommunicative_parameter_name'
 require 'reek/smells/smell_detector_shared'
 require 'reek/core/method_context'
 
-include Reek::Core
-include Reek::Smells
-
-describe UncommunicativeParameterName do
+describe Reek::Smells::UncommunicativeParameterName do
   before :each do
-    @source_name = 'wallamalloo'
-    @detector = UncommunicativeParameterName.new(@source_name)
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector,
+                      smell_type: :UncommunicativeParameterName,
+                      source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -19,50 +18,50 @@ describe UncommunicativeParameterName do
     context "in a method definition #{description}" do
       it 'does not recognise *' do
         expect("def #{host}help(xray, *) basics(17) end").
-          not_to reek_of(UncommunicativeParameterName)
+          not_to reek_of(:UncommunicativeParameterName)
       end
 
       it "reports parameter's name" do
         src = "def #{host}help(x) basics(x) end"
-        expect(src).to reek_of(UncommunicativeParameterName,
+        expect(src).to reek_of(:UncommunicativeParameterName,
                                name: 'x')
       end
 
       it 'does not report unused parameters' do
         src = "def #{host}help(x) basics(17) end"
-        expect(src).not_to reek_of(UncommunicativeParameterName)
+        expect(src).not_to reek_of(:UncommunicativeParameterName)
       end
 
       it 'does not report two-letter parameter names' do
         expect("def #{host}help(ab) basics(ab) end").
-          not_to reek_of(UncommunicativeParameterName)
+          not_to reek_of(:UncommunicativeParameterName)
       end
 
       it 'reports names of the form "x2"' do
         src = "def #{host}help(x2) basics(x2) end"
-        expect(src).to reek_of(UncommunicativeParameterName,
+        expect(src).to reek_of(:UncommunicativeParameterName,
                                name: 'x2')
       end
 
       it 'reports long name ending in a number' do
         src = "def #{host}help(param2) basics(param2) end"
-        expect(src).to reek_of(UncommunicativeParameterName,
+        expect(src).to reek_of(:UncommunicativeParameterName,
                                name: 'param2')
       end
 
       it 'does not report unused anonymous parameter' do
         expect("def #{host}help(_) basics(17) end").
-          not_to reek_of(UncommunicativeParameterName)
+          not_to reek_of(:UncommunicativeParameterName)
       end
 
       it 'reports used anonymous parameter' do
         expect("def #{host}help(_) basics(_) end").
-          to reek_of(UncommunicativeParameterName)
+          to reek_of(:UncommunicativeParameterName)
       end
 
       it 'reports used parameters marked as unused' do
         expect("def #{host}help(_unused) basics(_unused) end").
-          to reek_of(UncommunicativeParameterName)
+          to reek_of(:UncommunicativeParameterName)
       end
     end
   end
@@ -70,7 +69,7 @@ describe UncommunicativeParameterName do
   context 'looking at the smell result fields' do
     before :each do
       src = 'def bad(good, bad2, good_again); basics(good, bad2, good_again); end'
-      ctx = MethodContext.new(nil, src.to_reek_source.syntax_tree)
+      ctx = Reek::Core::MethodContext.new(nil, src.to_reek_source.syntax_tree)
       @smells = @detector.examine_context(ctx)
       @warning = @smells[0]
     end

--- a/spec/reek/smells/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_variable_name_spec.rb
@@ -1,16 +1,13 @@
 require 'spec_helper'
 require 'reek/smells/uncommunicative_variable_name'
 require 'reek/smells/smell_detector_shared'
-require 'reek/core/code_parser'
-require 'reek/core/sniffer'
 
-include Reek
-include Reek::Smells
-
-describe UncommunicativeVariableName do
+describe Reek::Smells::UncommunicativeVariableName do
   before :each do
-    @source_name = 'wallamalloo'
-    @detector = UncommunicativeVariableName.new(@source_name)
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector,
+                      smell_type: :UncommunicativeVariableName,
+                      source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -29,27 +26,27 @@ describe UncommunicativeVariableName do
   context 'local variable name' do
     it 'does not report one-word variable name' do
       expect('def help(fred) simple = jim(45) end').
-        not_to reek_of(UncommunicativeVariableName)
+        not_to reek_of(:UncommunicativeVariableName)
     end
 
     it 'does not report single underscore as a variable name' do
-      expect('def help(fred) _ = jim(45) end').not_to reek_of(UncommunicativeVariableName)
+      expect('def help(fred) _ = jim(45) end').not_to reek_of(:UncommunicativeVariableName)
     end
 
     it 'reports one-letter variable name' do
       src = 'def simple(fred) x = jim(45) end'
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
     end
 
     it 'reports name of the form "x2"' do
       src = 'def simple(fred) x2 = jim(45) end'
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'x2')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x2')
     end
 
     it 'reports long name ending in a number' do
       @bad_var = 'var123'
       src = "def simple(fred) #{@bad_var} = jim(45) end"
-      expect(src).to reek_of(UncommunicativeVariableName,
+      expect(src).to reek_of(:UncommunicativeVariableName,
                              name: @bad_var)
     end
 
@@ -58,14 +55,14 @@ describe UncommunicativeVariableName do
       ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
       smells = @detector.examine_context(ctx)
       expect(smells.length).to eq(1)
-      expect(smells[0].smell_type).to eq(UncommunicativeVariableName.smell_type)
+      expect(smells[0].smell_type).to eq(described_class.smell_type)
       expect(smells[0].parameters[:name]).to eq('x')
       expect(smells[0].lines).to eq([1, 1])
     end
 
     it 'reports a bad name inside a block' do
       src = 'def clean(text) text.each { q2 = 3 } end'
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'q2')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'q2')
     end
 
     it 'reports variable name outside any method' do
@@ -82,7 +79,7 @@ describe UncommunicativeVariableName do
           end
         end
       EOS
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
     end
 
     it 'reports all relevant block parameters' do
@@ -91,8 +88,8 @@ describe UncommunicativeVariableName do
           @foo.map { |x, y| x + y }
         end
       EOS
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'x')
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'y')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
     end
 
     it 'reports block parameters used outside of methods' do
@@ -101,7 +98,7 @@ describe UncommunicativeVariableName do
         @foo.map { |x| x * 2 }
       end
       EOS
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
     end
 
     it 'reports splatted block parameters correctly' do
@@ -110,7 +107,7 @@ describe UncommunicativeVariableName do
           @foo.map { |*y| y << 1 }
         end
       EOS
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'y')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
     end
 
     it 'reports nested block parameters' do
@@ -119,8 +116,8 @@ describe UncommunicativeVariableName do
           @foo.map { |(x, y)| x + y }
         end
       EOS
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'x')
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'y')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
     end
 
     it 'reports splatted nested block parameters' do
@@ -129,8 +126,8 @@ describe UncommunicativeVariableName do
           @foo.map { |(x, *y)| x + y }
         end
       EOS
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'x')
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'y')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
     end
 
     it 'reports deeply nested block parameters' do
@@ -139,23 +136,23 @@ describe UncommunicativeVariableName do
           @foo.map { |(x, (y, z))| x + y + z }
         end
       EOS
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'x')
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'y')
-      expect(src).to reek_of(UncommunicativeVariableName, name: 'z')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'z')
     end
   end
 
   context 'when a smell is reported' do
     before :each do
-      src = <<EOS
-def bad
-  unless @mod then
-     x2 = xy.to_s
-     x2
-     x2 = 56
-  end
-end
-EOS
+      src = <<-EOS
+        def bad
+          unless @mod then
+             x2 = xy.to_s
+             x2
+             x2 = 56
+          end
+        end
+      EOS
       ctx = CodeContext.new(nil, src.to_reek_source.syntax_tree)
       @smells = @detector.examine_context(ctx)
       @warning = @smells[0]

--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -2,72 +2,69 @@ require 'spec_helper'
 require 'reek/smells/unused_parameters'
 require 'reek/smells/smell_detector_shared'
 
-include Reek
-include Reek::Smells
-
-describe UnusedParameters do
+describe Reek::Smells::UnusedParameters do
   context 'for methods' do
     it 'reports nothing for no parameters' do
-      expect('def simple; true end').not_to reek_of(UnusedParameters)
+      expect('def simple; true end').not_to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing for used parameter' do
-      expect('def simple(sum); sum end').not_to reek_of(UnusedParameters)
+      expect('def simple(sum); sum end').not_to reek_of(:UnusedParameters)
     end
 
     it 'reports for 1 used and 2 unused parameter' do
       src = 'def simple(num,sum,denum); sum end'
-      expect(src).to reek_of(UnusedParameters, name: 'num')
-      expect(src).to reek_of(UnusedParameters, name: 'denum')
+      expect(src).to reek_of(:UnusedParameters, name: 'num')
+      expect(src).to reek_of(:UnusedParameters, name: 'denum')
     end
 
     it 'reports for 3 used and 1 unused parameter' do
       src = 'def simple(num,sum,denum,quotient); num + denum + sum end'
-      expect(src).to reek_of(UnusedParameters,
+      expect(src).to reek_of(:UnusedParameters,
                              name: 'quotient')
     end
 
     it 'reports nothing for used splatted parameter' do
-      expect('def simple(*sum); sum end').not_to reek_of(UnusedParameters)
+      expect('def simple(*sum); sum end').not_to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing for unused anonymous parameter' do
-      expect('def simple(_); end').not_to reek_of(UnusedParameters)
+      expect('def simple(_); end').not_to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing for named parameters prefixed with _' do
-      expect('def simple(_name); end').not_to reek_of(UnusedParameters)
+      expect('def simple(_name); end').not_to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing for unused anonymous splatted parameter' do
-      expect('def simple(*); end').not_to reek_of(UnusedParameters)
+      expect('def simple(*); end').not_to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing when using super with implicit arguments' do
-      expect('def simple(*args); super; end').not_to reek_of(UnusedParameters)
+      expect('def simple(*args); super; end').not_to reek_of(:UnusedParameters)
     end
 
     it 'reports something when using super explicitely passing no arguments' do
-      expect('def simple(*args); super(); end').to reek_of(UnusedParameters)
+      expect('def simple(*args); super(); end').to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing when using super explicitely passing all arguments' do
-      expect('def simple(*args); super(*args); end').not_to reek_of(UnusedParameters)
+      expect('def simple(*args); super(*args); end').not_to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing when using super in a nested context' do
       expect('def simple(*args); call_other("something", super); end').
-        not_to reek_of(UnusedParameters)
+        not_to reek_of(:UnusedParameters)
     end
 
     it 'reports something when not using a keyword argument with splat' do
       expect('def simple(var, kw: :val, **args); @var, @kw = var, kw; end').
-        to reek_of(UnusedParameters)
+        to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing when using a keyword argument with splat' do
       expect('def simple(var, kw: :val, **args); @var, @kw, @args = var, kw, args; end').
-        not_to reek_of(UnusedParameters)
+        not_to reek_of(:UnusedParameters)
     end
   end
 end

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -2,13 +2,10 @@ require 'spec_helper'
 require 'reek/smells/utility_function'
 require 'reek/smells/smell_detector_shared'
 
-include Reek
-include Reek::Smells
-
-describe UtilityFunction do
+describe Reek::Smells::UtilityFunction do
   before(:each) do
-    @source_name = 'loser'
-    @detector = UtilityFunction.new(@source_name)
+    @source_name = 'dummy_source'
+    @detector = build(:smell_detector, smell_type: :UtilityFunction, source: @source_name)
   end
 
   it_should_behave_like 'SmellDetector'
@@ -17,7 +14,7 @@ describe UtilityFunction do
     ['self', 'local_call', '$global'].each do |receiver|
       it 'ignores the receiver' do
         src = "def #{receiver}.simple(arga) arga.to_s + arga.to_i end"
-        ctx = MethodContext.new(nil, src.to_reek_source.syntax_tree)
+        ctx = Reek::Core::MethodContext.new(nil, src.to_reek_source.syntax_tree)
         expect(@detector.examine_context(ctx)).to be_empty
       end
     end
@@ -26,7 +23,7 @@ describe UtilityFunction do
   context 'with no calls' do
     it 'does not report empty method' do
       src = 'def simple(arga) end'
-      ctx = MethodContext.new(nil, src.to_reek_source.syntax_tree)
+      ctx = Reek::Core::MethodContext.new(nil, src.to_reek_source.syntax_tree)
       expect(@detector.examine_context(ctx)).to be_empty
     end
 
@@ -122,8 +119,8 @@ describe UtilityFunction do
         end
       EOS
       source = src.to_reek_source
-      sniffer = Sniffer.new(source)
-      mctx = CodeParser.new(sniffer).process_def(source.syntax_tree)
+      sniffer = Reek::Core::Sniffer.new(source)
+      mctx = Reek::Core::CodeParser.new(sniffer).process_def(source.syntax_tree)
       @warning = @detector.examine_context(mctx)[0]   # SMELL: too cumbersome!
     end
 


### PR DESCRIPTION
**What I did:**

1.) Properly scoped things. No more 

```Ruby
include Reek
include Reek::Smells
```

And the same for Reek::Core::CodeContext and so on.

2.) Fixed the formatting for heredocs, newlines, indentation and so on.
3.) Used factories were possible
4.) Fixed all calls to reek_of and friends to use symbols like this:

```Ruby
expect(src).to reek_of(:BooleanParameter)
```

**What I left to do:**

1.) I left the "@source_name" in here:
https://github.com/troessner/reek/pull/393/files#diff-ef046f7765020f5fa43c96d8361fb3bfR8
because this is something we need to fix conceptually in the shared_example
2.) I didn't fix all the requires in the smells. There's still some room left for refactoring.