### PR TITLE
Escape Regexp-like Strings on CodeContext matches

### DIFF
--- a/lib/reek/core/code_context.rb
+++ b/lib/reek/core/code_context.rb
@@ -29,7 +29,10 @@ module Reek
 
       def matches?(candidates)
         my_fq_name = full_name
-        candidates.any? { |str| /#{str}/ =~ my_fq_name }
+        candidates.any? do |candidate|
+          candidate = Regexp.quote(candidate) if candidate.is_a?(String)
+          /#{candidate}/ =~ my_fq_name
+        end
       end
 
       #

--- a/spec/reek/core/code_context_spec.rb
+++ b/spec/reek/core/code_context_spec.rb
@@ -25,11 +25,17 @@ describe CodeContext do
     it 'does not match when its own short name is not given' do
       expect(@ctx.matches?(['banana'])).to eq(false)
     end
+    it 'does not let pipe-ended Strings make matching ignore the rest' do
+      expect(@ctx.matches?(['banana|'])).to eq(false)
+    end
     it 'recognises its own short name' do
       expect(@ctx.matches?(['banana', @exp_name])).to eq(true)
     end
     it 'recognises its short name as a regex' do
       expect(@ctx.matches?([/banana/, /#{@exp_name}/])).to eq(true)
+    end
+    it 'does not blow up on []-ended Strings' do
+      expect(@ctx.matches?(['banana[]', @exp_name])).to eq(true)
     end
 
     context 'when there is an outer' do


### PR DESCRIPTION
I recently noticed a bug where a `|`-ending entry in an `exclude` config setting for a given smell would effectively exclude everything from the given smell; the below excludes _all_ methods (not just `Foo#|`) from being checked aginst `UncommunicativeVariableName`:

```yaml
UncommunicativeVariableName:
  exclude:
    - Foo#|
```

Today I noticed a bug where a `[]`-ending entry blows up the whole tool; the below makes Reek not work at all:

```yaml
UncommunicativeParameterName:
  exclude:
    - Bar#self.[]
```

I tracked down the culprit of both of these cases – the excludes were treated as regular expressions rather than straight strings.