### PR TITLE
Adds JSON output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ If you don't feel like getting your hands dirty with code there are still other 
 * plain text (default)
 * html (`--format html`)
 * yaml (`--format yaml`)
+* json (`--format json`)
 
 ## Additional resources
 

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -38,6 +38,7 @@ Feature: Reek can be controlled using command-line options
                                              html
                                              text (default)
                                              yaml
+                                             json
 
       Text format options:
               --[no-]color                 Use colors for the output (this is the default)

--- a/features/reports/json.feature
+++ b/features/reports/json.feature
@@ -1,0 +1,73 @@
+Feature: Report smells using simple JSON layout
+  In order to parse reek's output simply and consistently, simply
+  output a list of smells in JSON.
+
+  Scenario: output is empty when there are no smells
+    When I run reek --format json spec/samples/three_clean_files
+    Then it succeeds
+    And it reports this JSON:
+    """
+    []
+    """
+
+  Scenario: Indicate smells and print them as JSON when using files
+    When I run reek --format json spec/samples/standard_smelly/minimal_dirty.rb
+    Then the exit status indicates smells
+    And it reports this JSON:
+      """
+      [
+          {
+              "smell_category": "IrresponsibleModule",
+              "smell_type": "IrresponsibleModule",
+              "source": "spec/samples/standard_smelly/minimal_dirty.rb",
+              "context": "C",
+              "lines": [
+                  1
+              ],
+              "message": "has no descriptive comment",
+              "name": "C"
+          },
+          {
+              "smell_category": "UncommunicativeName",
+              "smell_type": "UncommunicativeModuleName",
+              "source": "spec/samples/standard_smelly/minimal_dirty.rb",
+              "context": "C",
+              "lines": [
+                  1
+              ],
+              "message": "has the name 'C'",
+              "name": "C"
+          },
+          {
+              "smell_category": "UncommunicativeName",
+              "smell_type": "UncommunicativeMethodName",
+              "source": "spec/samples/standard_smelly/minimal_dirty.rb",
+              "context": "C#m",
+              "lines": [
+                  2
+              ],
+              "message": "has the name 'm'",
+              "name": "m"
+          }
+      ]
+      """
+
+  Scenario: Indicate smells and print them as JSON when using STDIN
+    When I pass "class Turn; end" to reek --format json
+    Then the exit status indicates smells
+    And it reports this JSON:
+      """
+      [
+          {
+              "smell_category": "IrresponsibleModule",
+              "smell_type": "IrresponsibleModule",
+              "source": "$stdin",
+              "context": "Turn",
+              "lines": [
+                  1
+              ],
+              "message": "has no descriptive comment",
+              "name": "Turn"
+          }
+      ]
+      """

--- a/features/step_definitions/reek_steps.rb
+++ b/features/step_definitions/reek_steps.rb
@@ -44,6 +44,12 @@ Then /^it reports this yaml:$/ do |expected_yaml|
   expect(actual_warnings).to eq expected_warnings
 end
 
+Then /^it reports this JSON:$/ do |expected_json|
+  expected_warnings = JSON.parse(expected_json.chomp)
+  actual_warnings = JSON.parse(@last_stdout)
+  expect(actual_warnings).to eq expected_warnings
+end
+
 Then /^stderr reports:$/ do |report|
   expect(@last_stderr).to eq report
 end

--- a/lib/reek/cli/option_interpreter.rb
+++ b/lib/reek/cli/option_interpreter.rb
@@ -34,6 +34,8 @@ module Reek
         case @options.report_format
         when :yaml
           Report::YamlReport
+        when :json
+          Report::JsonReport
         when :html
           Report::HtmlReport
         else # :text

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -52,9 +52,9 @@ module Reek
       def set_alternative_formatter_options
         @parser.separator "\nReport format:"
         @parser.on(
-          '-f', '--format FORMAT', [:html, :text, :yaml],
+          '-f', '--format FORMAT', [:html, :text, :yaml, :json],
           'Report smells in the given format:',
-          '  html', '  text (default)', '  yaml'
+          '  html', '  text (default)', '  yaml', '  json'
         ) do |opt|
           @options.report_format = opt
         end

--- a/lib/reek/cli/report/report.rb
+++ b/lib/reek/cli/report/report.rb
@@ -1,4 +1,5 @@
 require 'rainbow'
+require 'json'
 
 module Reek
   module Cli
@@ -98,6 +99,15 @@ module Reek
       class YamlReport < Base
         def show
           print smells.map(&:yaml_hash).to_yaml
+        end
+      end
+
+      #
+      # Displays a list of smells in JSON format
+      # JSON with empty array for 0 smells
+      class JsonReport < Base
+        def show
+          print ::JSON.generate(smells.map(&:yaml_hash))
         end
       end
 

--- a/spec/reek/cli/json_report_spec.rb
+++ b/spec/reek/cli/json_report_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'reek/examiner'
+require 'reek/cli/report/report'
+require 'reek/cli/report/formatter'
+
+describe Reek::Cli::Report::JsonReport do
+  let(:instance) { Reek::Cli::Report::JsonReport.new }
+
+  context 'empty source' do
+    let(:examiner) { Reek::Examiner.new('') }
+
+    before do
+      instance.add_examiner examiner
+    end
+
+    it 'prints empty json' do
+      expect { instance.show }.to output(/^\[\]$/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
Includes both rspec and cucumber tests as seen on the yaml report.
_____

I needed JSON output while setting up a CI with Reek. I was using the YamlReport and `YAML.parse(output).to_ruby` to get a Hash, but I thought this could be useful for others as well.

I'm getting some 1 failure on rspec and 1 on cucumber, but they are not related to the files changed on this PR. I'm getting the same failures when pulling from master. Maybe is something on my local setup, so I thought I'll give this a try. 