### PR TITLE
Rake task: drop the no longer supported --quiet option

### DIFF
--- a/tasks/reek.rake
+++ b/tasks/reek.rake
@@ -3,5 +3,4 @@ require 'reek/rake/task'
 Reek::Rake::Task.new do |t|
   t.fail_on_error = true
   t.verbose = false
-  t.reek_opts = '--quiet'
 end


### PR DESCRIPTION
Running `rake reek` on the current master blows up with the `invalid option: --quiet` error.