### PR TITLE
Fix version command.

### DIFF
--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -2,6 +2,7 @@ require 'optparse'
 require 'ostruct'
 require 'rainbow'
 require 'reek/cli/option_interpreter'
+require 'reek/version'
 
 module Reek
   module Cli


### PR DESCRIPTION
The version command using the latest gem version fails:

>>   ( $ ) reek -v
/home/timo/.rvm/gems/ruby-2.1.1/gems/reek-2.0.1/lib/reek/cli/options.rb:125:in `block in set_utility_options': uninitialized constant Reek::Version (NameError)
	from /home/timo/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/optparse.rb:1390:in `call'
	from /home/timo/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/optparse.rb:1390:in `block in parse_in_order'
	from /home/timo/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/optparse.rb:1346:in `catch'
	from /home/timo/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/optparse.rb:1346:in `parse_in_order'
	from /home/timo/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/optparse.rb:1340:in `order!'
	from /home/timo/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/optparse.rb:1432:in `permute!'
	from /home/timo/.rvm/rubies/ruby-2.1.1/lib/ruby/2.1.0/optparse.rb:1454:in `parse!'
	from /home/timo/.rvm/gems/ruby-2.1.1/gems/reek-2.0.1/lib/reek/cli/options.rb:20:in `parse'
	from /home/timo/.rvm/gems/ruby-2.1.1/gems/reek-2.0.1/lib/reek/cli/application.rb:21:in `initialize'
	from /home/timo/.rvm/gems/ruby-2.1.1/gems/reek-2.0.1/bin/reek:11:in `new'
	from /home/timo/.rvm/gems/ruby-2.1.1/gems/reek-2.0.1/bin/reek:11:in `<top (required)>'
	from /home/timo/.rvm/gems/ruby-2.1.1/bin/reek:23:in `load'
	from /home/timo/.rvm/gems/ruby-2.1.1/bin/reek:23:in `<main>'
	from /home/timo/.rvm/gems/ruby-2.1.1/bin/ruby_executable_hooks:15:in `eval'
	from /home/timo/.rvm/gems/ruby-2.1.1/bin/ruby_executable_hooks:15:in `<main>'

This does not happen when you are in reek's working directory but somewhere else on your filesystem. I assume this is because of our weird "Use the local reek version when calling reek from the reek working directory. But still require reek to be installed properly" - logic (something we should fix, but that's another story), which is probably why none of us noticed the problem.:)
This pull request fixes the problem.