### PR TITLE
A variable can also be a shadowarg

### DIFF
--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -107,6 +107,8 @@ module Reek
           case subexp.type
           when :mlhs
             recursively_record_variable_names(accumulator, subexp)
+          when :shadowarg
+            record_variable_name(exp, subexp.shadowarg, accumulator)
           else
             record_variable_name(exp, subexp.name, accumulator)
           end


### PR DESCRIPTION
There is some little-known syntax which allows you to create a shadow variable, like:

    def foo(x)
        x.each do |thing ; x, y |
          #... x is local, not the param; y is also a local shadowarg
        end
    end

I'm not sure where a good place to put a test for this is -- let me know and I'll add one.