### PR TITLE
Allow all formatters to support -U (wiki links)

### DIFF
--- a/lib/reek/smell_warning.rb
+++ b/lib/reek/smell_warning.rb
@@ -42,7 +42,7 @@ module Reek
       listener.found_smell(self)
     end
 
-    def yaml_hash
+    def yaml_hash(warning_formatter = nil)
       result = {
         'smell_category' => smell_detector.smell_category,
         'smell_type'     => smell_detector.smell_type,
@@ -51,6 +51,9 @@ module Reek
         'lines'          => lines,
         'message'        => message
       }
+      if warning_formatter.respond_to?(:explanatory_link)
+        result.merge!('wiki_link' => warning_formatter.explanatory_link(smell_detector))
+      end
       parameters.each do |key, value|
         result[key.to_s] = value
       end


### PR DESCRIPTION
JSON and YAML report formatters ignored the -U (wiki link) flag. This pull request enables all report formatters to respect this option.