### PR TITLE
Tinycleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 ## Overview
 
 
-[![Build Status](https://secure.travis-ci.org/troessner/reek.png?branch=master)](http://travis-ci.org/troessner/reek?branch=master)
-[![Gem Version](https://badge.fury.io/rb/reek.png)](http://badge.fury.io/rb/reek)
+[![Build Status](https://secure.travis-ci.org/troessner/reek.png?branch=master)](https://travis-ci.org/troessner/reek?branch=master)
+[![Gem Version](https://badge.fury.io/rb/reek.png)](https://badge.fury.io/rb/reek)
 [![Dependency Status](https://gemnasium.com/troessner/reek.png)](https://gemnasium.com/troessner/reek)
-[![Inline docs](http://inch-ci.org/github/troessner/reek.png)](http://inch-ci.org/github/troessner/reek)
+[![Inline docs](https://inch-ci.org/github/troessner/reek.png)](https://inch-ci.org/github/troessner/reek)
 
 ## Quickstart
 
@@ -228,7 +228,7 @@ Colorful output for `reek`: [Preek](https://github.com/joenas/preek) (also with
 
 ### Find out more:
 
-* [Stack Overflow](http://stackoverflow.com/questions/tagged/reek)
+* [Stack Overflow](https://stackoverflow.com/questions/tagged/reek)
 * [RDoc](http://rdoc.info/projects/troessner/reek)
 
 ## Contributors

--- a/bin/reek
+++ b/bin/reek
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #
 # Reek examines Ruby source code for smells.
-# Visit http://wiki.github.com/troessner/reek for docs etc.
+# Visit https://wiki.github.com/troessner/reek for docs etc.
 #
 # Author: Kevin Rutherford
 #

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -31,7 +31,7 @@ Feature: Reek can be controlled using command-line options
 
       Configuration:
           -c, --config FILE                Read configuration options from FILE
-              --smell SMELL                Detect smell SMELL (default is all enabled smells)
+              --smell SMELL                Detect smell SMELL (default: all enabled smells)
 
       Report format:
           -f, --format FORMAT              Report smells in the given format:
@@ -41,10 +41,10 @@ Feature: Reek can be controlled using command-line options
                                              json
 
       Text format options:
-              --[no-]color                 Use colors for the output (this is the default)
-          -V, --[no-]empty-headings        Show headings for smell-free source files
-          -U, --[no-]wiki-links            Show link to related Reek wiki page for each smell
-          -n, --[no-]line-numbers          Show line numbers in the output (this is the default)
+              --[no-]color                 Use colors for the output (default: true)
+          -V, --[no-]empty-headings        Show headings for smell-free source files (default: false)
+          -U, --[no-]wiki-links            Show link to related wiki page for each smell (default: false)
+          -n, --[no-]line-numbers          Show line numbers in the output (default: true)
           -s, --single-line                Show location in editor-compatible single-line-per-smell format
               --sort-by SORTING            Sort reported files by the given criterium:
                                              smelliness ("smelliest" files first)

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -27,7 +27,7 @@ Feature: Reek can be controlled using command-line options
       reek -s lib
       cat my_class.rb | reek
 
-      See http://wiki.github.com/troessner/reek for detailed help.
+      See https://wiki.github.com/troessner/reek for detailed help.
 
       Configuration:
           -c, --config FILE                Read configuration options from FILE

--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -15,7 +15,7 @@ module Reek
       STATUS_SMELLS  = 2
 
       def initialize(argv)
-        @status  = STATUS_SUCCESS
+        @status = STATUS_SUCCESS
         options_parser = Options.new(argv)
         begin
           @options = options_parser.parse

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -66,7 +66,7 @@ module Reek
         @parser.on('-c', '--config FILE', 'Read configuration options from FILE') do |file|
           @options.config_file = file
         end
-        @parser.on('--smell SMELL', 'Detect smell SMELL (default is: all enabled smells)') do |smell|
+        @parser.on('--smell SMELL', 'Detect smell SMELL (default: all enabled smells)') do |smell|
           @options.smells_to_detect << smell
         end
       end
@@ -87,11 +87,11 @@ module Reek
 
       def set_up_verbosity_options
         @parser.on('-V', '--[no-]empty-headings',
-                   'Show headings for smell-free source files (default:false)') do |show_empty|
+                   'Show headings for smell-free source files (default: false)') do |show_empty|
           @options.show_empty = show_empty
         end
         @parser.on('-U', '--[no-]wiki-links',
-                   'Show link to related Reek wiki page for each smell (default:false)') do |show_links|
+                   'Show link to related wiki page for each smell (default: false)') do |show_links|
           @options.show_links = show_links
         end
       end

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -45,7 +45,7 @@ module Reek
           #{program_name} -s lib
           cat my_class.rb | #{program_name}
 
-          See http://wiki.github.com/troessner/reek for detailed help.
+          See https://wiki.github.com/troessner/reek for detailed help.
 
         EOB
       end

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -66,7 +66,7 @@ module Reek
         @parser.on('-c', '--config FILE', 'Read configuration options from FILE') do |file|
           @options.config_file = file
         end
-        @parser.on('--smell SMELL', 'Detect smell SMELL (default is all enabled smells)') do |smell|
+        @parser.on('--smell SMELL', 'Detect smell SMELL (default is: all enabled smells)') do |smell|
           @options.smells_to_detect << smell
         end
       end
@@ -80,25 +80,25 @@ module Reek
       end
 
       def set_up_color_option
-        @parser.on('--[no-]color', 'Use colors for the output (this is the default)') do |opt|
+        @parser.on('--[no-]color', 'Use colors for the output (default: true)') do |opt|
           @options.colored = opt
         end
       end
 
       def set_up_verbosity_options
         @parser.on('-V', '--[no-]empty-headings',
-                   'Show headings for smell-free source files') do |show_empty|
+                   'Show headings for smell-free source files (default:false)') do |show_empty|
           @options.show_empty = show_empty
         end
         @parser.on('-U', '--[no-]wiki-links',
-                   'Show link to related Reek wiki page for each smell') do |show_links|
+                   'Show link to related Reek wiki page for each smell (default:false)') do |show_links|
           @options.show_links = show_links
         end
       end
 
       def set_up_location_formatting_options
         @parser.on('-n', '--[no-]line-numbers',
-                   'Show line numbers in the output (this is the default)') do |show_numbers|
+                   'Show line numbers in the output (default: true)') do |show_numbers|
           @options.location_format = show_numbers ? :numbers : :plain
         end
         @parser.on('-s', '--single-line',

--- a/lib/reek/cli/report/formatter.rb
+++ b/lib/reek/cli/report/formatter.rb
@@ -4,8 +4,9 @@ module Reek
   module Cli
     module Report
       #
-      # Formatter handling the formatting of the report at large. Formatting
-      # the individual warnings is handled by the warning formatter passed in.
+      # Formatter handling the formatting of the report at large.
+      # Formatting of the individual warnings is handled by the
+      # passed-in warning formatter.
       #
       module Formatter
         def self.format_list(warnings, formatter = SimpleWarningFormatter.new)
@@ -25,7 +26,7 @@ module Reek
 
       #
       # Basic formatter that just shows a simple message for each warning,
-      # pre-pended with the result of the passed-in location formatter.
+      # prepended with the result of the passed-in location formatter.
       #
       class SimpleWarningFormatter
         def initialize(location_formatter = BlankLocationFormatter)
@@ -44,7 +45,7 @@ module Reek
       end
 
       #
-      # Formatter that adds a link to the Wiki to the basic message from
+      # Formatter that adds a link to the wiki to the basic message from
       # SimpleWarningFormatter.
       #
       class WikiLinkWarningFormatter < SimpleWarningFormatter

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
                 'Rakefile', 'assets/html_output.html.erb', 'bin/reek',
                 'config/defaults.reek', '{features,lib,spec,tasks}/**/*',
                 'reek.gemspec'] & `git ls-files -z`.split("\0")
-  s.homepage = 'http://wiki.github.com/troessner/reek'
+  s.homepage = 'https://wiki.github.com/troessner/reek'
   s.rdoc_options = ['--main', 'README.md',
                     '-x', 'assets/|bin/|config/|features/|spec/|tasks/']
   s.require_paths = ['lib']


### PR DESCRIPTION
@tuexss’s contribution from #414 with a passing spec:

> Small cleanup commit for more transparent help-output, moving external links http->https, and some minor typos/formatting issues.