### PR TITLE
Unify recorded references to lvar and lvasgn

### DIFF
--- a/lib/reek/core/method_context.rb
+++ b/lib/reek/core/method_context.rb
@@ -41,9 +41,9 @@ module Reek
         receiver ||= [:self]
         case receiver[0]
         when :lvasgn
-          @refs.record_reference_to(receiver.updated(:lvar))
+          @refs.record_reference_to(receiver.name)
         when :lvar
-          @refs.record_reference_to(receiver) unless meth == :new
+          @refs.record_reference_to(receiver.name) unless meth == :new
         when :self
           @refs.record_reference_to(:self)
         end

--- a/lib/reek/smells/feature_envy.rb
+++ b/lib/reek/smells/feature_envy.rb
@@ -43,7 +43,7 @@ module Reek
       #
       def examine_context(method_ctx)
         method_ctx.envious_receivers.map do |ref, occurs|
-          target = ref.format_ruby
+          target = ref.to_s
           SmellWarning.new self,
                            context: method_ctx.full_name,
                            lines: [method_ctx.exp.line],

--- a/lib/reek/source/sexp_extensions.rb
+++ b/lib/reek/source/sexp_extensions.rb
@@ -179,8 +179,12 @@ module Reek
 
       # Utility methods for :lvar nodes.
       module LvarNode
+        include VariableBase
+        # TODO: Replace with name().
         def var_name() self[1] end
       end
+
+      LvasgnNode = LvarNode
 
       # Base module for utility methods for :def and :defs nodes.
       module MethodNodeBase

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -138,6 +138,7 @@ describe Reek::Smells::FeatureEnvy do
   it 'counts =~ as a call' do
     src = <<-EOS
     def foo arg
+      bar(arg.baz)
       arg =~ /bar/
     end
     EOS
@@ -147,6 +148,7 @@ describe Reek::Smells::FeatureEnvy do
   it 'counts += as a call' do
     src = <<-EOS
     def foo arg
+      bar(arg.baz)
       arg += 1
     end
     EOS


### PR DESCRIPTION
Reek would record `lvar.foo` and `lvar += 4` as calls to different entities. This PR fixes this.