### PR TITLE
Recognise .reek as a valid configuration file

### DIFF
--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -48,7 +48,7 @@ module Reek
         end
 
         def detect_configuration_in_directory(directory)
-          Pathname.glob(directory.join('*.reek')).detect(&:file?)
+          directory.children.select(&:file?).find { |path| path.to_s.end_with?('.reek') }
         end
       end
     end


### PR DESCRIPTION
This fixes #425 but lacks test coverage.

I’m not a big fan of the [current way of testing `ConfigurationFileFinder`](https://github.com/troessner/reek/blob/706f4b734a50762e93f21c1a3182f9b8c650d7ab/spec/reek/configuration/configuration_file_finder_spec.rb), so I’d like to fix this in a separate PR (that would include coverage of bare `.reek` files).