### PR TITLE
Refactor ConfigurationFileFinder and its spec

### DIFF
--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -64,7 +64,8 @@ module Reek
       def set_configuration_options
         @parser.separator 'Configuration:'
         @parser.on('-c', '--config FILE', 'Read configuration options from FILE') do |file|
-          @options.config_file = file
+          raise ArgumentError, "Config file #{file} doesn't exist" unless File.exist?(file)
+          @options.config_file = Pathname.new(file)
         end
         @parser.on('--smell SMELL', 'Detect smell SMELL (default: all enabled smells)') do |smell|
           @options.smells_to_detect << smell

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -15,7 +15,7 @@ module Reek
 
         def initialize_with(options)
           @has_been_initialized = true
-          configuration_file_path = ConfigurationFileFinder.find(options)
+          configuration_file_path = ConfigurationFileFinder.find(options: options)
           return unless configuration_file_path
           load_from_file configuration_file_path
         end

--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -1,34 +1,59 @@
-require 'spec_helper'
-require 'reek/cli/application'
+# encoding: UTF-8
 
-include Reek::Cli
-include Reek::Configuration
+require 'pathname'
+require 'tmpdir'
+require 'spec_helper'
 
 describe ConfigurationFileFinder do
   describe '.find' do
-    let(:sample_config_path) { Pathname.new('spec/samples/simple_configuration.reek') }
-    let(:config_path_same_level) { Pathname.new('spec/samples/simple_configuration.reek') }
-    let(:options_with_config_file) { double(config_file: sample_config_path) }
-    let(:options_without_config_file) { double(config_file: nil) }
-
-    it 'should return the config file we passed as cli option if given' do
-      expect(ConfigurationFileFinder.find(options_with_config_file)).to eq(sample_config_path)
+    it 'returns the config_file if it’s set' do
+      config_file = double
+      options = double(config_file: config_file)
+      found = ConfigurationFileFinder.find(options: options)
+      expect(found).to eq(config_file)
     end
 
-    it 'should return the first configuration file it can find in the current directory' do
-      allow(ConfigurationFileFinder).to receive(:detect_or_traverse_up).
-        and_return config_path_same_level
-
-      expect(ConfigurationFileFinder.find(options_without_config_file)).
-        to eq(config_path_same_level)
+    it 'returns the file in current dir if config_file is nil' do
+      options = double(config_file: nil)
+      current = Pathname.new('spec/samples')
+      found = ConfigurationFileFinder.find(options: options, current: current)
+      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
     end
 
-    it 'should look in the HOME directory lastly' do
-      allow(ConfigurationFileFinder).to receive(:configuration_by_cli).and_return nil
-      allow(ConfigurationFileFinder).to receive(:configuration_in_file_system).and_return nil
-      expect(ConfigurationFileFinder).to receive(:configuration_in_home_directory).once
+    it 'returns the file in current dir if options is nil' do
+      current = Pathname.new('spec/samples')
+      found = ConfigurationFileFinder.find(current: current)
+      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
+    end
 
-      ConfigurationFileFinder.find nil
+    it 'returns the file in a parent dir if none in current dir' do
+      current = Pathname.new('spec/samples/no_config_file')
+      found = ConfigurationFileFinder.find(options: nil, current: current)
+      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
+    end
+
+    it 'returns the file even if it’s just ‘.reek’' do
+      current = Pathname.new('spec/samples/masked_by_dotfile')
+      found = ConfigurationFileFinder.find(current: current)
+      expect(found).to eq(Pathname.new('spec/samples/masked_by_dotfile/.reek'))
+    end
+
+    it 'returns the file in home if traversing from the current dir fails' do
+      Dir.mktmpdir do |tempdir|
+        current = Pathname.new(tempdir)
+        home    = Pathname.new('spec/samples')
+        found = ConfigurationFileFinder.find(current: current, home: home)
+        expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
+      end
+    end
+
+    it 'returns nil when there are no files to find' do
+      Dir.mktmpdir do |tempdir|
+        current = Pathname.new(tempdir)
+        home    = Pathname.new(tempdir)
+        found = ConfigurationFileFinder.find(current: current, home: home)
+        expect(found).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Just an indea, let me know what you think. Technical changes: `Options#config_file` is now a `Pathname`, `ConfigurationFileFinder` now also parses from `$HOME` up (IMHO harmless – especially when we already go up to the root from the current dir – and makes the code simpler).