### PR TITLE
Simplify ConfigurationFileFinder spec a bit

### DIFF
--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -28,7 +28,7 @@ describe ConfigurationFileFinder do
 
     it 'returns the file in a parent dir if none in current dir' do
       current = Pathname.new('spec/samples/no_config_file')
-      found = ConfigurationFileFinder.find(options: nil, current: current)
+      found = ConfigurationFileFinder.find(current: current)
       expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
     end
 


### PR DESCRIPTION
A minor simplification of the new `ConfigurationFileFinder` spec from #428. Apologies for not catching that yesterday.