### PR TITLE
Properly capitalise acronyms in class names

### DIFF
--- a/bin/reek
+++ b/bin/reek
@@ -8,4 +8,4 @@
 
 require_relative '../lib/reek/cli/application'
 
-exit Reek::Cli::Application.new(ARGV).execute
+exit Reek::CLI::Application.new(ARGV).execute

--- a/features/step_definitions/reek_steps.rb
+++ b/features/step_definitions/reek_steps.rb
@@ -23,15 +23,15 @@ Then /^stdout includes "(.*)"$/ do |text|
 end
 
 Then /^it succeeds$/ do
-  expect(@last_exit_status).to eq Reek::Cli::Application::STATUS_SUCCESS
+  expect(@last_exit_status).to eq Reek::CLI::Application::STATUS_SUCCESS
 end
 
 Then /^the exit status indicates an error$/ do
-  expect(@last_exit_status).to eq Reek::Cli::Application::STATUS_ERROR
+  expect(@last_exit_status).to eq Reek::CLI::Application::STATUS_ERROR
 end
 
 Then /^the exit status indicates smells$/ do
-  expect(@last_exit_status).to eq Reek::Cli::Application::STATUS_SMELLS
+  expect(@last_exit_status).to eq Reek::CLI::Application::STATUS_SMELLS
 end
 
 Then /^it reports:$/ do |report|

--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -3,7 +3,7 @@ require_relative 'reek_command'
 require_relative '../configuration/app_configuration'
 
 module Reek
-  module Cli
+  module CLI
     #
     # Represents an instance of a Reek application.
     # This is the entry point for all invocations of Reek from the

--- a/lib/reek/cli/command.rb
+++ b/lib/reek/cli/command.rb
@@ -1,5 +1,5 @@
 module Reek
-  module Cli
+  module CLI
     #
     # Base class for all commands
     #

--- a/lib/reek/cli/input.rb
+++ b/lib/reek/cli/input.rb
@@ -1,5 +1,5 @@
 module Reek
-  module Cli
+  module CLI
     #
     # CLI Input utility
     #

--- a/lib/reek/cli/option_interpreter.rb
+++ b/lib/reek/cli/option_interpreter.rb
@@ -5,12 +5,12 @@ require_relative 'report/formatter'
 require_relative 'report/heading_formatter'
 
 module Reek
-  module Cli
+  module CLI
     #
     # Interprets the options set from the command line
     #
     class OptionInterpreter
-      include Cli::Input
+      include CLI::Input
 
       extend Forwardable
 
@@ -33,11 +33,11 @@ module Reek
       def report_class
         case @options.report_format
         when :yaml
-          Report::YamlReport
+          Report::YAMLReport
         when :json
-          Report::JsonReport
+          Report::JSONReport
         when :html
-          Report::HtmlReport
+          Report::HTMLReport
         else # :text
           Report::TextReport
         end

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -5,7 +5,7 @@ require_relative 'option_interpreter'
 require_relative '../version'
 
 module Reek
-  module Cli
+  module CLI
     #
     # Parses the command line
     #

--- a/lib/reek/cli/reek_command.rb
+++ b/lib/reek/cli/reek_command.rb
@@ -2,7 +2,7 @@ require_relative 'command'
 require_relative '../examiner'
 
 module Reek
-  module Cli
+  module CLI
     #
     # A command to collect smells from a set of sources and write them out in
     # text report format.

--- a/lib/reek/cli/report/formatter.rb
+++ b/lib/reek/cli/report/formatter.rb
@@ -1,7 +1,7 @@
 require_relative 'location_formatter'
 
 module Reek
-  module Cli
+  module CLI
     module Report
       #
       # Formatter handling the formatting of the report at large.

--- a/lib/reek/cli/report/heading_formatter.rb
+++ b/lib/reek/cli/report/heading_formatter.rb
@@ -1,5 +1,5 @@
 module Reek
-  module Cli
+  module CLI
     module Report
       module HeadingFormatter
         #

--- a/lib/reek/cli/report/location_formatter.rb
+++ b/lib/reek/cli/report/location_formatter.rb
@@ -1,5 +1,5 @@
 module Reek
-  module Cli
+  module CLI
     module Report
       #
       # Formats the location of a warning as an empty string.

--- a/lib/reek/cli/report/report.rb
+++ b/lib/reek/cli/report/report.rb
@@ -2,7 +2,7 @@ require 'rainbow'
 require 'json'
 
 module Reek
-  module Cli
+  module CLI
     module Report
       #
       # A report that contains the smells and smell counts following source code analysis.
@@ -92,7 +92,7 @@ module Reek
       #
       # Displays a list of smells in YAML format
       # YAML with empty array for 0 smells
-      class YamlReport < Base
+      class YAMLReport < Base
         def show
           print smells.map(&:yaml_hash).to_yaml
         end
@@ -101,7 +101,7 @@ module Reek
       #
       # Displays a list of smells in JSON format
       # JSON with empty array for 0 smells
-      class JsonReport < Base
+      class JSONReport < Base
         def show
           print ::JSON.generate(
             smells.map do |smell|
@@ -114,7 +114,7 @@ module Reek
       #
       # Saves the report as a HTML file
       #
-      class HtmlReport < Base
+      class HTMLReport < Base
         require 'erb'
 
         def show

--- a/lib/reek/core/code_context.rb
+++ b/lib/reek/core/code_context.rb
@@ -13,7 +13,7 @@ module Reek
       # Initializes a new CodeContext.
       #
       # context - *_context from the `core` namespace
-      # exp - Reek::Source::AstNode
+      # exp - Reek::Source::ASTNode
       #
       # Examples:
       #

--- a/lib/reek/source/ast_node.rb
+++ b/lib/reek/source/ast_node.rb
@@ -4,7 +4,7 @@ module Reek
   module Source
     # Base class for AST nodes extended with utility methods. Contains some
     # methods to ease the transition from Sexp to AST::Node.
-    class AstNode < Parser::AST::Node
+    class ASTNode < Parser::AST::Node
       def initialize(type, children = [], options = {})
         @comments = options.fetch(:comments, [])
         super

--- a/lib/reek/source/ast_node_class_map.rb
+++ b/lib/reek/source/ast_node_class_map.rb
@@ -4,9 +4,9 @@ require_relative 'sexp_extensions'
 
 module Reek
   module Source
-    # Maps AST node types to sublasses of AstNode extended with the relevant
+    # Maps AST node types to sublasses of ASTNode extended with the relevant
     # utility modules.
-    class AstNodeClassMap
+    class ASTNodeClassMap
       def initialize
         @klass_map = {}
       end
@@ -14,7 +14,7 @@ module Reek
       def klass_for(type)
         @klass_map[type] ||=
           begin
-            klass = Class.new(AstNode)
+            klass = Class.new(ASTNode)
             klass.send :include, extension_map[type] if extension_map[type]
             klass.send :include, SexpNode
           end

--- a/lib/reek/source/sexp_extensions.rb
+++ b/lib/reek/source/sexp_extensions.rb
@@ -3,7 +3,7 @@ require_relative 'sexp_node'
 module Reek
   module Source
     #
-    # Extension modules providing utility methods to AstNode objects, depending
+    # Extension modules providing utility methods to ASTNode objects, depending
     # on their type.
     #
     module SexpExtensions

--- a/lib/reek/source/tree_dresser.rb
+++ b/lib/reek/source/tree_dresser.rb
@@ -7,7 +7,7 @@ module Reek
     # the tree more understandable and less implementation-dependent.
     #
     class TreeDresser
-      def initialize(klass_map = AstNodeClassMap.new)
+      def initialize(klass_map = ASTNodeClassMap.new)
         @klass_map = klass_map
       end
 

--- a/lib/reek/spec/should_reek.rb
+++ b/lib/reek/spec/should_reek.rb
@@ -17,7 +17,7 @@ module Reek
       end
 
       def failure_message_when_negated
-        rpt = Cli::Report::Formatter.format_list(@examiner.smells)
+        rpt = CLI::Report::Formatter.format_list(@examiner.smells)
         "Expected no smells, but got:\n#{rpt}"
       end
     end

--- a/lib/reek/spec/should_reek_only_of.rb
+++ b/lib/reek/spec/should_reek_only_of.rb
@@ -20,7 +20,7 @@ module Reek
       end
 
       def failure_message
-        rpt = Cli::Report::Formatter.format_list(@warnings)
+        rpt = CLI::Report::Formatter.format_list(@warnings)
         "Expected #{@examiner.description} to reek only of #{@smell_category}, but got:\n#{rpt}"
       end
 

--- a/spec/reek/cli/html_report_spec.rb
+++ b/spec/reek/cli/html_report_spec.rb
@@ -3,10 +3,10 @@ require_relative '../../../lib/reek/examiner'
 require_relative '../../../lib/reek/cli/report/report'
 
 include Reek
-include Reek::Cli
+include Reek::CLI
 
-describe Report::HtmlReport do
-  let(:instance) { Report::HtmlReport.new }
+describe Report::HTMLReport do
+  let(:instance) { Report::HTMLReport.new }
 
   context 'with an empty source' do
     let(:examiner) { Examiner.new('') }

--- a/spec/reek/cli/json_report_spec.rb
+++ b/spec/reek/cli/json_report_spec.rb
@@ -3,8 +3,8 @@ require_relative '../../../lib/reek/examiner'
 require_relative '../../../lib/reek/cli/report/report'
 require_relative '../../../lib/reek/cli/report/formatter'
 
-describe Reek::Cli::Report::JsonReport do
-  let(:instance) { Reek::Cli::Report::JsonReport.new }
+describe Reek::CLI::Report::JSONReport do
+  let(:instance) { Reek::CLI::Report::JSONReport.new }
 
   context 'empty source' do
     let(:examiner) { Reek::Examiner.new('') }

--- a/spec/reek/cli/option_interperter_spec.rb
+++ b/spec/reek/cli/option_interperter_spec.rb
@@ -2,13 +2,13 @@ require_relative '../../spec_helper'
 
 require_relative '../../../lib/reek/cli/options'
 
-describe Reek::Cli::OptionInterpreter do
+describe Reek::CLI::OptionInterpreter do
   let(:options) { OpenStruct.new }
-  let(:instance) { Reek::Cli::OptionInterpreter.new(options) }
+  let(:instance) { Reek::CLI::OptionInterpreter.new(options) }
 
   describe '#reporter' do
     it 'returns a Report::TextReport instance by default' do
-      expect(instance.reporter).to be_instance_of Reek::Cli::Report::TextReport
+      expect(instance.reporter).to be_instance_of Reek::CLI::Report::TextReport
     end
   end
 end

--- a/spec/reek/cli/text_report_spec.rb
+++ b/spec/reek/cli/text_report_spec.rb
@@ -6,7 +6,7 @@ require_relative '../../../lib/reek/cli/report/heading_formatter'
 require 'rainbow'
 
 include Reek
-include Reek::Cli
+include Reek::CLI
 
 describe Report::TextReport do
   let(:report_options) do

--- a/spec/reek/cli/yaml_report_spec.rb
+++ b/spec/reek/cli/yaml_report_spec.rb
@@ -4,10 +4,10 @@ require_relative '../../../lib/reek/cli/report/report'
 require_relative '../../../lib/reek/cli/report/formatter'
 
 include Reek
-include Reek::Cli
+include Reek::CLI
 
-describe Report::YamlReport do
-  let(:instance) { Report::YamlReport.new }
+describe Report::YAMLReport do
+  let(:instance) { Report::YAMLReport.new }
 
   context 'empty source' do
     let(:examiner) { Examiner.new('') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ module Helpers
 
   # :reek:UncommunicativeMethodName
   def s(type, *children)
-    @klass_map ||= Reek::Source::AstNodeClassMap.new
+    @klass_map ||= Reek::Source::ASTNodeClassMap.new
     @klass_map.klass_for(type).new(type, children)
   end
 


### PR DESCRIPTION
Ok, here’s a potentially controversial one: my brain freezes for a moment (and my eyes bleed a bit) every time I read one of those class names that contain mostly-lowercased acronyms.

The only reason for spelling `ASTNode` as `AstNode` that I can think of would be if there was some class autoloading that couldn’t handle acronyms, but (a) there isn’t one and (b) even Rails 2.3 handles such cases properly (_I don’t want to speak about why I know this in 2015_).

Let me know what you think. I’ll be happy to add backward compatibility (via `AstNode = ASTNode`, etc.) if you think we need to keep it until 3.0.