### PR TITLE
Pick config file that comes first alphabetically

### DIFF
--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -31,7 +31,7 @@ module Reek
 
       def find_by_dir(start)
         start.ascend do |dir|
-          files = dir.children.select(&:file?)
+          files = dir.children.select(&:file?).sort
           found = files.find { |file| file.to_s.end_with?('.reek') }
           return found if found
         end

--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -4,6 +4,8 @@ require 'pathname'
 require 'tmpdir'
 require_relative '../../spec_helper'
 
+include Reek::Configuration
+
 describe ConfigurationFileFinder do
   describe '.find' do
     it 'returns the config_file if it’s set' do


### PR DESCRIPTION
This fixes a small problem I had where removing `exceptions.reek` and then adding it again broke the ConfigurationFileFinder specs.