### PR TITLE
UtilityFunction: drop max_helper_calls

### DIFF
--- a/config/defaults.reek
+++ b/config/defaults.reek
@@ -109,4 +109,3 @@ UnusedParameters:
 UtilityFunction:
   enabled: true
   exclude: []
-  max_helper_calls: 0

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -35,13 +35,6 @@ module Reek
     # +FeatureEnvy+ is reported instead.
     #
     class UtilityFunction < SmellDetector
-      # The name of the config field that sets the maximum number of
-      # calls permitted within a helper method. Any method with more than
-      # this number of method calls on other objects will be considered a
-      # candidate Utility Function.
-      HELPER_CALLS_LIMIT_KEY = 'max_helper_calls'
-      DEFAULT_HELPER_CALLS_LIMIT = 0
-
       def self.smell_category
         'LowCohesion'
       end
@@ -49,10 +42,6 @@ module Reek
       class << self
         def contexts      # :nodoc:
           [:def]
-        end
-
-        def default_config
-          super.merge(HELPER_CALLS_LIMIT_KEY => DEFAULT_HELPER_CALLS_LIMIT)
         end
       end
 
@@ -64,9 +53,7 @@ module Reek
       def examine_context(method_ctx)
         return [] if method_ctx.num_statements == 0
         return [] if method_ctx.references_self?
-        return [] if num_helper_methods(method_ctx) <= value(HELPER_CALLS_LIMIT_KEY,
-                                                             method_ctx,
-                                                             DEFAULT_HELPER_CALLS_LIMIT)
+        return [] if num_helper_methods(method_ctx).zero?
 
         [SmellWarning.new(self,
                           context: method_ctx.full_name,


### PR DESCRIPTION
Fixes #441. Targeted 2.2 as per #422. This is a reopened #447. :)