### PR TITLE
ConfigurationFileFinder: test magic paths

### DIFF
--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+require 'fileutils'
 require 'pathname'
 require 'tmpdir'
 require_relative '../../spec_helper'
@@ -53,6 +54,17 @@ describe Reek::Configuration::ConfigurationFileFinder do
         home    = Pathname.new(tempdir)
         found = described_class.find(current: current, home: home)
         expect(found).to be_nil
+      end
+    end
+
+    it 'works with paths that need escaping' do
+      Dir.mktmpdir("ma\ngic d*r") do |tempdir|
+        config = Pathname.new("#{tempdir}/ma\ngic f*le.reek")
+        subdir = Pathname.new("#{tempdir}/ma\ngic subd*r")
+        FileUtils.touch config
+        FileUtils.mkdir subdir
+        found = described_class.find(current: subdir)
+        expect(found).to eq(config)
       end
     end
   end


### PR DESCRIPTION
<del>The fact that we couldn’t match the `.reek` config file via `*.reek` globbing was growing on me, so I dove into docs and found a way.</del> It turns out the globbing doesn’t work 100% of the time in Rubinius, so this PR only adds the below:

I also fondly remember the wise words of Michael Grünewald:

> Hobby: creating bug tickets, waiting for people to find out about my home directory – which happens to contain spaces, stars and newlines.

– so I added a relevant spec.