### PR TITLE
Better/new {,Singleton}MethodContext#envious_receivers tests

### DIFF
--- a/lib/reek/core/method_context.rb
+++ b/lib/reek/core/method_context.rb
@@ -25,7 +25,7 @@ module Reek
       attr_reader :num_statements
 
       def initialize(outer, exp)
-        super(outer, exp)
+        super
         @parameters = exp.parameters.dup
         @parameters.extend MethodParameters
         @num_statements = 0

--- a/lib/reek/core/singleton_method_context.rb
+++ b/lib/reek/core/singleton_method_context.rb
@@ -6,10 +6,6 @@ module Reek
     # A context wrapper for any singleton method definition found in a syntax tree.
     #
     class SingletonMethodContext < MethodContext
-      def initialize(outer, exp)
-        super(outer, exp)
-      end
-
       def envious_receivers
         []
       end

--- a/spec/reek/core/method_context_spec.rb
+++ b/spec/reek/core/method_context_spec.rb
@@ -21,28 +21,33 @@ describe Reek::Core::MethodContext, 'matching' do
 end
 
 describe Reek::Core::MethodContext do
-  it 'should record ivars as refs to self' do
-    sexp = s(:def, :feed, s(:args), nil)
-    mctx = Reek::Core::MethodContext.new(Reek::Core::StopContext.new, sexp)
-    expect(mctx.envious_receivers).to eq([])
-    mctx.record_call_to(s(:send, s(:ivar, :@cow), :feed_to))
-    expect(mctx.envious_receivers).to eq([])
+  let(:mc) do
+    sexp = s(:def, :foo, s(:args, s(:arg, :bar)), nil)
+    Reek::Core::MethodContext.new(Reek::Core::StopContext.new, sexp)
   end
 
-  it 'should count calls to self' do
-    sexp = s(:def, :equals, s(:args), nil)
-    mctx = Reek::Core::MethodContext.new(Reek::Core::StopContext.new, sexp)
-    mctx.refs.record_reference_to([:lvar, :other])
-    mctx.record_call_to(s(:send, s(:self), :thing))
-    expect(mctx.envious_receivers).to be_empty
-  end
+  describe '#envious_receivers' do
+    it 'should ignore ivars as refs to self' do
+      mc.record_call_to s(:send, s(:ivar, :@cow), :feed_to)
+      expect(mc.envious_receivers).to be_empty
+    end
 
-  it 'should recognise a call on self' do
-    sexp = s(:def, :deep, s(:args), nil)
-    mc = Reek::Core::MethodContext.new(Reek::Core::StopContext.new, sexp)
-    mc.record_call_to(s(:send, s(:lvar, :text), :each, s(:arglist)))
-    mc.record_call_to(s(:send, nil, :shelve, s(:arglist)))
-    expect(mc.envious_receivers).to be_empty
+    it 'should ignore explicit calls to self' do
+      mc.refs.record_reference_to [:lvar, :other]
+      mc.record_call_to s(:send, s(:self), :thing)
+      expect(mc.envious_receivers).to be_empty
+    end
+
+    it 'should ignore implicit calls to self' do
+      mc.record_call_to s(:send, s(:lvar, :text), :each, s(:arglist))
+      mc.record_call_to s(:send, nil, :shelve, s(:arglist))
+      expect(mc.envious_receivers).to be_empty
+    end
+
+    it 'should record envious calls' do
+      mc.record_call_to s(:send, s(:lvar, :bar), :baz)
+      expect(mc.envious_receivers).to eq(bar: 1)
+    end
   end
 end
 

--- a/spec/reek/core/singleton_method_context_spec.rb
+++ b/spec/reek/core/singleton_method_context_spec.rb
@@ -1,7 +1,17 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/core/module_context'
 require_relative '../../../lib/reek/core/singleton_method_context'
 require_relative '../../../lib/reek/core/stop_context'
 
 describe Reek::Core::SingletonMethodContext do
+  let(:smc) do
+    sexp = s(:def, :foo, s(:args, s(:arg, :bar)), nil)
+    Reek::Core::SingletonMethodContext.new(Reek::Core::StopContext.new, sexp)
+  end
+
+  describe '#envious_receivers' do
+    it 'should not record envious calls' do
+      smc.record_call_to s(:send, s(:lvar, :bar), :baz)
+      expect(smc.envious_receivers).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
I got curious why `SingletonMethodContext` tests are empty and came up with a clean-up of `MethodContext#envious_receivers` tests and a `SingletonMethodContext#envious_receivers` test.