### PR TITLE
Clean up RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
 
 # FIXME: Lower the ABC size by fixing the biggest offenders
 Metrics/AbcSize:
-  Max: 25
+  Max: 18
 
 # FIXME: Make the class shorter
 Metrics/ClassLength:
@@ -15,7 +15,7 @@ Metrics/ClassLength:
 
 # FIXME: Lower the method length by fixing the biggest offenders
 Metrics/MethodLength:
-  Max: 46
+  Max: 15
 
 # Be a little more lenient with line length
 Metrics/LineLength:
@@ -33,10 +33,6 @@ Style/SingleLineMethods:
 Style/SignalException:
   EnforcedStyle: only_raise
 
-# Allow multiple Hash parameters to look similar
-Style/BracesAroundHashParameters:
-  EnforcedStyle: context_dependent
-
 # Place . on the previous line
 Style/DotPosition:
   EnforcedStyle: trailing
@@ -45,14 +41,6 @@ Style/DotPosition:
 Style/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 
-# Enforce GaurdClause if there are 2 or more lines in the body
-Style/GuardClause:
-  MinBodyLength: 2
-
-# Allow s()
-Style/MethodCallParentheses:
-  Enabled: false
-
 # Allow multiline block chains
 Style/MultilineBlockChain:
   Enabled: false
@@ -60,7 +48,3 @@ Style/MultilineBlockChain:
 # Allow Perl-style references to regex matches
 Style/PerlBackrefs:
   Enabled: false
-
-# Only register TrivialAccessors offenses when the name matches
-Style/TrivialAccessors:
-  ExactNameMatch: true


### PR DESCRIPTION
This cleans up the RuboCop config as per current develop state: lowers acceptable offence parameters closer to RuboCop’s defaults and removes offences the codebase no longer commits.

Let me know if you believe we should allow any of the removed offences in the future.

(Apologies for the slew of clean-up PRs, but I’m trying to get the codebase as friendly as possible before ROSSConf Vienna next weekend – and RuboCop config is one of the things I want to talk about.)