### PR TITLE
Sort SmellRepository.smell_types by name

### DIFF
--- a/lib/reek/core/smell_repository.rb
+++ b/lib/reek/core/smell_repository.rb
@@ -11,7 +11,7 @@ module Reek
       attr_reader :detectors
 
       def self.smell_types
-        Reek::Smells::SmellDetector.descendants
+        Reek::Smells::SmellDetector.descendants.sort_by(&:name)
       end
 
       def initialize(source_description = nil, smell_types = self.class.smell_types)

--- a/spec/reek/core/smell_repository_spec.rb
+++ b/spec/reek/core/smell_repository_spec.rb
@@ -13,5 +13,9 @@ describe Reek::Core::SmellRepository do
     it 'should exclude certain smell_types' do
       expect(smell_types).to_not include(Reek::Smells::SmellDetector)
     end
+
+    it 'should return the smell types in alphabetic order' do
+      expect(smell_types).to eq(smell_types.sort_by(&:name))
+    end
   end
 end


### PR DESCRIPTION
Now and then (BUT QUITE IRREGULARLY) running specs would regenerate a different `config/defaults.reek` than the one in the repo.

Thanks to the magic of `sudo chattr +i config/defaults.reek` I pinpointed the culprit. This PR makes sure the smell types are returned in a stable order.