### PR TITLE
Extract method to reduce ABC size

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,10 +4,6 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
 
-# FIXME: Lower the ABC size by fixing the biggest offenders
-Metrics/AbcSize:
-  Max: 16
-
 # FIXME: Make the class shorter
 Metrics/ClassLength:
   Exclude:

--- a/lib/reek/smells/prima_donna_method.rb
+++ b/lib/reek/smells/prima_donna_method.rb
@@ -28,18 +28,25 @@ module Reek
 
       def examine_context(ctx)
         ctx.node_instance_methods.map do |method_sexp|
-          next unless method_sexp.ends_with_bang?
-
-          version_without_bang = ctx.node_instance_methods.find do |sexp_item|
-            sexp_item.name.to_s == method_sexp.name_without_bang
-          end
-          next if version_without_bang
-
-          SmellWarning.new self,
-                           context: ctx.full_name,
-                           lines: [ctx.exp.line],
-                           message: "has prima donna method `#{method_sexp.name}`"
+          check_for_smells(method_sexp, ctx)
         end.compact
+      end
+
+      private
+
+      def check_for_smells(method_sexp, ctx)
+        return unless method_sexp.ends_with_bang?
+
+        version_without_bang = ctx.node_instance_methods.find do |sexp_item|
+          sexp_item.name.to_s == method_sexp.name_without_bang
+        end
+
+        return if version_without_bang
+
+        SmellWarning.new self,
+                         context: ctx.full_name,
+                         lines: [ctx.exp.line],
+                         message: "has prima donna method `#{method_sexp.name}`"
       end
     end
   end


### PR DESCRIPTION
RuboCop identified that `PrimaDonnaMethod#examine_constent` had a high
ABC size.