### PR TITLE
fix Gem::ConflictError when executing bin/reek directly

### DIFF
--- a/bin/reek
+++ b/bin/reek
@@ -6,6 +6,8 @@
 # Author: Kevin Rutherford
 #
 
+require 'bundler/setup'
+
 require_relative '../lib/reek/cli/application'
 
 exit Reek::CLI::Application.new(ARGV).execute


### PR DESCRIPTION
after cloning and executing `bin/reek` we faced the following error.

```
$ bin/reek .
/Users/ben/.rbenv/versions/2.2.1/lib/ruby/2.2.0/rubygems/specification.rb:2112:in `raise_if_conflicts': Unable to activate unparser-0.2.2, because parser-2.2.2.1 conflicts with parser (~> 2.2.0.2) (Gem::ConflictError)
```

require `bundler/setup` to load the gem versions in Gemfile.lock

worked on this with @phillipp

#rossconf :dancer: