### PR TITLE
Do not enable colorization if stdout is not a TTY

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Exclude:
     - lib/reek/core/tree_walker.rb
+    - lib/reek/cli/options.rb
 
 # FIXME: Lower the method length by fixing the biggest offenders
 Metrics/MethodLength:

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -10,10 +10,11 @@ module Reek
     # Parses the command line
     #
     class Options
-      def initialize(argv)
+      def initialize(argv = [])
         @argv    = argv
         @parser  = OptionParser.new
-        @options = OpenStruct.new(colored: true, smells_to_detect: [])
+        @options = OpenStruct.new(colored: color_support?,
+                                  smells_to_detect: [])
         set_up_parser
       end
 
@@ -25,6 +26,10 @@ module Reek
       end
 
       private
+
+      def color_support?
+        $stdout.tty?
+      end
 
       def set_up_parser
         set_banner

--- a/spec/reek/cli/options_spec.rb
+++ b/spec/reek/cli/options_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../../spec_helper'
+
+require_relative '../../../lib/reek/cli/options'
+
+describe Reek::CLI::Options do
+  describe '#initialize' do
+    it 'should enable colors when stdout is a TTY' do
+      allow($stdout).to receive_messages(tty?: false)
+      options = Reek::CLI::Options.new.parse
+      expect(options.colored).to be false
+    end
+
+    it 'should not enable colors when stdout is not a TTY' do
+      allow($stdout).to receive_messages(tty?: true)
+      options = Reek::CLI::Options.new.parse
+      expect(options.colored).to be true
+    end
+  end
+end


### PR DESCRIPTION
If the standard output is not a TTY -- for example when piping output to a pager such as less or redirecting it into a file -- colorization should not be enabled by default.