### PR TITLE
Update quality spec to new rspec syntax

### DIFF
--- a/spec/quality/reek_source_spec.rb
+++ b/spec/quality/reek_source_spec.rb
@@ -2,6 +2,6 @@ require_relative '../spec_helper'
 
 describe 'Reek source code' do
   it 'has no smells' do
-    Dir['lib/**/*.rb'].should_not reek
+    expect(Dir['lib/**/*.rb']).to_not reek
   end
 end


### PR DESCRIPTION
I'm getting a rspec deprecation warning when running

    $ bundle exec rake test:quality

This is the rspec deprecation warning:

```
Deprecation Warnings:

Using `should_not` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(
:rspec) { |c| c.syntax = :should }` instead. Called from /Users/bruno/dev/reek/spec/quality/reek_source_spec.rb:5:in `block (2 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total
```

And this is fixed pretty easily.


Btw. the `$ bundle exec rake test:quality` test fails (but I think this is a known thing).