### PR TITLE
Travis: notify GitHub all is well before allowed failures finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
+  fast_finish: true
 notifications:
   recipients:
     - timo.roessner@googlemail.com


### PR DESCRIPTION
Currently Travis waits for all builds (even allowed failures) to finish before marking the given PR green. The jruby-head build is slow ([~10 minutes now](https://travis-ci.org/troessner/reek/builds/60014081)) and is usually the bottleneck when one is waiting for the build.

This [makes Travis notify GitHub all is well](http://blog.travis-ci.com/2013-11-27-fast-finishing-builds/) as soon as all of the required build jobs pass.