### PR TITLE
Ensure running bin/reek from checkout works

### DIFF
--- a/lib/reek/core/examiner.rb
+++ b/lib/reek/core/examiner.rb
@@ -1,7 +1,7 @@
-require_relative '../source/source_repository'
-require_relative 'warning_collector'
-require_relative 'smell_repository'
 require_relative 'tree_walker'
+require_relative 'smell_repository'
+require_relative 'warning_collector'
+require_relative '../source/source_repository'
 
 module Reek
   module Core


### PR DESCRIPTION
We would like it to be possible to checkout the reek source and simply run `bin/reek`. However, dependency issues may exist between our external dependencies. In this particular case, unparser depends on a slightly older version of parser. Rubygems will handle this correctly if unparser is required first. A slight re-ordering of our internal requires makes this happen.

There is no nice way to test this automatically, but simply running `bin/reek -v` now and again should do it.