### PR TITLE
Refactor sexp.

### DIFF
--- a/lib/reek/core/reference_collector.rb
+++ b/lib/reek/core/reference_collector.rb
@@ -14,9 +14,9 @@ module Reek
       def num_refs_to_self
         result = 0
         [:self, :zsuper, :ivar, :ivasgn].each do |node_type|
-          @ast.look_for(node_type, STOP_NODES) { result += 1 }
+          @ast.each_node(node_type, STOP_NODES) { result += 1 }
         end
-        @ast.look_for(:send, STOP_NODES) do |call|
+        @ast.each_node(:send, STOP_NODES) do |call|
           result += 1 unless call.receiver
         end
         result

--- a/lib/reek/sexp/sexp_extensions.rb
+++ b/lib/reek/sexp/sexp_extensions.rb
@@ -259,7 +259,7 @@ module Reek
         include MethodNodeBase
         def full_name(outer)
           prefix = outer == '' ? '' : "#{outer}#"
-          "#{prefix}#{SexpNode.format(receiver)}.#{name}"
+          "#{prefix}#{SexpFormatter.format(receiver)}.#{name}"
         end
 
         def depends_on_instance?
@@ -314,7 +314,7 @@ module Reek
         end
 
         def text_name
-          SexpNode.format(name)
+          SexpFormatter.format(name)
         end
       end
 

--- a/lib/reek/sexp/sexp_formatter.rb
+++ b/lib/reek/sexp/sexp_formatter.rb
@@ -10,6 +10,11 @@ module Reek
     #
     # :reek:DuplicateMethodCall { max_calls: 2 } is ok for lines.first
     class SexpFormatter
+      # Formats the given sexp.
+      #
+      # sexp - S-expression of type AST::Node or something that is at least to_s-able.
+      #
+      # Returns a formatted string representation.
       def self.format(sexp)
         return sexp.to_s unless sexp.is_a? AST::Node
         lines = Unparser.unparse(sexp).split "\n"

--- a/lib/reek/sexp/sexp_node.rb
+++ b/lib/reek/sexp/sexp_node.rb
@@ -5,74 +5,86 @@ module Reek
     # syntax tree more easily.
     #
     module SexpNode
-      def self.format(expr)
-        case expr
-        when AST::Node then expr.format_ruby
-        else expr.to_s
-        end
-      end
-
-      def hash
-        inspect.hash
-      end
-
-      def each_node(type, ignoring = [], &blk)
+      #
+      # Carries out a depth-first traversal of this syntax tree, yielding
+      # every Sexp of type `target_type`. The traversal ignores any node
+      # whose type is listed in the Array `ignoring`.
+      # Takes a block as well.
+      #
+      # target_type - the type to look for, e.g. :send, :block
+      # ignoring - types to ignore, e.g. [:casgn, :class, :module]
+      # blk - block to execute for every hit
+      #
+      # Examples:
+      #   context.each_node(:send, [:mlhs]) do |call_node| .... end
+      #   context.each_node(:lvar).any? { |it| it.var_name == 'something' }
+      #
+      # Returns an array with all matching nodes.
+      def each_node(target_type, ignoring = [], &blk)
         if block_given?
-          look_for(type, ignoring, &blk)
+          look_for_type(target_type, ignoring, &blk)
         else
           result = []
-          look_for(type, ignoring) { |exp| result << exp }
+          look_for_type(target_type, ignoring) { |exp| result << exp }
           result
         end
       end
 
-      def find_nodes(types, ignoring = [])
+      #
+      # Carries out a depth-first traversal of this syntax tree, yielding
+      # every Sexp of type `target_type`. The traversal ignores any node
+      # whose type is listed in the Array `ignoring`, including the top node.
+      # Takes a block as well.
+      #
+      # target_types - the types to look for, e.g. [:send, :block]
+      # ignoring - types to ignore, e.g. [:casgn, :class, :module]
+      # blk - block to execute for every hit
+      #
+      # Examples:
+      #   exp.find_nodes([:block]).flat_map do |elem| ... end
+      #
+      # Returns an array with all matching nodes.
+      def find_nodes(target_types, ignoring = [])
         result = []
-        look_for_alt(types, ignoring) { |exp| result << exp }
+        look_for_types(target_types, ignoring) { |exp| result << exp }
         result
       end
 
-      def each_sexp
-        children.each { |elem| yield elem if elem.is_a? AST::Node }
+      def contains_nested_node?(target_type)
+        look_for_type(target_type) { |_elem| return true }
+        false
       end
 
-      #
-      # Carries out a depth-first traversal of this syntax tree, yielding
-      # every Sexp of type +target_type+. The traversal ignores any node
-      # whose type is listed in the Array +ignoring+.
-      #
-      def look_for(target_type, ignoring = [], &blk)
+      def format_to_ruby
+        SexpFormatter.format(self)
+      end
+
+      protected
+
+      # See ".each_node" for documentation.
+      def look_for_type(target_type, ignoring = [], &blk)
         each_sexp do |elem|
-          elem.look_for(target_type, ignoring, &blk) unless ignoring.include?(elem.type)
+          elem.look_for_type(target_type, ignoring, &blk) unless ignoring.include?(elem.type)
         end
         blk.call(self) if type == target_type
       end
 
-      #
-      # Carries out a depth-first traversal of this syntax tree, yielding
-      # every Sexp of type +target_type+. The traversal ignores any node
-      # whose type is listed in the Array +ignoring+, includeing the top node.
-      #
-      # Also, doesn't nest
-      #
-      def look_for_alt(target_types, ignoring = [], &blk)
+      # See ".find_nodes" for documentation.
+      def look_for_types(target_types, ignoring = [], &blk)
         return if ignoring.include?(type)
         if target_types.include? type
           blk.call(self)
         else
           each_sexp do |elem|
-            elem.look_for_alt(target_types, ignoring, &blk)
+            elem.look_for_types(target_types, ignoring, &blk)
           end
         end
       end
 
-      def contains_nested_node?(target_type)
-        look_for(target_type) { |_elem| return true }
-        false
-      end
+      private
 
-      def format_ruby
-        SexpFormatter.format(self)
+      def each_sexp
+        children.each { |elem| yield elem if elem.is_a? AST::Node }
       end
     end
   end

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -69,7 +69,7 @@ module Reek
         end
 
         def call
-          @call ||= @call_node.format_ruby
+          @call ||= @call_node.format_to_ruby
         end
 
         def occurs

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -53,7 +53,7 @@ module Reek
           lines.length > @max_identical_ifs
         end.map do |key, lines|
           occurs = lines.length
-          expression = key.format_ruby
+          expression = key.format_to_ruby
           SmellWarning.new self,
                            context: ctx.full_name,
                            lines: lines,

--- a/spec/reek/sexp/sexp_node_spec.rb
+++ b/spec/reek/sexp/sexp_node_spec.rb
@@ -5,7 +5,7 @@ describe Reek::Sexp::SexpNode do
   context 'format' do
     it 'formats self' do
       @node = s(:self)
-      expect(@node.format_ruby).to eq('self')
+      expect(@node.format_to_ruby).to eq('self')
     end
   end
 


### PR DESCRIPTION
Major changes:
- Stopped the proliferation of methods from SexpNode across our codebase. Now just "each_node" and "find_nodes" is used for traversing the AST outside of the SexpNode. 
- Tomdoc'ed all-the-things
- Make SexpFormatter the only authority for formatting Sexp's.
