### PR TITLE
Improve YARD output

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,10 +1,7 @@
 --no-private
 --readme README.md
-lib/reek.rb
-lib/reek/*.rb
-lib/reek/smells/*.rb
-lib/reek/source/*.rb
-lib/reek/spec/*.rb
-lib/reek/rake/*.rb
+--load ./docs/yard_plugin.rb
 -
 *.txt
+*.md
+docs/*.md

--- a/docs/yard_plugin.rb
+++ b/docs/yard_plugin.rb
@@ -1,0 +1,14 @@
+require 'yard'
+
+# Template helper to modify processing of links in HTML generated from our
+# markdown files.
+module LocalLinkHelper
+  # Rewrites links to (assumed local) markdown files so they're processed as
+  # {file: } directives.
+  def resolve_links(text)
+    text = text.gsub(%r{<a href="([^"]*.md)">([^<]*)</a>}, '{file:\1 \2}')
+    super text
+  end
+end
+
+YARD::Templates::Template.extra_includes << LocalLinkHelper

--- a/lib/reek/core/examiner.rb
+++ b/lib/reek/core/examiner.rb
@@ -24,7 +24,7 @@ module Reek
       #
       # Creates an Examiner which scans the given +source+ for code smells.
       #
-      # @param [Source::SourceCode, Array<String>, #to_reek_source]
+      # @param source [Source::SourceCode, Array<String>, #to_reek_source]
       #   If +source+ is a String it is assumed to be Ruby source code;
       #   if it is a File, the file is opened and parsed for Ruby source code;
       #   and if it is an Array, it is assumed to be a list of file paths,
@@ -40,23 +40,21 @@ module Reek
       end
 
       #
-      # List the smells found in the source.
-      #
-      # @return [Array<SmellWarning>]
+      # @return [Array<SmellWarning>] the smells found in the source
       #
       def smells
         @smells ||= @collector.warnings
       end
 
       #
-      # Returns the number of smells found in the source
+      # @return [Integer] the number of smells found in the source
       #
       def smells_count
         smells.length
       end
 
       #
-      # True if and only if there are code smells in the source.
+      # @return [Boolean] true if and only if there are code smells in the source.
       #
       def smelly?
         !smells.empty?


### PR DESCRIPTION
Several improvements to the YARD output:

* Include all files in `lib/`; we can exclude any classes we don't want to see by marking them `@private` or `private_constant` (I didn't know about the latter option).
* Update Examiner to use the full power of YARD.
* Include extra documentation files.
* Fix up local markdown links.