### PR TITLE
Cleanup attribute smell spec

### DIFF
--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -1,37 +1,40 @@
 require_relative '../../spec_helper'
 require_relative '../../../lib/reek/smells/attribute'
-require_relative '../../../lib/reek/core/module_context'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::Attribute do
-  before :each do
+  let(:config) do
+    {
+      Attribute: { Reek::Core::SmellConfiguration::ENABLED_KEY => true }
+    }
+  end
+
+  before(:each) do
     @source_name = 'dummy_source'
     @detector = build(:smell_detector, smell_type: :Attribute, source: @source_name)
+  end
+
+  around(:each) do |example|
+    with_test_config(config) do
+      example.run
+    end
   end
 
   it_should_behave_like 'SmellDetector'
 
   context 'with no attributes' do
-    it 'records nothing in the module' do
-      src = 'module Fred; end'
-      ctx = Reek::Core::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      expect(@detector.examine_context(ctx)).to be_empty
+    it 'records nothing' do
+      expect('
+        class Klass
+        end
+      ').to_not reek_of(:Attribute)
     end
+  end
 
-    shared_examples_for 'no attribute found' do
-      before :each do
-        ctx = Reek::Core::CodeContext.new(nil, Reek::Source::SourceCode.from(@src).syntax_tree)
-        @smells = @detector.examine_context(ctx)
-      end
-
-      it 'records no attribute' do
-        expect(@smells.length).to eq(0)
-      end
-    end
-
-    context 'declared in a class' do
-      before :each do
-        @src = "class Fred
+  context 'with attributes' do
+    it 'records nothing' do
+      expect('
+        class Klass
           attr :super_private, :super_private2
           private :super_private, :super_private2
           private
@@ -40,210 +43,80 @@ RSpec.describe Reek::Smells::Attribute do
           attr :super_thing2
           private
           attr :super_thing2
-        end"
-      end
-
-      it_should_behave_like 'no attribute found'
+        end
+      ').to_not reek_of(:Attribute)
     end
 
-    context 'declared in a module' do
-      before :each do
-        @src = "module Fred
-          attr :super_private, :super_private2
-          private :super_private, :super_private2
+    it 'records attr attribute in a module' do
+      expect('
+        module Mod
+          attr :my_attr
+        end
+      ').to reek_of(:Attribute, name: 'my_attr')
+    end
+
+    it 'records attr attribute' do
+      expect('
+        class Klass
+          attr :my_attr
+        end
+      ').to reek_of(:Attribute, name: 'my_attr')
+    end
+
+    it 'records reader attribute' do
+      expect('
+        class Klass
+          attr_reader :my_attr
+        end
+      ').to reek_of(:Attribute, name: 'my_attr')
+    end
+
+    it 'records writer attribute' do
+      expect('
+        class Klass
+          attr_writer :my_attr
+        end
+      ').to reek_of(:Attribute, name: 'my_attr')
+    end
+
+    it 'records accessor attribute' do
+      expect('
+        class Klass
+          attr_accessor :my_attr
+        end
+      ').to reek_of(:Attribute, name: 'my_attr')
+    end
+
+    it 'records attr attribute after switching visbility' do
+      expect('
+        class Klass
           private
-          attr :super_thing
-        end"
-      end
-
-      it_should_behave_like 'no attribute found'
-    end
-  end
-
-  context 'with one attribute' do
-    before :each do
-      @attr_name = 'super_thing'
+          attr :my_attr
+          public :my_attr
+          private :my_attr
+          public :my_attr
+        end
+      ').to reek_of(:Attribute, name: 'my_attr')
     end
 
-    shared_examples_for 'one attribute found' do
-      before :each do
-        ctx = Reek::Core::CodeContext.new(nil, Reek::Source::SourceCode.from(@src).syntax_tree)
-        @smells = @detector.examine_context(ctx)
-      end
-
-      it 'records only that attribute' do
-        expect(@smells.length).to eq(1)
-      end
-
-      it 'reports the attribute name' do
-        expect(@smells[0].parameters[:name]).to eq(@attr_name)
-      end
-
-      it 'reports the declaration line number' do
-        expect(@smells[0].lines).to eq([1])
-      end
-
-      it 'reports the correct smell class' do
-        expect(@smells[0].smell_category).to eq(described_class.smell_category)
-      end
-
-      it 'reports the context fq name' do
-        expect(@smells[0].context).to eq('Fred')
-      end
-    end
-
-    context 'declared in a class' do
-      before :each do
-        @src = "class Fred; attr :#{@attr_name}; end"
-      end
-
-      it_should_behave_like 'one attribute found'
-    end
-
-    context 'reader in a class' do
-      before :each do
-        @src = "class Fred; attr_reader :#{@attr_name}; end"
-      end
-
-      it_should_behave_like 'one attribute found'
-    end
-
-    context 'writer in a class' do
-      before :each do
-        @src = "class Fred; attr_writer :#{@attr_name}; end"
-      end
-
-      it_should_behave_like 'one attribute found'
-    end
-
-    context 'accessor in a class' do
-      before :each do
-        @src = "class Fred; attr_accessor :#{@attr_name}; end"
-      end
-
-      it_should_behave_like 'one attribute found'
-    end
-
-    context 'declared in a module' do
-      before :each do
-        @src = "module Fred; attr :#{@attr_name}; end"
-      end
-
-      it_should_behave_like 'one attribute found'
-    end
-
-    context 'reader in a module' do
-      before :each do
-        @src = "module Fred; attr_reader :#{@attr_name}; end"
-      end
-
-      it_should_behave_like 'one attribute found'
-    end
-
-    context 'writer in a module' do
-      before :each do
-        @src = "module Fred; attr_writer :#{@attr_name}; end"
-      end
-
-      it_should_behave_like 'one attribute found'
-    end
-
-    context 'accessor in a module' do
-      before :each do
-        @src = "module Fred; attr_accessor :#{@attr_name}; end"
-      end
-
-      it_should_behave_like 'one attribute found'
-    end
-
-    context 'declared in a class' do
-      before :each do
-        @src = "class Fred; private; attr :#{@attr_name}
-          public :#{@attr_name}
-          private :#{@attr_name}
-          public :#{@attr_name}
-        end"
-      end
-
-      it_should_behave_like 'one attribute found'
-    end
-
-    context 'declared in a module' do
-      before :each do
-        @src = "module Fred; private; attr :#{@attr_name}
-          public :#{@attr_name}
-          private :#{@attr_name}
-          public :#{@attr_name}
-        end"
-      end
-      it_should_behave_like 'one attribute found'
-    end
-  end
-
-  context 'with two attribute' do
-    before :each do
-      @attr_name = 'super_thing'
-    end
-
-    shared_examples_for 'two attributes found' do
-      before :each do
-        ctx = Reek::Core::CodeContext.new(nil, Reek::Source::SourceCode.from(@src).syntax_tree)
-        @smells = @detector.examine_context(ctx)
-      end
-
-      it 'records only that attribute' do
-        expect(@smells.length).to eq(2)
-      end
-
-      it 'reports the attribute name' do
-        expect(@smells[0].parameters[:name]).to eq(@attr_name)
-      end
-
-      it 'reports the declaration line number' do
-        expect(@smells[0].lines).to eq([1])
-      end
-
-      it 'reports the correct smell class' do
-        expect(@smells[0].smell_category).to eq(described_class.smell_category)
-      end
-
-      it 'reports the context fq name' do
-        expect(@smells[0].context).to eq('Fred')
-      end
-    end
-
-    context 'declared in a class' do
-      before :each do
-        @src = "class Fred; private; attr :#{@attr_name}
-          public
-          attr :#{@attr_name}
+    it "doesn't record protected attributes" do
+      src = '
+        class Klass
           protected
           attr :iam_protected
-        end"
-      end
-
-      it_should_behave_like 'two attributes found'
+        end
+      '
+      expect(src).to_not reek_of(:Attribute, name: 'iam_protected')
     end
 
-    context 'declared in a class' do
-      before :each do
-        @src = "class Fred; private; attr :#{@attr_name}
-          public
-          attr :#{@attr_name}
-        end"
-      end
-
-      it_should_behave_like 'two attributes found'
-    end
-
-    context 'declared in a module' do
-      before :each do
-        @src = "module Fred; private; attr :#{@attr_name}
-          public
-          attr :#{@attr_name}
-        end"
-      end
-      it_should_behave_like 'two attributes found'
+    it "doesn't record private attributes" do
+      src = '
+        class Klass
+          private
+          attr :iam_private
+        end
+      '
+      expect(src).to_not reek_of(:Attribute, name: 'iam_private')
     end
   end
 end


### PR DESCRIPTION
as proposed in #495 here is a cleanup of the attributes spec.

i used the `ShouldReekOf` custom matcher to avoid shared specs and duplication.

is there some sort of code coverage in place?
i had to enable the Attribute smell by default to get it working with `ShouldReekOf`, is there a better way to do this?