### PR TITLE
Only attempt to require actual ruby files

### DIFF
--- a/lib/reek/smells.rb
+++ b/lib/reek/smells.rb
@@ -1,6 +1,7 @@
 require 'pathname'
 
 (Pathname.new(__FILE__).dirname + 'smells').children.each do |path|
+  next unless path.extname == '.rb'
   require_relative "smells/#{path.basename('.rb')}"
 end
 


### PR DESCRIPTION
This stops reek from attempting to require any `.swp` files that might be present.