### PR TITLE
Move smell-related classes out of /core to /smells.

### DIFF
--- a/lib/reek/core/examiner.rb
+++ b/lib/reek/core/examiner.rb
@@ -5,8 +5,8 @@
 #
 # See also https://github.com/troessner/reek/pull/468
 require_relative 'tree_walker'
-require_relative 'smell_repository'
 require_relative '../cli/warning_collector'
+require_relative '../smells/smell_repository'
 require_relative '../source/source_repository'
 
 module Reek
@@ -64,7 +64,7 @@ module Reek
 
       def run
         @sources.each do |source|
-          smell_repository = Core::SmellRepository.new(source.description, @smell_types)
+          smell_repository = Smells::SmellRepository.new(source.description, @smell_types)
           syntax_tree = source.syntax_tree
           Core::TreeWalker.new(smell_repository).process(syntax_tree) if syntax_tree
           smell_repository.report_on(@collector)
@@ -73,11 +73,11 @@ module Reek
 
       def eligible_smell_types(smell_types_to_filter_by = [])
         if smell_types_to_filter_by.any?
-          Core::SmellRepository.smell_types.select do |klass|
+          Smells::SmellRepository.smell_types.select do |klass|
             smell_types_to_filter_by.include? klass.smell_type
           end
         else
-          Core::SmellRepository.smell_types
+          Smells::SmellRepository.smell_types
         end
       end
     end

--- a/lib/reek/core/tree_walker.rb
+++ b/lib/reek/core/tree_walker.rb
@@ -12,7 +12,7 @@ module Reek
     # SMELL: This class is responsible for counting statements and for feeding
     # each context to the smell repository.
     class TreeWalker
-      def initialize(smell_repository = Core::SmellRepository.new)
+      def initialize(smell_repository = Smells::SmellRepository.new)
         @smell_repository = smell_repository
         @element = Context::RootContext.new
       end

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -1,5 +1,4 @@
 require_relative 'smell_detector'
-require_relative '../core/smell_configuration'
 
 module Reek
   module Smells
@@ -31,7 +30,7 @@ module Reek
       end
 
       def self.default_config
-        super.merge(Core::SmellConfiguration::ENABLED_KEY => false)
+        super.merge(SmellConfiguration::ENABLED_KEY => false)
       end
 
       #

--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -1,5 +1,4 @@
 require_relative 'smell_detector'
-require_relative '../core/smell_configuration'
 
 module Reek
   module Smells
@@ -21,7 +20,7 @@ module Reek
       def self.default_config
         super.merge(
           MAX_ALLOWED_PARAMS_KEY => DEFAULT_MAX_ALLOWED_PARAMS,
-          Core::SmellConfiguration::OVERRIDES_KEY => {
+          SmellConfiguration::OVERRIDES_KEY => {
             'initialize' => { MAX_ALLOWED_PARAMS_KEY => 5 }
           }
         )

--- a/lib/reek/smells/smell_configuration.rb
+++ b/lib/reek/smells/smell_configuration.rb
@@ -1,5 +1,5 @@
 module Reek
-  module Core
+  module Smells
     #
     # Represents a single set of configuration options for a smell detector
     #

--- a/lib/reek/smells/smell_detector.rb
+++ b/lib/reek/smells/smell_detector.rb
@@ -1,5 +1,5 @@
 require 'set'
-require_relative '../core/smell_configuration'
+require_relative 'smell_configuration'
 
 module Reek
   module Smells
@@ -30,7 +30,7 @@ module Reek
 
         def default_config
           {
-            Core::SmellConfiguration::ENABLED_KEY => true,
+            SmellConfiguration::ENABLED_KEY => true,
             EXCLUDE_KEY => DEFAULT_EXCLUDE_SET.dup
           }
         end
@@ -71,7 +71,7 @@ module Reek
 
       def initialize(source, config = self.class.default_config)
         @source = source
-        @config = Core::SmellConfiguration.new(config)
+        @config = SmellConfiguration.new(config)
         @smells_found = []
       end
 
@@ -98,7 +98,7 @@ module Reek
       end
 
       def enabled_for?(context)
-        enabled? && config_for(context)[Core::SmellConfiguration::ENABLED_KEY] != false
+        enabled? && config_for(context)[SmellConfiguration::ENABLED_KEY] != false
       end
 
       def exception?(context)

--- a/lib/reek/smells/smell_repository.rb
+++ b/lib/reek/smells/smell_repository.rb
@@ -1,9 +1,9 @@
 require_relative '../smells'
-require_relative '../smells/smell_detector'
+require_relative 'smell_detector'
 require_relative '../configuration/app_configuration'
 
 module Reek
-  module Core
+  module Smells
     #
     # Contains all the existing smells and exposes operations on them.
     #

--- a/spec/reek/configuration/app_configuration_spec.rb
+++ b/spec/reek/configuration/app_configuration_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 require_relative '../../../lib/reek/configuration/app_configuration'
-require_relative '../../../lib/reek/core/smell_repository'
+require_relative '../../../lib/reek/smells/smell_repository'
 
 RSpec.describe Reek::Configuration::AppConfiguration do
   let(:sample_configuration_path) { 'spec/samples/simple_configuration.reek' }
@@ -36,7 +36,7 @@ RSpec.describe Reek::Configuration::AppConfiguration do
   describe '.configure_smell_repository' do
     it 'should configure a given smell_repository' do
       Reek::Configuration::AppConfiguration.load_from_file(sample_configuration_path)
-      smell_repository = Reek::Core::SmellRepository.new('def m; end')
+      smell_repository = Reek::Smells::SmellRepository.new('def m; end')
       Reek::Configuration::AppConfiguration.configure_smell_repository smell_repository
 
       expect(smell_repository.detectors[Reek::Smells::DataClump]).to be_enabled

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -5,7 +5,7 @@ require_relative 'smell_detector_shared'
 RSpec.describe Reek::Smells::Attribute do
   let(:config) do
     {
-      Attribute: { Reek::Core::SmellConfiguration::ENABLED_KEY => true }
+      Attribute: { Reek::Smells::SmellConfiguration::ENABLED_KEY => true }
     }
   end
 

--- a/spec/reek/smells/smell_configuration_spec.rb
+++ b/spec/reek/smells/smell_configuration_spec.rb
@@ -1,9 +1,9 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/core/smell_configuration'
+require_relative '../../../lib/reek/smells/smell_configuration'
 
-RSpec.describe Reek::Core::SmellConfiguration do
+RSpec.describe Reek::Smells::SmellConfiguration do
   it 'returns the default value when key not found' do
-    cf = Reek::Core::SmellConfiguration.new({})
+    cf = described_class.new({})
     expect(cf.value('fred', nil, 27)).to eq(27)
   end
 
@@ -12,7 +12,7 @@ RSpec.describe Reek::Core::SmellConfiguration do
       @base_config = { 'enabled' => true, 'exclude' => [],
                        'reject' => [/^.$/, /[0-9]$/, /[A-Z]/],
                        'accept' => ['_'] }
-      @smell_config = Reek::Core::SmellConfiguration.new(@base_config)
+      @smell_config = described_class.new(@base_config)
     end
 
     it { expect(@smell_config.merge!({})).to eq(@base_config) }

--- a/spec/reek/smells/smell_detector_shared.rb
+++ b/spec/reek/smells/smell_detector_shared.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/core/smell_configuration'
+require_relative '../../../lib/reek/smells/smell_configuration'
 
 RSpec.shared_examples_for 'SmellDetector' do
   context 'exception matching follows the context' do
@@ -21,7 +21,7 @@ RSpec.shared_examples_for 'SmellDetector' do
 
   context 'configuration' do
     it 'becomes disabled when disabled' do
-      enabled_key = Reek::Core::SmellConfiguration::ENABLED_KEY
+      enabled_key = Reek::Smells::SmellConfiguration::ENABLED_KEY
       @detector.configure_with(enabled_key => false)
       expect(@detector).not_to be_enabled
     end

--- a/spec/reek/smells/smell_repository_spec.rb
+++ b/spec/reek/smells/smell_repository_spec.rb
@@ -1,9 +1,9 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/core/smell_repository'
+require_relative '../../../lib/reek/smells/smell_repository'
 
-RSpec.describe Reek::Core::SmellRepository do
+RSpec.describe Reek::Smells::SmellRepository do
   describe '.smell_types' do
-    let(:smell_types) { Reek::Core::SmellRepository.smell_types }
+    let(:smell_types) { described_class.smell_types }
 
     it 'should include existing smell_types' do
       expect(smell_types).to include(Reek::Smells::IrresponsibleModule)
@@ -19,7 +19,7 @@ RSpec.describe Reek::Core::SmellRepository do
     end
 
     it "should raise an ArgumentError if smell to configure doesn't exist" do
-      repository = Reek::Core::SmellRepository.new
+      repository = described_class.new
       expect { repository.configure('SomethingNonExistant', {}) }.
         to raise_error ArgumentError,
                        'Unknown smell type SomethingNonExistant found in configuration'

--- a/tasks/develop.rake
+++ b/tasks/develop.rake
@@ -1,11 +1,11 @@
 require 'rake/clean'
-require_relative '../lib/reek/core/smell_repository'
+require_relative '../lib/reek/smells/smell_repository'
 
 CONFIG_FILE = 'config/defaults.reek'
 
 file CONFIG_FILE do
   config = {}
-  Reek::Core::SmellRepository.smell_types.each do |klass|
+  Reek::Smells::SmellRepository.smell_types.each do |klass|
     config[klass.name.split(/::/)[-1]] = klass.default_config
   end
   $stderr.puts "Creating #{CONFIG_FILE}"


### PR DESCRIPTION
Fixes the last part of #517 and move SmellConfiguration and SmellRepository to lib/reek/smells.

Both classes are related to smells, but not to anything else in /core AFAIS.