### PR TITLE
Improve irresponsible module

### DIFF
--- a/features/samples.feature
+++ b/features/samples.feature
@@ -9,9 +9,10 @@ Feature: Basic smell detection
     Then the exit status indicates smells
     And it reports:
     """
-    inline.rb -- 44 warnings:
+    inline.rb -- 45 warnings:
       CompilationError has no descriptive comment (IrresponsibleModule)
       Dir has no descriptive comment (IrresponsibleModule)
+      File has no descriptive comment (IrresponsibleModule)
       File#self.write_with_backup has approx 6 statements (TooManyStatements)
       Inline declares the class variable @@directory (ClassVariable)
       Inline declares the class variable @@rootdir (ClassVariable)

--- a/lib/reek/context/code_context.rb
+++ b/lib/reek/context/code_context.rb
@@ -1,3 +1,4 @@
+require_relative '../core/code_comment'
 
 module Reek
   module Context
@@ -97,7 +98,7 @@ module Reek
 
       def config
         @config ||= if @exp
-                      Core::CodeComment.new(@exp.comments || '').config
+                      Core::CodeComment.new(@exp.full_comment || '').config
                     else
                       {}
                     end

--- a/lib/reek/context/module_context.rb
+++ b/lib/reek/context/module_context.rb
@@ -15,6 +15,10 @@ module Reek
       def node_instance_methods
         local_nodes(:def)
       end
+
+      def descriptively_commented?
+        Core::CodeComment.new(exp.leading_comment).descriptive?
+      end
     end
   end
 end

--- a/lib/reek/core/ast_node.rb
+++ b/lib/reek/core/ast_node.rb
@@ -10,8 +10,16 @@ module Reek
         super
       end
 
-      def comments
+      def full_comment
         @comments.map(&:text).join("\n")
+      end
+
+      def leading_comment
+        line = location.line
+        comment_lines = @comments.select do |comment|
+          comment.location.line < line
+        end
+        comment_lines.map(&:text).join("\n")
       end
 
       # @deprecated

--- a/lib/reek/smells/irresponsible_module.rb
+++ b/lib/reek/smells/irresponsible_module.rb
@@ -1,5 +1,4 @@
 require_relative 'smell_detector'
-require_relative '../core/code_comment'
 
 module Reek
   module Smells
@@ -13,7 +12,7 @@ module Reek
         [:class]
       end
 
-      def self.descriptive   # :nodoc:
+      def descriptive   # :nodoc:
         @descriptive ||= {}
       end
 
@@ -23,13 +22,17 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        comment = Core::CodeComment.new(ctx.exp.comments)
-        return [] if self.class.descriptive[ctx.full_name] ||= comment.descriptive?
+        return [] if descriptive?(ctx)
+        expression = ctx.exp
         [SmellWarning.new(self,
                           context: ctx.full_name,
-                          lines: [ctx.exp.line],
+                          lines: [expression.line],
                           message: 'has no descriptive comment',
-                          parameters: {  name: ctx.exp.text_name })]
+                          parameters: {  name: expression.text_name })]
+      end
+
+      def descriptive?(ctx)
+        descriptive[ctx.full_name] ||= ctx.descriptively_commented?
       end
     end
   end

--- a/spec/reek/context/code_context_spec.rb
+++ b/spec/reek/context/code_context_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Reek::Context::CodeContext do
       @exp = double('exp')
       allow(@exp).to receive(:name).and_return(@exp_name)
       allow(@exp).to receive(:full_name).and_return(@full_name)
-      allow(@exp).to receive(:comments).and_return('')
       @ctx = Reek::Context::CodeContext.new(nil, @exp)
     end
     it 'gets its short name from the exp' do
@@ -169,7 +168,7 @@ EOS
 
     before :each do
       allow(sniffer).to receive(:smell_type).and_return('DuplicateMethodCall')
-      allow(expression).to receive(:comments).and_return(
+      allow(expression).to receive(:full_comment).and_return(
         ':reek:DuplicateMethodCall: { allow_calls: [ puts ] }')
     end
 

--- a/spec/reek/smells/irresponsible_module_spec.rb
+++ b/spec/reek/smells/irresponsible_module_spec.rb
@@ -4,14 +4,6 @@ require_relative '../../../lib/reek/smells/irresponsible_module'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::IrresponsibleModule do
-  before(:each) do
-    @bad_module_name = 'WrongUn'
-    @source_name = 'dummy_source'
-    @detector = build(:smell_detector, smell_type: :IrresponsibleModule, source: @source_name)
-  end
-
-  it_should_behave_like 'SmellDetector'
-
   it 'does not report re-opened modules' do
     src = <<-EOS
       # Abstract base class
@@ -27,19 +19,12 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
       # test class
       class Responsible; end
     EOS
-    ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-    expect(@detector.examine_context(ctx)).to be_empty
+    expect(src).not_to reek_of(:IrresponsibleModule)
   end
 
   it 'reports a class without a comment' do
-    src = "class #{@bad_module_name}; end"
-    ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-    smells = @detector.examine_context(ctx)
-    expect(smells.length).to eq(1)
-    expect(smells[0].smell_category).to eq(Reek::Smells::IrresponsibleModule.smell_category)
-    expect(smells[0].smell_type).to eq(Reek::Smells::IrresponsibleModule.smell_type)
-    expect(smells[0].lines).to eq([1])
-    expect(smells[0].parameters[:name]).to eq(@bad_module_name)
+    src = 'class BadClass; end'
+    expect(src).to reek_of :IrresponsibleModule, name: 'BadClass'
   end
 
   it 'reports a class with an empty comment' do
@@ -47,7 +32,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
       #
       #
       #
-      class #{@bad_module_name}; end
+      class BadClass; end
     EOS
     expect(src).to reek_of :IrresponsibleModule
   end
@@ -63,14 +48,25 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
     expect(src).to reek_of(:IrresponsibleModule)
   end
 
-  it 'reports a fq module name correctly' do
+  it 'reports a class with a trailing comment' do
+    src = <<-EOS
+      class BadClass
+      end # end BadClass
+    EOS
+    expect(src).to reek_of(:IrresponsibleModule)
+  end
+
+  it 'reports a fully qualified class name correctly' do
     src = 'class Foo::Bar; end'
-    ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-    smells = @detector.examine_context(ctx)
-    expect(smells.length).to eq(1)
-    expect(smells[0].smell_category).to eq(described_class.smell_category)
-    expect(smells[0].smell_type).to eq(described_class.smell_type)
-    expect(smells[0].parameters[:name]).to eq('Foo::Bar')
-    expect(smells[0].context).to match(/#{smells[0].parameters['name']}/)
+    expect(src).to reek_of :IrresponsibleModule, name: 'Foo::Bar'
+  end
+
+  context 'when a smell is reported' do
+    before do
+      @source_name = 'dummy_source'
+      @detector = build(:smell_detector, smell_type: :IrresponsibleModule, source: @source_name)
+    end
+
+    it_should_behave_like 'SmellDetector'
   end
 end

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Reek::Source::SourceCode do
       source = "# this is\n# a comment\ndef foo; end"
       source_code = Reek::Source::SourceCode.new(source, '(string)')
       result = source_code.syntax_tree
-      expect(result.comments).to eq "# this is\n# a comment"
+      expect(result.leading_comment).to eq "# this is\n# a comment"
     end
 
     it 'cleanly processes empty source' do


### PR DESCRIPTION
Changes comment handling to only consider preceding comments as potentially descriptive. In particular, the following is not:

```
class Foo
  ...
end # class Foo
```

I haven't considered what to do with the following case, yet:

```
class Foo # handles bars
  ...
end
```