### PR TITLE
Require smells explicitly and fix some missing require_relatives

### DIFF
--- a/lib/reek/smells.rb
+++ b/lib/reek/smells.rb
@@ -1,13 +1,24 @@
-require 'pathname'
-
-(Pathname.new(__FILE__).dirname + 'smells').children.each do |path|
-  require_relative "smells/#{path.basename('.rb')}"
-end
-
-module Reek
-  #
-  # This module contains the various smell detectors.
-  #
-  module Smells
-  end
-end
+require_relative 'smells/attribute'
+require_relative 'smells/boolean_parameter'
+require_relative 'smells/class_variable'
+require_relative 'smells/control_parameter'
+require_relative 'smells/data_clump'
+require_relative 'smells/duplicate_method_call'
+require_relative 'smells/feature_envy'
+require_relative 'smells/irresponsible_module'
+require_relative 'smells/long_parameter_list'
+require_relative 'smells/long_yield_list'
+require_relative 'smells/module_initialize'
+require_relative 'smells/nested_iterators'
+require_relative 'smells/nil_check'
+require_relative 'smells/prima_donna_method'
+require_relative 'smells/repeated_conditional'
+require_relative 'smells/too_many_instance_variables'
+require_relative 'smells/too_many_methods'
+require_relative 'smells/too_many_statements'
+require_relative 'smells/uncommunicative_method_name'
+require_relative 'smells/uncommunicative_module_name'
+require_relative 'smells/uncommunicative_parameter_name'
+require_relative 'smells/uncommunicative_variable_name'
+require_relative 'smells/unused_parameters'
+require_relative 'smells/utility_function'

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -1,4 +1,6 @@
+require_relative 'smell_configuration'
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/boolean_parameter.rb
+++ b/lib/reek/smells/boolean_parameter.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/class_variable.rb
+++ b/lib/reek/smells/class_variable.rb
@@ -1,5 +1,6 @@
 require 'set'
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/control_parameter.rb
+++ b/lib/reek/smells/control_parameter.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/feature_envy.rb
+++ b/lib/reek/smells/feature_envy.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/irresponsible_module.rb
+++ b/lib/reek/smells/irresponsible_module.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -1,4 +1,6 @@
+require_relative 'smell_configuration'
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/long_yield_list.rb
+++ b/lib/reek/smells/long_yield_list.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/module_initialize.rb
+++ b/lib/reek/smells/module_initialize.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/nil_check.rb
+++ b/lib/reek/smells/nil_check.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/prima_donna_method.rb
+++ b/lib/reek/smells/prima_donna_method.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -1,5 +1,6 @@
-require_relative 'smell_detector'
 require_relative '../ast/ast_node'
+require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/too_many_methods.rb
+++ b/lib/reek/smells/too_many_methods.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/too_many_statements.rb
+++ b/lib/reek/smells/too_many_statements.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/uncommunicative_method_name.rb
+++ b/lib/reek/smells/uncommunicative_method_name.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -1,4 +1,5 @@
 require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -1,5 +1,6 @@
-require_relative 'smell_detector'
 require_relative '../ast/reference_collector'
+require_relative 'smell_detector'
+require_relative 'smell_warning'
 
 module Reek
   module Smells

--- a/lib/reek/tree_walker.rb
+++ b/lib/reek/tree_walker.rb
@@ -2,6 +2,7 @@ require_relative 'context/method_context'
 require_relative 'context/module_context'
 require_relative 'context/root_context'
 require_relative 'context/singleton_method_context'
+require_relative 'smells/smell_repository'
 
 module Reek
   #

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -1,4 +1,6 @@
 require_relative '../../lib/reek/smells'
+require_relative '../../lib/reek/smells/smell_detector'
+require_relative '../../lib/reek/smells/smell_warning'
 
 FactoryGirl.define do
   factory :smell_detector, class: Reek::Smells::SmellDetector do

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../../spec_helper'
 require_relative '../../../lib/reek/smells/attribute'
+require_relative '../../../lib/reek/smells/smell_configuration'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::Attribute do

--- a/spec/reek/smells/smell_repository_spec.rb
+++ b/spec/reek/smells/smell_repository_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative '../../../lib/reek/smells/smell_detector'
 require_relative '../../../lib/reek/smells/smell_repository'
 
 RSpec.describe Reek::Smells::SmellRepository do


### PR DESCRIPTION
As per the discussion in #513, let’s just require all of the smells explicitly.