### PR TITLE
Drop support for Ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: ruby
 bundler_args: --without local_development
 script: bundle exec rake
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2

--- a/docs/Reek-Driven-Development.md
+++ b/docs/Reek-Driven-Development.md
@@ -28,14 +28,6 @@ end
 
 By requiring "reek/spec":http://reek.rubyforge.org/rdoc/classes/Reek/Spec.html you gain access to the `reek` matcher, which returns true if and only if `reek` finds smells in your code. And if the test fails, the matcher produces an error message that includes details of all the smells it found.
 
-Note: if you're on ruby 1.9  and RSpec2 you should include Reek::Spec in the configuration block like so,
-
-```Ruby
-RSpec.configure do |c|
-  c.include(Reek::Spec)
-end
-```
-
 ## assert
 
 If you're not yet into BDD with Rspec, you can still gain the benefits of Reek-driven development using assertions:

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^bin/}).map { |path| File.basename(path) }
   s.homepage = 'https://github.com/troessner/reek/wiki'
   s.rdoc_options = %w(--main README.md -x assets/|bin/|config/|features/|spec/|tasks/)
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
   s.summary = 'Code smell detector for Ruby'
 
   s.add_runtime_dependency 'parser',   '~> 2.2.2.5'


### PR DESCRIPTION
Resolves #527.

* Do not run tests on Ruby 1.9 anymore (Travis CI)
* Remove Ruby 1.9 specific instructions from docs
* Bump `required_ruby_version` in gemspec from `1.9.3` to `2.0.0`

Anything missing? Basically just grepped for `1.9` in the repo. We could also think about pulling in more 2.0 specific stuff (keyword arguments, `%i` notation etc). Does `reek` have any Ruby 1.9 specific code that could be removed / simplified?