### PR TITLE
Fix annoying warning under ruby22 and refactor spec set up.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :local_development do
-  gem 'pry'
   platforms :mri do
-    if RUBY_VERSION >= '2.0.0'
-      gem 'byebug'
-      gem 'pry-byebug'
-    end
+    gem 'pry-byebug'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,15 +4,14 @@ require_relative '../lib/reek/configuration/app_configuration'
 
 Reek::CLI::Silencer.silently do
   require 'factory_girl'
+  begin
+    require 'pry-byebug'
+  rescue LoadError # rubocop:disable Lint/HandleExceptions
+  end
 end
 if Gem.loaded_specs['factory_girl'].version > Gem::Version.create('4.5.0')
   raise 'Remove the above silencer as well as this check now that ' \
         '`factory_girl` gem is updated to version greater than 4.5.0!'
-end
-
-begin
-  require 'pry-byebug'
-rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
 FactoryGirl.find_definitions


### PR DESCRIPTION
Regarding "Fix warning": Under ruby22 the following warning would clog the screen:

```
/home/timo/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54: warning: loading in progress, circular require considered harmful - /home/timo/.rvm/gems/ruby-2.2.0/gems/pry-0.10.1/lib/pry.rb
	from /home/timo/.rvm/gems/ruby-2.2.0/gems/rspec-core-3.2.3/exe/rspec:4:in  `<main>'
	from /home/timo/.rvm/gems/ruby-2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:38:in  `invoke'
	from /home/timo/.rvm/gems/ruby-2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:70:in  `run'
	from /home/timo/.rvm/gems/ruby-2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:85:in  `run'
	from /home/timo/.rvm/gems/ruby-2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/runner.rb:97:in  `setup'
	from /home/timo/.rvm/gems/ruby-2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1224:in  `load_spec_files'
	from /home/timo/.rvm/gems/ruby-2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1224:in  `each'
	from /home/timo/.rvm/gems/ruby-2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1226:in  `block in load_spec_files'
	from /home/timo/.rvm/gems/ruby-2.2.0/gems/rspec-core-3.2.3/lib/rspec/core/configuration.rb:1226:in  `load'
	from /home/timo/dev/reek/spec/reek/ast/object_refs_spec.rb:1:in  `<top (required)>'
	from /home/timo/dev/reek/spec/reek/ast/object_refs_spec.rb:1:in  `require_relative'
	from /home/timo/dev/reek/spec/spec_helper.rb:14:in  `<top (required)>'
````