### PR TITLE
Recognize methods defined with class << self syntax as singleton methods.

### DIFF
--- a/lib/reek/ast/ast_node.rb
+++ b/lib/reek/ast/ast_node.rb
@@ -5,8 +5,11 @@ module Reek
     # Base class for AST nodes extended with utility methods. Contains some
     # methods to ease the transition from Sexp to AST::Node.
     class ASTNode < ::Parser::AST::Node
+      attr_reader :parent
+
       def initialize(type, children = [], options = {})
         @comments = options.fetch(:comments, [])
+        @parent   = options.fetch(:parent, nil)
         super
       end
 

--- a/lib/reek/ast/sexp_extensions.rb
+++ b/lib/reek/ast/sexp_extensions.rb
@@ -266,6 +266,11 @@ module Reek
         def depends_on_instance?
           AST::ReferenceCollector.new(self).num_refs_to_self > 0
         end
+
+        def singleton_method?
+          # This catches the case where methods are defined within the "class << self" syntax.
+          parent.type == :sclass if parent
+        end
       end
 
       # Utility methods for :defs nodes.

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -53,6 +53,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(method_ctx)
+        return [] if method_ctx.exp.singleton_method?
         return [] if method_ctx.num_statements == 0
         return [] if method_ctx.references_self?
         return [] if num_helper_methods(method_ctx).zero?

--- a/lib/reek/tree_dresser.rb
+++ b/lib/reek/tree_dresser.rb
@@ -10,13 +10,13 @@ module Reek
       @klass_map = klass_map
     end
 
-    def dress(sexp, comment_map)
+    def dress(sexp, comment_map, parent = nil)
       return sexp unless sexp.is_a? ::Parser::AST::Node
       type = sexp.type
-      children = sexp.children.map { |child| dress(child, comment_map) }
+      children = sexp.children.map { |child| dress(child, comment_map, sexp) }
       comments = comment_map[sexp]
       @klass_map.klass_for(type).new(type, children,
-                                     location: sexp.loc, comments: comments)
+                                     location: sexp.loc, comments: comments, parent: parent)
     end
   end
 end

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -42,6 +42,28 @@ RSpec.describe Reek::Smells::UtilityFunction do
     end
   end
 
+  context 'Singleton methods' do
+    it 'for classes with `class << self` notation should not report UtilityFunction' do
+      src = 'class C; class << self; def m(a) a.to_s; end; end; end'
+      expect(src).not_to reek_of(:UtilityFunction)
+    end
+
+    it 'for classes with `self.` notation should not report UtilityFunction' do
+      src = 'class C; def self.m(a) a.to_s; end; end'
+      expect(src).not_to reek_of(:UtilityFunction)
+    end
+
+    it 'for modules with `class << self` notation should not report UtilityFunction' do
+      src = 'module M; class << self; def self.m(a) a.to_s; end; end; end'
+      expect(src).not_to reek_of(:UtilityFunction)
+    end
+
+    it 'for modules with `self.` notation should not report UtilityFunction' do
+      src = 'module M; def self.simple(a) a.to_s; end; end'
+      expect(src).not_to reek_of(:UtilityFunction)
+    end
+  end
+
   context 'with no calls' do
     it 'does not report empty method' do
       expect('def simple(arga) end').not_to reek_of(:UtilityFunction)


### PR DESCRIPTION
Fixes #112 
The way this works is that we're passing the parent scope for each sexp to Treedresser and then store this parent scope with each adorned ASTNode.
We then check in the UtilityFunction Detector if the parent scope is of type ":sclass".
I believe this is a simple yet elegant solution.