### PR TITLE
Integrate Ataru.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 cache: bundler
 language: ruby
 bundler_args: --without local_development
-script: bundle exec rake
+script:
+- bundle exec rake
+- bundle exec ataru check
 rvm:
   - 2.0.0
   - 2.1

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,7 +14,7 @@ You can use reek inside your Ruby file `check_dirty.rb`
 require 'reek'
 require 'reek/source/source_code'
 require 'reek/cli/report/report'
-require 'reek/core/examiner'
+require 'reek/examiner'
 
 source =<<END
 class Dirty
@@ -30,7 +30,7 @@ END
 
 source_code = Reek::Source::SourceCode.from(source)
 reporter = Reek::CLI::Report::TextReport.new
-reporter.add_examiner Reek::Core::Examiner.new(source_code)
+reporter.add_examiner Reek::Examiner.new(source_code)
 puts reporter.show
 ```
 

--- a/lib/reek/cli/report/report.rb
+++ b/lib/reek/cli/report/report.rb
@@ -1,5 +1,7 @@
 require 'rainbow'
 require 'json'
+require_relative 'formatter'
+require_relative 'heading_formatter'
 
 module Reek
   module CLI

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'activesupport', '~> 4.2'
   s.add_development_dependency 'aruba',         '~> 0.6.2'
+  s.add_development_dependency 'ataru',         '~> 0.2.0'
   s.add_development_dependency 'bundler',       '~> 1.1'
   s.add_development_dependency 'cucumber',      '~> 2.0'
   s.add_development_dependency 'factory_girl',  '~> 4.0'


### PR DESCRIPTION
Fixes #472 

I really like ataru but it has quite some annoying limitations. 
E.g. there is not silent flag. Which is why at the end of a rake run you'll see:

```
# Running:

..string -- 9 warnings:
  Dirty has no descriptive comment (IrresponsibleModule)
  Dirty#awful has 4 parameters (LongParameterList)
  Dirty#awful has approx 6 statements (TooManyStatements)
  Dirty#awful has boolean parameter 'log' (BooleanParameter)
  Dirty#awful has the parameter name 'x' (UncommunicativeParameterName)
  Dirty#awful has the variable name 'w' (UncommunicativeVariableName)
  Dirty#awful has unused parameter 'log' (UnusedParameters)
  Dirty#awful has unused parameter 'offset' (UnusedParameters)
  Dirty#awful has unused parameter 'y' (UnusedParameters)
.```

Annoying, but ok for me.