### PR TITLE
Fix Travis on JRuby-HEAD using explicit opts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,17 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - jruby-19mode
   - rbx-2
   - ruby-head
-  - jruby-head
 matrix:
+  include:
+    - rvm: jruby-19mode
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+    - rvm: jruby-head
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
   allow_failures:
     - rvm: jruby-head
+      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
     - rvm: ruby-head
   fast_finish: true
 notifications:


### PR DESCRIPTION
See https://travis-ci.org/troessner/reek/jobs/67756300#L297-L307

This is really only an issue on JRUBY-HEAD where cext.enabled property no longer exists.

```ruby
expected: ""
     got: "jruby: warning: unknown property jruby.cext.enabled\njruby: warning: unknown property jruby.cext.enabled\njruby: warning: unknown property jruby.cext.enabled\njruby: warning: unknown property jruby.cext.enabled\n"
(compared using ==)
Diff:
@@ -1 +1,5 @@
+jruby: warning: unknown property jruby.cext.enabled
+jruby: warning: unknown property jruby.cext.enabled
+jruby: warning: unknown property jruby.cext.enabled
+jruby: warning: unknown property jruby.cext.enabled
 (RSpec::Expectations::ExpectationNotMetError)
./features/step_definitions/reek_steps.rb:58:in `/^it reports no errors$/'
features/configuration_loading.feature:29:in `Then it reports no errors'
```

ref: https://github.com/rspec/rspec-dev/pull/115
