### PR TITLE
Fix reek descending into hidden directories.

### DIFF
--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -31,7 +31,7 @@ module Reek
           Find.find(given_path) do |path|
             pathname = Pathname.new(path)
             if pathname.directory?
-              exclude_path?(pathname) ? Find.prune : next
+              exclude_path?(pathname) || hidden_directory?(pathname) ? Find.prune : next
             else
               relevant_paths << pathname
             end
@@ -50,6 +50,10 @@ module Reek
 
       def print_no_such_file_error(path)
         $stderr.puts "Error: No such file - #{path}"
+      end
+
+      def hidden_directory?(pathname)
+        pathname.basename.to_s.start_with? '.'
       end
     end
   end

--- a/spec/reek/source/source_locator_spec.rb
+++ b/spec/reek/source/source_locator_spec.rb
@@ -3,6 +3,25 @@ require_relative '../../../lib/reek/source/source_locator'
 
 RSpec.describe Reek::Source::SourceLocator do
   describe '#sources' do
+    context 'applied to hidden directories' do
+      let(:path) { 'spec/samples/source_with_hidden_directories' }
+      let(:expected_files) do
+        ['spec/samples/source_with_hidden_directories/uncommunicative_parameter_name.rb']
+      end
+      let(:files_that_are_expected_to_be_ignored) do
+        ['spec/samples/source_with_hidden_directories/.hidden/uncommunicative_method_name.rb']
+      end
+
+      it 'does not scan hidden directories' do
+        sources = described_class.new([path]).sources
+
+        expect(sources.map(&:path)).
+          not_to include(files_that_are_expected_to_be_ignored)
+
+        expect(sources.map(&:path)).to eq expected_files
+      end
+    end
+
     context 'exclude paths' do
       let(:config) { 'spec/samples/configuration/with_excluded_paths.reek' }
       let(:path) { 'spec/samples/source_with_exclude_paths' }

--- a/spec/samples/source_with_hidden_directories/.hidden/uncommunicative_method_name.rb
+++ b/spec/samples/source_with_hidden_directories/.hidden/uncommunicative_method_name.rb
@@ -1,0 +1,5 @@
+# Klass comment.
+class Klass
+  def m
+  end
+end

--- a/spec/samples/source_with_hidden_directories/uncommunicative_parameter_name.rb
+++ b/spec/samples/source_with_hidden_directories/uncommunicative_parameter_name.rb
@@ -1,0 +1,6 @@
+# Klass comment
+class Klass
+  def method(a)
+    a + @x
+  end
+end


### PR DESCRIPTION
Fix of the first problem reported in #557:

>> files prefixed with a dot (.git)
files suffixed with a .cache
Everything. This was not the case in previous versions.