### PR TITLE
[WIP] Bump dev dependencies

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -16,7 +16,7 @@ class ReekWorld
   end
 
   def reek_with_pipe(stdin, args)
-    run_interactive("reek --no-color #{args}")
+    run "reek --no-color #{args}"
     type(stdin)
     close_input
   end

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'unparser', '~> 0.2.2'
 
   s.add_development_dependency 'activesupport', '~> 4.2'
-  s.add_development_dependency 'aruba',         '~> 0.6.2'
+  s.add_development_dependency 'aruba',         '~> 0.7.1'
   s.add_development_dependency 'ataru',         '~> 0.2.0'
   s.add_development_dependency 'bundler',       '~> 1.1'
   s.add_development_dependency 'cucumber',      '~> 2.0'

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl',  '~> 4.0'
   s.add_development_dependency 'rake',          '~> 10.0'
   s.add_development_dependency 'rspec',         '~> 3.0'
-  s.add_development_dependency 'rubocop',       '~> 0.30.0'
+  s.add_development_dependency 'rubocop',       '~> 0.32.1'
 end


### PR DESCRIPTION
Today in yakshaving – did `bundle outdated`, decided to bump depedencies before other work, [found out it’s not as trivial as usual](https://github.com/cucumber/aruba/pull/277).

This is a work-in-progress till that issue is fixed and aruba 0.7.2 released.