### PR TITLE
Redo Report::HTMLReport#show and its spec

### DIFF
--- a/lib/reek/report/report.rb
+++ b/lib/reek/report/report.rb
@@ -129,13 +129,11 @@ module Reek
     class HTMLReport < Base
       require 'erb'
 
-      def show
-        path = File.expand_path('../../../../assets/html_output.html.erb',
-                                __FILE__)
-        File.open('reek.html', 'w+') do |file|
-          file.puts ERB.new(File.read(path)).result(binding)
-        end
-        print("Html file saved\n")
+      def show(target_path = 'reek.html')
+        template_path = '../../../../assets/html_output.html.erb'
+        erb = ERB.new(File.read(File.expand_path(template_path, __FILE__)))
+        File.write target_path, erb.result(binding)
+        puts 'HTML file saved'
       end
     end
 

--- a/spec/reek/report/html_report_spec.rb
+++ b/spec/reek/report/html_report_spec.rb
@@ -1,3 +1,4 @@
+require 'tempfile'
 require_relative '../../spec_helper'
 require_relative '../../../lib/reek/examiner'
 require_relative '../../../lib/reek/report/report'
@@ -13,13 +14,10 @@ RSpec.describe Reek::Report::HTMLReport do
     end
 
     it 'has the text 0 total warnings' do
-      instance.show
-
-      file = File.expand_path('../../../../reek.html', __FILE__)
-      text = File.read(file)
-      File.delete(file)
-
-      expect(text).to include('0 total warnings')
+      tempfile = Tempfile.new(['Reek::Report::HTMLReport.', '.html'])
+      response = "HTML file saved\n"
+      expect { instance.show tempfile.path }.to output(response).to_stdout
+      expect(tempfile.read).to include('0 total warnings')
     end
   end
 end


### PR DESCRIPTION
I got frustrated by the `Html file saved` printed on spec runs. This PR:
* properly capitalises that line (is this backward-incompatible? if so I’ll make it keep the awful case),
* uses `File.write` and side-steps a line-wrapping need in `Report::HTMLReport#show`,
* redoes the spec to use a (legibly-named) tempfile.