### PR TITLE
ObjectRefs: track lines for FeatureEnvy

### DIFF
--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -34,7 +34,7 @@ module Reek
       end
 
       def line
-        loc.line
+        loc.line unless loc.nil?
       end
 
       # @deprecated

--- a/lib/reek/ast/object_refs.rb
+++ b/lib/reek/ast/object_refs.rb
@@ -1,33 +1,30 @@
 module Reek
+  # @api private
   module AST
+    ObjectRef = Struct.new(:name, :line)
     #
     # Manages and counts the references out of a method to other objects.
     #
-    # @api private
-    class ObjectRefs  # :nodoc:
+    class ObjectRefs
       def initialize
-        @refs = Hash.new(0)
+        @refs = Hash.new { |refs, name| refs[name] = [] }
       end
 
-      def record_reference_to(exp)
-        @refs[exp] += 1
+      def most_popular
+        max = @refs.values.map(&:size).max
+        @refs.select { |_name, refs| refs.size == max }
       end
 
-      def references_to(exp)
-        @refs[exp]
+      def record_reference_to(name, line: nil)
+        @refs[name] << ObjectRef.new(name, line)
       end
 
-      def max_refs
-        @refs.values.max || 0
-      end
-
-      def max_keys
-        max = max_refs
-        @refs.select { |_key, val| val == max }
+      def references_to(name)
+        @refs[name]
       end
 
       def self_is_max?
-        max_keys.length == 0 || @refs[:self] == max_refs
+        @refs.empty? || most_popular.keys.include?(:self)
       end
     end
   end

--- a/lib/reek/context/method_context.rb
+++ b/lib/reek/context/method_context.rb
@@ -56,7 +56,7 @@ module Reek
       end
 
       def envious_receivers
-        return [] if @refs.self_is_max?
+        return {} if @refs.self_is_max?
         @refs.max_keys
       end
 

--- a/lib/reek/context/method_context.rb
+++ b/lib/reek/context/method_context.rb
@@ -43,11 +43,11 @@ module Reek
         receiver ||= [:self]
         case receiver[0]
         when :lvasgn
-          @refs.record_reference_to(receiver.name)
+          @refs.record_reference_to(receiver.name, line: exp.line)
         when :lvar
-          @refs.record_reference_to(receiver.name) unless meth == :new
+          @refs.record_reference_to(receiver.name, line: exp.line) unless meth == :new
         when :self
-          @refs.record_reference_to(:self)
+          @refs.record_reference_to(:self, line: exp.line)
         end
       end
 
@@ -57,7 +57,7 @@ module Reek
 
       def envious_receivers
         return {} if @refs.self_is_max?
-        @refs.max_keys
+        @refs.most_popular
       end
 
       def references_self?

--- a/lib/reek/context/singleton_method_context.rb
+++ b/lib/reek/context/singleton_method_context.rb
@@ -8,7 +8,7 @@ module Reek
     # @api private
     class SingletonMethodContext < MethodContext
       def envious_receivers
-        []
+        {}
       end
     end
   end

--- a/lib/reek/smells/feature_envy.rb
+++ b/lib/reek/smells/feature_envy.rb
@@ -51,7 +51,7 @@ module Reek
         method_ctx.envious_receivers.map do |name, refs|
           SmellWarning.new self,
                            context: method_ctx.full_name,
-                           lines: [method_ctx.exp.line],
+                           lines: refs.map(&:line),
                            message: "refers to #{name} more than self",
                            parameters: { name: name.to_s, count: refs.size }
         end

--- a/lib/reek/smells/feature_envy.rb
+++ b/lib/reek/smells/feature_envy.rb
@@ -48,13 +48,12 @@ module Reek
       #
       def examine_context(method_ctx)
         return [] unless method_ctx.references_self?
-        method_ctx.envious_receivers.map do |ref, occurs|
-          target = ref.to_s
+        method_ctx.envious_receivers.map do |name, refs|
           SmellWarning.new self,
                            context: method_ctx.full_name,
                            lines: [method_ctx.exp.line],
-                           message: "refers to #{target} more than self",
-                           parameters: { name: target, count: occurs }
+                           message: "refers to #{name} more than self",
+                           parameters: { name: name.to_s, count: refs.size }
         end
       end
     end

--- a/spec/reek/ast/object_refs_spec.rb
+++ b/spec/reek/ast/object_refs_spec.rb
@@ -8,24 +8,24 @@ RSpec.describe Reek::AST::ObjectRefs do
 
   context 'when empty' do
     it 'should report no refs to self' do
-      expect(@refs.references_to(:self)).to eq(0)
+      expect(@refs.references_to(:self)).to be_empty
     end
   end
 
   context 'with references to a, b, and a' do
     context 'with no refs to self' do
       before(:each) do
-        @refs.record_reference_to('a')
-        @refs.record_reference_to('b')
-        @refs.record_reference_to('a')
+        @refs.record_reference_to(:a)
+        @refs.record_reference_to(:b)
+        @refs.record_reference_to(:a)
       end
 
       it 'should report no refs to self' do
-        expect(@refs.references_to(:self)).to eq(0)
+        expect(@refs.references_to(:self)).to be_empty
       end
 
       it 'should report :a as the max' do
-        expect(@refs.max_keys).to eq('a' => 2)
+        expect(@refs.most_popular).to include(:a)
       end
 
       it 'should not report self as the max' do
@@ -38,12 +38,12 @@ RSpec.describe Reek::AST::ObjectRefs do
         end
 
         it 'should report 1 ref to self' do
-          expect(@refs.references_to(:self)).to eq(1)
+          expect(@refs.references_to(:self).size).to eq(1)
         end
 
         it 'should not report self among the max' do
-          expect(@refs.max_keys).to include('a')
-          expect(@refs.max_keys).not_to include(:self)
+          expect(@refs.most_popular).to include(:a)
+          expect(@refs.most_popular).not_to include(:self)
         end
 
         it 'should not report self as the max' do
@@ -57,19 +57,19 @@ RSpec.describe Reek::AST::ObjectRefs do
     before(:each) do
       @refs.record_reference_to(:self)
       @refs.record_reference_to(:self)
-      @refs.record_reference_to('a')
+      @refs.record_reference_to(:a)
       @refs.record_reference_to(:self)
-      @refs.record_reference_to('b')
-      @refs.record_reference_to('a')
+      @refs.record_reference_to(:b)
+      @refs.record_reference_to(:a)
       @refs.record_reference_to(:self)
     end
 
     it 'should report all refs to self' do
-      expect(@refs.references_to(:self)).to eq(4)
+      expect(@refs.references_to(:self).size).to eq(4)
     end
 
     it 'should report self among the max' do
-      expect(@refs.max_keys).to eq(self: 4)
+      expect(@refs.most_popular).to include(:self)
     end
 
     it 'should report self as the max' do
@@ -79,20 +79,20 @@ RSpec.describe Reek::AST::ObjectRefs do
 
   context 'when self is not the only max' do
     before(:each) do
-      @refs.record_reference_to('a')
+      @refs.record_reference_to(:a)
       @refs.record_reference_to(:self)
       @refs.record_reference_to(:self)
-      @refs.record_reference_to('b')
-      @refs.record_reference_to('a')
+      @refs.record_reference_to(:b)
+      @refs.record_reference_to(:a)
     end
 
     it 'should report all refs to self' do
-      expect(@refs.references_to(:self)).to eq(2)
+      expect(@refs.references_to(:self).size).to eq(2)
     end
 
     it 'should report self among the max' do
-      expect(@refs.max_keys).to include('a')
-      expect(@refs.max_keys).to include(:self)
+      expect(@refs.most_popular).to include(:a)
+      expect(@refs.most_popular).to include(:self)
     end
 
     it 'should report self as the max' do
@@ -102,19 +102,19 @@ RSpec.describe Reek::AST::ObjectRefs do
 
   context 'when self is not among the max' do
     before(:each) do
-      @refs.record_reference_to('a')
-      @refs.record_reference_to('b')
-      @refs.record_reference_to('a')
-      @refs.record_reference_to('b')
+      @refs.record_reference_to(:a)
+      @refs.record_reference_to(:b)
+      @refs.record_reference_to(:a)
+      @refs.record_reference_to(:b)
     end
 
     it 'should report all refs to self' do
-      expect(@refs.references_to(:self)).to eq(0)
+      expect(@refs.references_to(:self).size).to eq(0)
     end
 
     it 'should not report self among the max' do
-      expect(@refs.max_keys).to include('a')
-      expect(@refs.max_keys).to include('b')
+      expect(@refs.most_popular).to include(:a)
+      expect(@refs.most_popular).to include(:b)
     end
 
     it 'should not report self as the max' do

--- a/spec/reek/context/method_context_spec.rb
+++ b/spec/reek/context/method_context_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Reek::Context::MethodContext do
     end
 
     it 'should ignore explicit calls to self' do
-      mc.refs.record_reference_to [:lvar, :other]
+      mc.refs.record_reference_to :other
       mc.record_call_to s(:send, s(:self), :thing)
       expect(mc.envious_receivers).to be_empty
     end
@@ -46,7 +46,7 @@ RSpec.describe Reek::Context::MethodContext do
 
     it 'should record envious calls' do
       mc.record_call_to s(:send, s(:lvar, :bar), :baz)
-      expect(mc.envious_receivers).to eq(bar: 1)
+      expect(mc.envious_receivers).to include(:bar)
     end
   end
 end

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -260,7 +260,6 @@ RSpec.describe Reek::Smells::FeatureEnvy do
     end
 
     it 'reports the referring lines' do
-      skip
       expect(@smells[0].lines).to eq([2, 4, 5])
     end
   end


### PR DESCRIPTION
This makes `ObjectRefs` collect `ObjectRef` objects, which track the callsite lines, and makes `FeatureEnvy` use it to fix #480.