### PR TITLE
Bump dev dependencies

### DIFF
--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -27,7 +27,7 @@ end
 
 Given(/^the "(.*?)" sample file exists$/) do |file_name|
   full_path = File.expand_path file_name, 'spec/samples'
-  in_current_dir { FileUtils.cp full_path, file_name }
+  in_current_directory { FileUtils.cp full_path, file_name }
 end
 
 Given(/^a directory called 'clean_files' containing some clean files$/) do
@@ -135,7 +135,7 @@ When(/^I run "reek (.*?)" in the subdirectory$/) do |args|
 end
 
 Given(/^a masking configuration file in the HOME directory$/) do
-  set_env('HOME', File.expand_path(File.join(current_dir, 'home')))
+  set_env('HOME', File.expand_path(File.join(current_directory, 'home')))
   write_file('home/config.reek', <<-EOS.strip_heredoc)
     ---
     DuplicateMethodCall:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -16,7 +16,7 @@ class ReekWorld
   end
 
   def reek_with_pipe(stdin, args)
-    run_interactive("reek --no-color #{args}")
+    run "reek --no-color #{args}"
     type(stdin)
     close_input
   end

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'unparser', '~> 0.2.2'
 
   s.add_development_dependency 'activesupport', '~> 4.2'
-  s.add_development_dependency 'aruba',         '~> 0.6.2'
+  s.add_development_dependency 'aruba',         '~> 0.7.2'
   s.add_development_dependency 'ataru',         '~> 0.2.0'
   s.add_development_dependency 'bundler',       '~> 1.1'
   s.add_development_dependency 'cucumber',      '~> 2.0'

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl',  '~> 4.0'
   s.add_development_dependency 'rake',          '~> 10.0'
   s.add_development_dependency 'rspec',         '~> 3.0'
-  s.add_development_dependency 'rubocop',       '~> 0.30.0'
+  s.add_development_dependency 'rubocop',       '~> 0.32.1'
 end


### PR DESCRIPTION
This bumps dev dependencies to their current versions. Big shout-out to @maxmeyer for fixing https://github.com/cucumber/aruba/pull/277 on the spot and releasing aruba 0.7.2! :sparkles: 