### PR TITLE
Move report option mapping into Report

### DIFF
--- a/lib/reek/cli/option_interpreter.rb
+++ b/lib/reek/cli/option_interpreter.rb
@@ -1,8 +1,6 @@
 require 'forwardable'
 require_relative 'input'
-require_relative '../report/report'
-require_relative '../report/formatter'
-require_relative '../report/heading_formatter'
+require_relative '../report'
 
 module Reek
   module CLI
@@ -31,48 +29,24 @@ module Reek
             heading_formatter: heading_formatter)
       end
 
-      # TODO: Move report type mapping into Report
       def report_class
-        case @options.report_format
-        when :yaml
-          Report::YAMLReport
-        when :json
-          Report::JSONReport
-        when :html
-          Report::HTMLReport
-        when :xml
-          Report::XMLReport
-        else # :text
-          Report::TextReport
-        end
+        Report.report_class(@options.report_format)
       end
 
       def warning_formatter
-        klass = if @options.show_links
-                  Report::WikiLinkWarningFormatter
-                else
-                  Report::SimpleWarningFormatter
-                end
-        klass.new(location_formatter)
+        warning_formatter_class.new(location_formatter)
+      end
+
+      def warning_formatter_class
+        Report.warning_formatter_class(@options.show_links ? :wiki_links : :simple)
       end
 
       def location_formatter
-        case @options.location_format
-        when :single_line
-          Report::SingleLineLocationFormatter
-        when :plain
-          Report::BlankLocationFormatter
-        else # :numbers
-          Report::DefaultLocationFormatter
-        end
+        Report.location_formatter(@options.location_format)
       end
 
       def heading_formatter
-        if @options.show_empty
-          Report::HeadingFormatter::Verbose
-        else
-          Report::HeadingFormatter::Quiet
-        end
+        Report.heading_formatter(@options.show_empty ? :verbose : :quiet)
       end
 
       def sort_by_issue_count

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -15,7 +15,9 @@ module Reek
       def initialize(argv = [])
         @argv    = argv
         @parser  = OptionParser.new
-        @options = OpenStruct.new(colored: color_support?,
+        @options = OpenStruct.new(report_format: :text,
+                                  location_format: :numbers,
+                                  colored: color_support?,
                                   smells_to_detect: [])
         set_up_parser
       end

--- a/lib/reek/report.rb
+++ b/lib/reek/report.rb
@@ -1,0 +1,71 @@
+require_relative 'report/report'
+require_relative 'report/formatter'
+require_relative 'report/heading_formatter'
+
+module Reek
+  # Reek reporting functionality.
+  module Report
+    module_function
+
+    # @api private
+    REPORT_CLASSES = {
+      yaml: YAMLReport,
+      json: JSONReport,
+      html: HTMLReport,
+      xml: XMLReport,
+      text: TextReport
+    }
+
+    # @api private
+    LOCATION_FORMATTERS = {
+      single_line: SingleLineLocationFormatter,
+      plain: BlankLocationFormatter,
+      numbers: DefaultLocationFormatter
+    }
+
+    # @api private
+    HEADING_FORMATTERS = {
+      verbose: HeadingFormatter::Verbose,
+      quiet: HeadingFormatter::Quiet }
+
+    # @api private
+    WARNING_FORMATTER_CLASSES = {
+      wiki_links: WikiLinkWarningFormatter,
+      simple: SimpleWarningFormatter
+    }
+
+    # Map report format symbol to a report class.
+    #
+    # @param [Symbol] report_format The format to map
+    #
+    # @return The mapped report class
+    #
+    # @api private
+    def report_class(report_format)
+      REPORT_CLASSES.fetch(report_format) do
+        raise "Unknown report format: #{report_format}"
+      end
+    end
+
+    # @api private
+    def location_formatter(location_format)
+      LOCATION_FORMATTERS.fetch(location_format) do
+        raise "Unknown location format: #{location_format}"
+      end
+    end
+
+    # @api private
+    def heading_formatter(heading_format)
+      HEADING_FORMATTERS.fetch(heading_format) do
+        raise "Unknown heading format: #{heading_format}"
+      end
+    end
+
+    # @api private
+    def warning_formatter_class(warning_format)
+      WARNING_FORMATTER_CLASSES.fetch(warning_format) do
+        raise "Unknown warning format: #{warning_format}"
+      end
+    end
+  end
+end

--- a/spec/reek/cli/option_interpreter_spec.rb
+++ b/spec/reek/cli/option_interpreter_spec.rb
@@ -4,12 +4,17 @@ require_relative '../../../lib/reek/cli/options'
 require_relative '../../../lib/reek/report/report'
 
 RSpec.describe Reek::CLI::OptionInterpreter do
-  let(:options) { OpenStruct.new }
-  let(:instance) { Reek::CLI::OptionInterpreter.new(options) }
-
   describe '#reporter' do
-    it 'returns a Report::TextReport instance by default' do
-      expect(instance.reporter).to be_instance_of Reek::Report::TextReport
+    let(:instance) { Reek::CLI::OptionInterpreter.new(options) }
+
+    context 'with a valid set of options' do
+      let(:options) do
+        OpenStruct.new(report_format: :text,
+                       location_format: :plain)
+      end
+      it 'returns an object of the correct subclass of Report::Base' do
+        expect(instance.reporter).to be_instance_of Reek::Report::TextReport
+      end
     end
   end
 end

--- a/spec/reek/cli/options_spec.rb
+++ b/spec/reek/cli/options_spec.rb
@@ -3,17 +3,26 @@ require_relative '../../spec_helper'
 require_relative '../../../lib/reek/cli/options'
 
 RSpec.describe Reek::CLI::Options do
-  describe '#initialize' do
-    it 'should enable colors when stdout is a TTY' do
-      allow($stdout).to receive_messages(tty?: false)
-      options = Reek::CLI::Options.new.parse
-      expect(options.colored).to be false
-    end
+  describe '#parse' do
+    context 'with no arguments passed' do
+      let(:options) { Reek::CLI::Options.new.parse }
+      it 'enables colors when stdout is a TTY' do
+        allow($stdout).to receive_messages(tty?: false)
+        expect(options.colored).to be false
+      end
 
-    it 'should not enable colors when stdout is not a TTY' do
-      allow($stdout).to receive_messages(tty?: true)
-      options = Reek::CLI::Options.new.parse
-      expect(options.colored).to be true
+      it 'does not enable colors when stdout is not a TTY' do
+        allow($stdout).to receive_messages(tty?: true)
+        expect(options.colored).to be true
+      end
+
+      it 'sets a valid default value for report_format' do
+        expect(options.report_format).to eq :text
+      end
+
+      it 'sets a valid default value for location_format' do
+        expect(options.location_format).to eq :numbers
+      end
     end
   end
 end


### PR DESCRIPTION
Re-targeted version of #552.

- Delegate option mapping from OptionInterpreter to Report
- Demand a valid option to be passed instead of relying on defaults