### PR TITLE
Target JRuby 9.0.0.0 (rather than JRuby 1.7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ rvm:
   - ruby-head
 matrix:
   include:
-    - rvm: jruby-19mode
-      env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
+    - rvm: jruby
+      env: JRUBY_OPTS='--2.0 --server -Xcompile.invokedynamic=false'
     - rvm: jruby-head
       env: JRUBY_OPTS='--server -Xcompile.invokedynamic=false'
   allow_failures:


### PR DESCRIPTION
Ok, this one might be controversial, but here goes: I think reek 3 should support JRuby 9.0.0.0 (even though it’s not released yet) rather than JRuby 1.7.

In my opinion one of the main reasons we dropped Ruby 1.9 support in reek 3 was to be able to use Ruby 2.0 syntax, from keyword arguments to things like `__dir__`. JRuby 1.7 supports only Ruby 1.9 syntax (and features), while JRuby 9.0.0.0 supports Ruby 2.2 syntax (and features) – so if we want to support JRuby 1.7 in reek 3 then using Ruby 2.0 features would have to wait for reek 4.