### PR TITLE
Handle modifier style use of module_function for UtilityFunction

### DIFF
--- a/lib/reek/ast/sexp_extensions.rb
+++ b/lib/reek/ast/sexp_extensions.rb
@@ -254,43 +254,7 @@ module Reek
       # Checking if a method is a singleton method.
       module SingletonMethod
         def singleton_method?
-          singleton_method_via_class_self_notation? ||
-            singleton_method_via_module_function?
-        end
-
-        # Ruby allows us to make a method a singleton_method after having defined the
-        # method via `module_function`.
-        #
-        # To check if we used "module_function" for a method we need to check on the parent
-        # level of the method in question if there is a call to "module_function".
-        # Given someting like
-        #   class C
-        #     def m; 3 + 7; end
-        #     module_function :m
-        #   end
-        # the AST (truncated, without the class definition) would look like this:
-        #   (def :m
-        #     (args)
-        #     (send
-        #       (int 3) :+
-        #       (int 7)))
-        #   (send nil :module_function
-        #     (sym :m))))
-        # With multiple arguments to module_function this gets more complicated:
-        #   (send nil :module_function
-        #     (sym :m1)
-        #     (send nil :m2))
-        #
-        # @return [Boolean]
-        def singleton_method_via_module_function?
-          return unless parent
-          module_function_calls(parent).any? do |module_function_call|
-            method_name_nodes = module_function_call.children[2..-1]
-            method_names = method_name_nodes.map do |node|
-              node.children.last
-            end
-            method_names.include?(name)
-          end
+          singleton_method_via_class_self_notation?
         end
 
         # Ruby allows us to make a method a singleton_method using the
@@ -302,16 +266,6 @@ module Reek
         def singleton_method_via_class_self_notation?
           return unless parent
           parent.type == :sclass
-        end
-
-        private
-
-        def module_function_calls(parent)
-          parent.children.select do |elem|
-            elem.is_a?(::Parser::AST::Node) &&
-              elem.type == :send &&
-              elem.children[1] == :module_function
-          end
         end
       end
 

--- a/lib/reek/context/method_context.rb
+++ b/lib/reek/context/method_context.rb
@@ -38,6 +38,10 @@ module Reek
         @default_assignments ||=
           exp.parameters.select(&:optional_argument?).map(&:children)
       end
+
+      def singleton_method?
+        exp.singleton_method? || visibility == :module_function
+      end
     end
   end
 end

--- a/lib/reek/context/root_context.rb
+++ b/lib/reek/context/root_context.rb
@@ -11,6 +11,10 @@ module Reek
         super(nil, exp)
       end
 
+      def type
+        :root
+      end
+
       def full_name
         ''
       end

--- a/lib/reek/smells/smell_repository.rb
+++ b/lib/reek/smells/smell_repository.rb
@@ -34,8 +34,8 @@ module Reek
         @detectors.each_value { |detector| detector.report_on(listener) }
       end
 
-      def examine(scope, node_type)
-        smell_listeners[node_type].each do |detector|
+      def examine(scope)
+        smell_listeners[scope.type].each do |detector|
           detector.examine(scope)
         end
       end

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -54,7 +54,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(method_ctx)
-        return [] if method_ctx.exp.singleton_method?
+        return [] if method_ctx.singleton_method?
         return [] if method_ctx.num_statements == 0
         return [] if method_ctx.references_self?
         return [] if num_helper_methods(method_ctx).zero?

--- a/spec/reek/context/code_context_spec.rb
+++ b/spec/reek/context/code_context_spec.rb
@@ -188,4 +188,55 @@ EOS
       end
     end
   end
+
+  describe '#append_child_context' do
+    let(:context) { Reek::Context::CodeContext.new(nil, double('exp1')) }
+    let(:first_child) { Reek::Context::CodeContext.new(context, double('exp2')) }
+    let(:second_child) { Reek::Context::CodeContext.new(context, double('exp3')) }
+
+    it 'appends the child to the list of children' do
+      context.append_child_context first_child
+      context.append_child_context second_child
+      expect(context.children).to eq [first_child, second_child]
+    end
+  end
+
+  describe '#track_visibility' do
+    let(:context) { Reek::Context::CodeContext.new(nil, double('exp1')) }
+    let(:first_child) { Reek::Context::CodeContext.new(context, double('exp2', name: :foo)) }
+    let(:second_child) { Reek::Context::CodeContext.new(context, double('exp3')) }
+
+    it 'sets visibility on subsequent child contexts' do
+      context.append_child_context first_child
+      context.track_visibility :private
+      context.append_child_context second_child
+      expect(first_child.visibility).to eq :public
+      expect(second_child.visibility).to eq :private
+    end
+
+    it 'sets visibility on specifically mentioned child contexts' do
+      context.append_child_context first_child
+      context.track_visibility :private, [first_child.name]
+      context.append_child_context second_child
+      expect(first_child.visibility).to eq :private
+      expect(second_child.visibility).to eq :public
+    end
+  end
+
+  describe '#each' do
+    let(:context) { Reek::Context::CodeContext.new(nil, double('exp1')) }
+    let(:first_child) { Reek::Context::CodeContext.new(context, double('exp2')) }
+    let(:second_child) { Reek::Context::CodeContext.new(context, double('exp3')) }
+
+    it 'yields each child' do
+      context.append_child_context first_child
+      context.append_child_context second_child
+      result = []
+      context.each do |ctx|
+        result << ctx
+      end
+
+      expect(result).to eq [context, first_child, second_child]
+    end
+  end
 end

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -73,9 +73,54 @@ RSpec.describe Reek::Smells::UtilityFunction do
           class C
             def m1(a) a.to_s; end
             def m2(a) a.to_s; end
-            module_function :m1, m2
+            module_function :m1, :m2
           end
           EOS
+        expect(src).not_to reek_of(:UtilityFunction)
+      end
+
+      it 'does not report module functions defined by earlier modifier' do
+        src = <<-EOF
+          module M
+            module_function
+            def simple(a) a.to_s; end
+          end
+        EOF
+        expect(src).not_to reek_of(:UtilityFunction)
+      end
+
+      it 'reports functions preceded by canceled modifier' do
+        src = <<-EOF
+          module M
+            module_function
+            public
+            def simple(a) a.to_s; end
+          end
+        EOF
+        expect(src).to reek_of(:UtilityFunction)
+      end
+
+      it 'does not report when module_function is called in separate scope' do
+        src = <<-EOF
+          class C
+            def m(a) a.to_s; end
+            begin
+              module_function :m
+            end
+          end
+        EOF
+        expect(src).not_to reek_of(:UtilityFunction)
+      end
+
+      it 'does not report when module_function modifier is called in separate scope' do
+        src = <<-EOF
+          class C
+            begin
+              module_function
+            end
+            def m(a) a.to_s; end
+          end
+        EOF
         expect(src).not_to reek_of(:UtilityFunction)
       end
     end

--- a/spec/reek/tree_walker_spec.rb
+++ b/spec/reek/tree_walker_spec.rb
@@ -38,7 +38,7 @@ end
 # all contexts.
 class TestSmellRepository
   attr_reader :num_statements
-  def examine(context, _type)
+  def examine(context)
     @num_statements = context.num_statements
   end
 end


### PR DESCRIPTION
This fixes #582.

To be able to track calls to module_function in all cases, these calls are handled during the walking of the tree by TreeWalker. Parent contexts track the currently set visibility and pass it on to any new child contexts. If module_function is used with arguments, the parent context will instead modify the visibility of existing children.

In order to have the final visibility at hand while detecting smells, the smell detection is done after the entire tree has been walked.

Next steps:
* Move smell detection phase out of TreeWalker
* Change Attribute to use this same mechanism.