### PR TITLE
Handle casgn style class definitions

### DIFF
--- a/lib/reek/context/code_context.rb
+++ b/lib/reek/context/code_context.rb
@@ -82,7 +82,7 @@ module Reek
         type = receiver ? receiver.type : :self
         case type
         when :lvar, :lvasgn
-          unless exp.method_name == :new
+          unless exp.object_creation_call?
             @refs.record_reference_to(receiver.name, line: exp.line)
           end
         when :self

--- a/lib/reek/context/module_context.rb
+++ b/lib/reek/context/module_context.rb
@@ -23,8 +23,9 @@ module Reek
       #
       # @return true if the module is a namespace module
       def namespace_module?
+        return false if exp.type == :casgn
         contents = exp.children.last
-        contents && contents.find_nodes([:def, :defs], [:class, :module]).empty?
+        contents && contents.find_nodes([:def, :defs], [:casgn, :class, :module]).empty?
       end
     end
   end

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -108,7 +108,7 @@ module Reek
 
         def collect_calls(result)
           context.each_node(:send, [:mlhs]) do |call_node|
-            next if initializer_call? call_node
+            next if call_node.object_creation_call?
             next if simple_method_call? call_node
             result[call_node].record(call_node)
           end
@@ -123,10 +123,6 @@ module Reek
 
         def simple_method_call?(call_node)
           !call_node.receiver && call_node.args.empty?
-        end
-
-        def initializer_call?(call_node)
-          call_node.method_name == :new
         end
 
         def allow_calls?(method)

--- a/lib/reek/smells/irresponsible_module.rb
+++ b/lib/reek/smells/irresponsible_module.rb
@@ -11,7 +11,7 @@ module Reek
     # @api private
     class IrresponsibleModule < SmellDetector
       def self.contexts
-        [:class, :module]
+        [:casgn, :class, :module]
       end
 
       #
@@ -26,7 +26,7 @@ module Reek
                           context: ctx.full_name,
                           lines: [expression.line],
                           message: 'has no descriptive comment',
-                          parameters: { name: expression.text_name })]
+                          parameters: { name: expression.name })]
       end
 
       private

--- a/lib/reek/tree_walker.rb
+++ b/lib/reek/tree_walker.rb
@@ -50,6 +50,14 @@ module Reek
 
     alias_method :process_class, :process_module
 
+    def process_casgn(exp)
+      if exp.defines_module?
+        process_module(exp)
+      else
+        process_default(exp)
+      end
+    end
+
     def process_def(exp)
       inside_new_context(Context::MethodContext, exp) do
         count_clause(exp.body)

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -309,15 +309,11 @@ RSpec.describe Reek::AST::SexpExtensions::ModuleNode do
     end
 
     it 'has the correct #name' do
-      expect(subject.name).to eq :Fred
+      expect(subject.name).to eq 'Fred'
     end
 
     it 'has the correct #simple_name' do
-      expect(subject.simple_name).to eq :Fred
-    end
-
-    it 'has the correct #text_name' do
-      expect(subject.text_name).to eq 'Fred'
+      expect(subject.simple_name).to eq 'Fred'
     end
 
     it 'has a simple full_name' do
@@ -335,15 +331,11 @@ RSpec.describe Reek::AST::SexpExtensions::ModuleNode do
     end
 
     it 'has the correct #name' do
-      expect(subject.name).to eq s(:const, s(:const, nil, :Foo), :Bar)
+      expect(subject.name).to eq 'Foo::Bar'
     end
 
     it 'has the correct #simple_name' do
-      expect(subject.simple_name).to eq :Bar
-    end
-
-    it 'has the correct #text_name' do
-      expect(subject.text_name).to eq 'Foo::Bar'
+      expect(subject.simple_name).to eq 'Bar'
     end
 
     it 'has a simple full_name' do


### PR DESCRIPTION
Introduces a new ModuleContext for classes defined by constant assignment, like so:

```ruby
Foo = Class.new do
  def bar(a, b)
  end
end
```

This means smells on methods inside the class definition will have the correct context reported.

Also makes IrresponsibleModule detect when such classes have no comment. Other smells still have to be adjusted to consider :casgn contexts.

This makes reek handle the following sample code (from #341) correctly:

```ruby
# Reports the wrong context (A instead of B)
module A
  B = Struct.new(:c) do
    def initialize
    end

    def foo(a, b)

    end
  end
end
```