### PR TITLE
Use Pathnames where possible

### DIFF
--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -26,7 +26,7 @@ Given(/^a smelly file with inline masking called 'inline.rb'$/) do
 end
 
 Given(/^the "(.*?)" sample file exists$/) do |file_name|
-  full_path = File.expand_path file_name, 'spec/samples'
+  full_path = Pathname("#{__dir__}/../../spec/samples/#{file_name}")
   in_current_directory { FileUtils.cp full_path, file_name }
 end
 
@@ -135,7 +135,7 @@ When(/^I run "reek (.*?)" in the subdirectory$/) do |args|
 end
 
 Given(/^a masking configuration file in the HOME directory$/) do
-  set_env('HOME', File.expand_path(File.join(current_directory, 'home')))
+  set_env 'HOME', Pathname("#{__dir__}/../../#{current_directory}/home").to_s
   write_file('home/config.reek', <<-EOS.strip_heredoc)
     ---
     DuplicateMethodCall:

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -74,7 +74,7 @@ module Reek
         @parser.separator 'Configuration:'
         @parser.on('-c', '--config FILE', 'Read configuration options from FILE') do |file|
           raise ArgumentError, "Config file #{file} doesn't exist" unless File.exist?(file)
-          @options.config_file = Pathname.new(file)
+          @options.config_file = Pathname(file)
         end
         @parser.on('--smell SMELL', 'Detect smell SMELL (default: all enabled smells)') do |smell|
           @options.smells_to_detect << smell

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require_relative './configuration_file_finder'
 
 module Reek
@@ -36,7 +37,7 @@ module Reek
         end
 
         def load_from_file(path)
-          if File.size(path) == 0
+          if path.size.zero?
             report_problem('Empty file', path)
             return
           end
@@ -56,9 +57,11 @@ module Reek
         end
 
         def exclude_paths
-          @exclude_paths ||= @configuration.
-            fetch(EXCLUDE_PATHS_KEY, []).
-            map { |path| path.chomp('/') }
+          @exclude_paths ||= begin
+            @configuration.fetch(EXCLUDE_PATHS_KEY, []).map do |string|
+              Pathname(string.chomp('/'))
+            end
+          end
         end
 
         private

--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -18,11 +18,11 @@ module Reek
       module_function
 
       # FIXME: switch to kwargs on upgrade to Ruby 2 and drop `params.fetch` calls:
-      # def find(options: nil, current: Pathname.pwd, home: Pathname.new(Dir.home))
+      # def find(options: nil, current: Pathname.pwd, home: Pathname(Dir.home))
       def find(params = {})
-        options = params.fetch(:options) { nil                    }
-        current = params.fetch(:current) { Pathname.pwd           }
-        home    = params.fetch(:home)    { Pathname.new(Dir.home) }
+        options = params.fetch(:options) { nil                }
+        current = params.fetch(:current) { Pathname.pwd       }
+        home    = params.fetch(:home)    { Pathname(Dir.home) }
         find_by_cli(options) || find_by_dir(current) || find_by_dir(home)
       end
 

--- a/lib/reek/report/report.rb
+++ b/lib/reek/report/report.rb
@@ -1,5 +1,6 @@
-require 'rainbow'
 require 'json'
+require 'pathname'
+require 'rainbow'
 require_relative 'formatter'
 require_relative 'heading_formatter'
 
@@ -129,9 +130,9 @@ module Reek
     class HTMLReport < Base
       require 'erb'
 
-      def show(target_path = 'reek.html')
-        template_path = File.expand_path('../html_report.html.erb', __FILE__)
-        File.write target_path, ERB.new(File.read(template_path)).result(binding)
+      def show(target_path = Pathname('reek.html'))
+        template_path = Pathname("#{__dir__}/html_report.html.erb")
+        File.write target_path, ERB.new(template_path.read).result(binding)
         puts 'HTML file saved'
       end
     end

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -18,7 +18,7 @@ module Reek
       # Initializer.
       #
       # code        - ruby code as String
-      # description - in case of STDIN this is "STDIN" otherwise it's a filepath as String
+      # description - 'STDIN', 'string' or a filepath as String
       # parser      - the parser to use for generating AST's out of the given source
       def initialize(code, description, parser = Parser::Ruby22)
         @source      = code
@@ -27,8 +27,8 @@ module Reek
       end
 
       # Initializes an instance of SourceCode given a source.
-      # This source can come via 3 different ways:
-      # - from files a la `reek lib/reek/`
+      # This source can come via 4 different ways:
+      # - from Files or Pathnames a la `reek lib/reek/`
       # - from IO (STDIN) a la `echo "class Foo; end" | reek`
       # - from String via our rspec matchers a la `expect("class Foo; end").to reek`
       #
@@ -37,9 +37,10 @@ module Reek
       # @return an instance of SourceCode
       def self.from(source)
         case source
-        when File   then new(source.read, source.path)
-        when IO     then new(source.readlines.join, 'STDIN')
-        when String then new(source, 'string')
+        when File     then new(source.read, source.path)
+        when IO       then new(source.readlines.join, 'STDIN')
+        when Pathname then new(source.read, source.to_s)
+        when String   then new(source, 'string')
         end
       end
 

--- a/spec/reek/configuration/app_configuration_spec.rb
+++ b/spec/reek/configuration/app_configuration_spec.rb
@@ -1,9 +1,12 @@
+require 'pathname'
 require_relative '../../spec_helper'
 require_relative '../../../lib/reek/configuration/app_configuration'
 require_relative '../../../lib/reek/smells/smell_repository'
 
 RSpec.describe Reek::Configuration::AppConfiguration do
-  let(:sample_configuration_path) { 'spec/samples/configuration/simple_configuration.reek' }
+  let(:sample_configuration_path) do
+    Pathname('spec/samples/configuration/simple_configuration.reek')
+  end
   let(:sample_configuration_loaded) do
     {
       'UncommunicativeVariableName' => { 'enabled' => false },
@@ -47,13 +50,15 @@ RSpec.describe Reek::Configuration::AppConfiguration do
   end
 
   describe '.exclude_paths' do
-    let(:config_path) { 'spec/samples/configuration/with_excluded_paths.reek' }
+    let(:config_path) do
+      Pathname('spec/samples/configuration/with_excluded_paths.reek')
+    end
 
     it 'should return all paths to exclude' do
       with_test_config(config_path) do
         expect(described_class.exclude_paths).to eq [
-          'spec/samples/source_with_exclude_paths/ignore_me',
-          'spec/samples/source_with_exclude_paths/nested/ignore_me_as_well'
+          Pathname('spec/samples/source_with_exclude_paths/ignore_me'),
+          Pathname('spec/samples/source_with_exclude_paths/nested/ignore_me_as_well')
         ]
       end
     end

--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -16,44 +16,44 @@ RSpec.describe Reek::Configuration::ConfigurationFileFinder do
 
     it 'returns the file in current dir if config_file is nil' do
       options = double(config_file: nil)
-      current = Pathname.new('spec/samples')
+      current = Pathname('spec/samples')
       found = described_class.find(options: options, current: current)
-      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
+      expect(found).to eq(Pathname('spec/samples/exceptions.reek'))
     end
 
     it 'returns the file in current dir if options is nil' do
-      current = Pathname.new('spec/samples')
+      current = Pathname('spec/samples')
       found = described_class.find(current: current)
-      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
+      expect(found).to eq(Pathname('spec/samples/exceptions.reek'))
     end
 
     it 'returns the file in a parent dir if none in current dir' do
-      current = Pathname.new('spec/samples/no_config_file')
+      current = Pathname('spec/samples/no_config_file')
       found = described_class.find(current: current)
-      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
+      expect(found).to eq(Pathname('spec/samples/exceptions.reek'))
     end
 
     it 'returns the file even if it’s just ‘.reek’' do
-      current = Pathname.new('spec/samples/masked_by_dotfile')
+      current = Pathname('spec/samples/masked_by_dotfile')
       found = described_class.find(current: current)
-      expect(found).to eq(Pathname.new('spec/samples/masked_by_dotfile/.reek'))
+      expect(found).to eq(Pathname('spec/samples/masked_by_dotfile/.reek'))
     end
 
     it 'returns the file in home if traversing from the current dir fails' do
       skip_if_a_config_in_tempdir
       Dir.mktmpdir do |tempdir|
-        current = Pathname.new(tempdir)
-        home    = Pathname.new('spec/samples')
+        current = Pathname(tempdir)
+        home    = Pathname('spec/samples')
         found = described_class.find(current: current, home: home)
-        expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
+        expect(found).to eq(Pathname('spec/samples/exceptions.reek'))
       end
     end
 
     it 'returns nil when there are no files to find' do
       skip_if_a_config_in_tempdir
       Dir.mktmpdir do |tempdir|
-        current = Pathname.new(tempdir)
-        home    = Pathname.new(tempdir)
+        current = Pathname(tempdir)
+        home    = Pathname(tempdir)
         found = described_class.find(current: current, home: home)
         expect(found).to be_nil
       end
@@ -61,8 +61,8 @@ RSpec.describe Reek::Configuration::ConfigurationFileFinder do
 
     it 'works with paths that need escaping' do
       Dir.mktmpdir("ma\ngic d*r") do |tempdir|
-        config = Pathname.new("#{tempdir}/ma\ngic f*le.reek")
-        subdir = Pathname.new("#{tempdir}/ma\ngic subd*r")
+        config = Pathname("#{tempdir}/ma\ngic f*le.reek")
+        subdir = Pathname("#{tempdir}/ma\ngic subd*r")
         FileUtils.touch config
         FileUtils.mkdir subdir
         found = described_class.find(current: subdir)
@@ -73,7 +73,7 @@ RSpec.describe Reek::Configuration::ConfigurationFileFinder do
     private
 
     def skip_if_a_config_in_tempdir
-      found = described_class.find(current: Pathname.new(Dir.tmpdir))
+      found = described_class.find(current: Pathname(Dir.tmpdir))
       skip "skipped: #{found} exists and would fail this test" if found
     end
   end

--- a/spec/reek/report/xml_report_spec.rb
+++ b/spec/reek/report/xml_report_spec.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require_relative '../../spec_helper'
 require_relative '../../../lib/reek/examiner'
 require_relative '../../../lib/reek/report/report'
@@ -27,8 +28,8 @@ RSpec.describe Reek::Report::XMLReport do
     end
 
     it 'prints non-empty checkstyle xml' do
-      sample_path = File.expand_path 'checkstyle.xml', 'spec/samples'
-      expect { instance.show }.to output(File.read(sample_path)).to_stdout
+      sample_path = Pathname("#{__dir__}/../../samples/checkstyle.xml")
+      expect { instance.show }.to output(sample_path.read).to_stdout
     end
   end
 end

--- a/spec/reek/source/source_locator_spec.rb
+++ b/spec/reek/source/source_locator_spec.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require_relative '../../spec_helper'
 require_relative '../../../lib/reek/configuration/app_configuration'
 require_relative '../../../lib/reek/source/source_locator'
@@ -6,32 +7,36 @@ RSpec.describe Reek::Source::SourceLocator do
   describe '#sources' do
     context 'applied to hidden directories' do
       let(:path) { 'spec/samples/source_with_hidden_directories' }
-      let(:expected_files) do
-        ['spec/samples/source_with_hidden_directories/uncommunicative_parameter_name.rb']
+      let(:expected_paths) do
+        [Pathname('spec/samples/source_with_hidden_directories/' \
+                  'uncommunicative_parameter_name.rb')]
       end
-      let(:files_that_are_expected_to_be_ignored) do
-        ['spec/samples/source_with_hidden_directories/.hidden/uncommunicative_method_name.rb']
+      let(:paths_that_are_expected_to_be_ignored) do
+        [Pathname('spec/samples/source_with_hidden_directories/' \
+                  '.hidden/uncommunicative_method_name.rb')]
       end
 
       it 'does not scan hidden directories' do
         sources = described_class.new([path]).sources
 
-        expect(sources.map(&:path)).
-          not_to include(*files_that_are_expected_to_be_ignored)
+        expect(sources).not_to include(*paths_that_are_expected_to_be_ignored)
 
-        expect(sources.map(&:path)).to eq expected_files
-
+        expect(sources).to eq expected_paths
         Reek::Configuration::AppConfiguration.reset
       end
     end
 
     context 'exclude paths' do
-      let(:config) { 'spec/samples/configuration/with_excluded_paths.reek' }
+      let(:config) do
+        Pathname('spec/samples/configuration/with_excluded_paths.reek')
+      end
       let(:path) { 'spec/samples/source_with_exclude_paths' }
-      let(:files_that_are_expected_to_be_ignored) do
+      let(:paths_that_are_expected_to_be_ignored) do
         [
-          'spec/samples/source_with_exclude_paths/ignore_me/uncommunicative_method_name.rb',
-          'spec/samples/source_with_exclude_paths/nested/ignore_me_as_well/irresponsible_module.rb'
+          Pathname('spec/samples/source_with_exclude_paths/' \
+                   'ignore_me/uncommunicative_method_name.rb'),
+          Pathname('spec/samples/source_with_exclude_paths/' \
+                   'nested/ignore_me_as_well/irresponsible_module.rb')
         ]
       end
 
@@ -39,52 +44,49 @@ RSpec.describe Reek::Source::SourceLocator do
         with_test_config(config) do
           sources = described_class.new([path]).sources
 
-          expect(sources.map(&:path).sort).
-            not_to include(*files_that_are_expected_to_be_ignored)
+          expect(sources).not_to include(*paths_that_are_expected_to_be_ignored)
 
-          expect(sources.map(&:path).sort).to eq [
-            'spec/samples/source_with_exclude_paths/nested/uncommunicative_parameter_name.rb'
+          expect(sources).to eq [
+            Pathname('spec/samples/source_with_exclude_paths/' \
+                     'nested/uncommunicative_parameter_name.rb')
           ]
         end
       end
     end
 
-    context 'non-ruby files' do
+    context 'non-ruby paths' do
       let(:path) { 'spec/samples/source_with_non_ruby_files' }
-      let(:expected_files) do
-        ['spec/samples/source_with_non_ruby_files/uncommunicative_parameter_name.rb']
+      let(:expected_sources) do
+        [Pathname('spec/samples/source_with_non_ruby_files/' \
+                  'uncommunicative_parameter_name.rb')]
       end
-      let(:files_that_are_expected_to_be_ignored) do
+      let(:paths_that_are_expected_to_be_ignored) do
         [
-          'spec/samples/source_with_non_ruby_files/gibberish',
-          'spec/samples/source_with_non_ruby_files/python_source.py'
+          Pathname('spec/samples/source_with_non_ruby_files/gibberish'),
+          Pathname('spec/samples/source_with_non_ruby_files/python_source.py')
         ]
       end
 
-      it 'does only use ruby source files' do
+      it 'does only use ruby source paths' do
         sources = described_class.new([path]).sources
 
-        expect(sources.map(&:path)).
-          not_to include(*files_that_are_expected_to_be_ignored)
+        expect(sources).not_to include(*paths_that_are_expected_to_be_ignored)
 
-        expect(sources.map(&:path)).to eq expected_files
+        expect(sources).to eq expected_sources
       end
     end
 
     context 'passing "." or "./" as argument' do
-      let(:expected_files) do
-        [
-          'spec/spec_helper.rb',
-          'lib/reek.rb'
-        ]
+      let(:expected_sources) do
+        [Pathname('spec/spec_helper.rb'), Pathname('lib/reek.rb')]
       end
 
       it 'expands it correctly' do
-        sources_for_dot       = described_class.new(['.']).sources
-        sources_for_dot_slash = described_class.new(['./']).sources
+        sources_for_dot       = described_class.new([Pathname('.')]).sources
+        sources_for_dot_slash = described_class.new([Pathname('./')]).sources
 
-        expect(sources_for_dot.map(&:path)).to include(*expected_files)
-        expect(sources_for_dot.map(&:path)).to eq(sources_for_dot_slash.map(&:path))
+        expect(sources_for_dot).to include(*expected_sources)
+        expect(sources_for_dot).to eq(sources_for_dot_slash)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require_relative '../lib/reek/spec'
 require_relative '../lib/reek/ast/ast_node_class_map'
 require_relative '../lib/reek/configuration/app_configuration'
@@ -21,12 +22,13 @@ SAMPLES_DIR = 'spec/samples'
 # Simple helpers for our specs.
 module Helpers
   def with_test_config(config)
-    if config.is_a? String
-      Reek::Configuration::AppConfiguration.load_from_file(config)
-    elsif config.is_a? Hash
+    case config
+    when Hash
       Reek::Configuration::AppConfiguration.class_eval do
         @configuration = config
       end
+    when Pathname, String
+      Reek::Configuration::AppConfiguration.load_from_file(Pathname(config))
     else
       raise "Unknown config given in `with_test_config`: #{config.inspect}"
     end


### PR DESCRIPTION
This:
* uses `__dir__` wrapped in a `Pathname` instead of `File.expand_path` (where possible),
* makes `AppConfiguration.load_from_file` take a `Pathname` instead of a `String` (is this a backward-incompatible change? I can make it take either…),
* makes `AppConfiguration.exclude_paths` return `Array<Pathname>`,
* makes `SourceLocator#sources` return `Array<Pathname>`,
* uses `Kernel.Pathname` (rather than `Pathname.new`) consistently throughout the codebase.

Once we drop Ruby 2.0 and 2.1 support we can start using the nicer-looking `Pathname#/` instead of `Pathname#+` and `Pathname#write` instead of `File.write`.

Fixes #555.