### PR TITLE
SourceLocator: drop Method#to_proc’s cleverness

### DIFF
--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -12,7 +12,7 @@ module Reek
       #
       # paths - a list of paths as Strings
       def initialize(paths)
-        @paths = paths.map(&method(:Pathname)).flat_map do |path|
+        @paths = paths.map { |string| Pathname(string) }.flat_map do |path|
           current_directory?(path) ? path.entries : path
         end
       end


### PR DESCRIPTION
This might not be as readable as it should, [as per this comment](https://github.com/troessner/reek/pull/596#discussion_r34425701), so let’s drop it. :)