### PR TITLE
Pathname switch fixes

### DIFF
--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -135,7 +135,7 @@ When(/^I run "reek (.*?)" in the subdirectory$/) do |args|
 end
 
 Given(/^a masking configuration file in the HOME directory$/) do
-  set_env 'HOME', Pathname.new("#{__dir__}/../../#{current_directory}/home").to_s
+  set_env 'HOME', Pathname.new("#{current_directory}/home").expand_path.to_s
   write_file('home/config.reek', <<-EOS.strip_heredoc)
     ---
     DuplicateMethodCall:

--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -26,7 +26,7 @@ Given(/^a smelly file with inline masking called 'inline.rb'$/) do
 end
 
 Given(/^the "(.*?)" sample file exists$/) do |file_name|
-  full_path = Pathname("#{__dir__}/../../spec/samples/#{file_name}")
+  full_path = Pathname.new("#{__dir__}/../../spec/samples/#{file_name}")
   in_current_directory { FileUtils.cp full_path, file_name }
 end
 
@@ -135,7 +135,7 @@ When(/^I run "reek (.*?)" in the subdirectory$/) do |args|
 end
 
 Given(/^a masking configuration file in the HOME directory$/) do
-  set_env 'HOME', Pathname("#{__dir__}/../../#{current_directory}/home").to_s
+  set_env 'HOME', Pathname.new("#{__dir__}/../../#{current_directory}/home").to_s
   write_file('home/config.reek', <<-EOS.strip_heredoc)
     ---
     DuplicateMethodCall:

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -74,7 +74,7 @@ module Reek
         @parser.separator 'Configuration:'
         @parser.on('-c', '--config FILE', 'Read configuration options from FILE') do |file|
           raise ArgumentError, "Config file #{file} doesn't exist" unless File.exist?(file)
-          @options.config_file = Pathname(file)
+          @options.config_file = Pathname.new(file)
         end
         @parser.on('--smell SMELL', 'Detect smell SMELL (default: all enabled smells)') do |smell|
           @options.smells_to_detect << smell

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -59,7 +59,7 @@ module Reek
         def exclude_paths
           @exclude_paths ||= begin
             @configuration.fetch(EXCLUDE_PATHS_KEY, []).map do |string|
-              Pathname(string.chomp('/'))
+              Pathname.new(string.chomp('/'))
             end
           end
         end

--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -18,11 +18,11 @@ module Reek
       module_function
 
       # FIXME: switch to kwargs on upgrade to Ruby 2 and drop `params.fetch` calls:
-      # def find(options: nil, current: Pathname.pwd, home: Pathname(Dir.home))
+      # def find(options: nil, current: Pathname.pwd, home: Pathname.new(Dir.home))
       def find(params = {})
-        options = params.fetch(:options) { nil                }
-        current = params.fetch(:current) { Pathname.pwd       }
-        home    = params.fetch(:home)    { Pathname(Dir.home) }
+        options = params.fetch(:options) { nil                    }
+        current = params.fetch(:current) { Pathname.pwd           }
+        home    = params.fetch(:home)    { Pathname.new(Dir.home) }
         find_by_cli(options) || find_by_dir(current) || find_by_dir(home)
       end
 

--- a/lib/reek/report/report.rb
+++ b/lib/reek/report/report.rb
@@ -130,8 +130,8 @@ module Reek
     class HTMLReport < Base
       require 'erb'
 
-      def show(target_path = Pathname('reek.html'))
-        template_path = Pathname("#{__dir__}/html_report.html.erb")
+      def show(target_path = Pathname.new('reek.html'))
+        template_path = Pathname.new("#{__dir__}/html_report.html.erb")
         File.write target_path, ERB.new(template_path.read).result(binding)
         puts 'HTML file saved'
       end

--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -12,7 +12,8 @@ module Reek
       #
       # paths - a list of paths as Strings
       def initialize(paths)
-        @paths = paths.map { |string| Pathname.new(string) }.flat_map do |path|
+        @paths = paths.flat_map do |string|
+          path = Pathname.new(string)
           current_directory?(path) ? path.entries : path
         end
       end

--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -12,7 +12,7 @@ module Reek
       #
       # paths - a list of paths as Strings
       def initialize(paths)
-        @paths = paths.map { |string| Pathname(string) }.flat_map do |path|
+        @paths = paths.map { |string| Pathname.new(string) }.flat_map do |path|
           current_directory?(path) ? path.entries : path
         end
       end
@@ -61,7 +61,7 @@ module Reek
       end
 
       def current_directory?(path)
-        [Pathname('.'), Pathname('./')].include?(path)
+        [Pathname.new('.'), Pathname.new('./')].include?(path)
       end
     end
   end

--- a/spec/reek/configuration/app_configuration_spec.rb
+++ b/spec/reek/configuration/app_configuration_spec.rb
@@ -5,7 +5,7 @@ require_relative '../../../lib/reek/smells/smell_repository'
 
 RSpec.describe Reek::Configuration::AppConfiguration do
   let(:sample_configuration_path) do
-    Pathname('spec/samples/configuration/simple_configuration.reek')
+    Pathname.new('spec/samples/configuration/simple_configuration.reek')
   end
   let(:sample_configuration_loaded) do
     {
@@ -51,14 +51,14 @@ RSpec.describe Reek::Configuration::AppConfiguration do
 
   describe '.exclude_paths' do
     let(:config_path) do
-      Pathname('spec/samples/configuration/with_excluded_paths.reek')
+      Pathname.new('spec/samples/configuration/with_excluded_paths.reek')
     end
 
     it 'should return all paths to exclude' do
       with_test_config(config_path) do
         expect(described_class.exclude_paths).to eq [
-          Pathname('spec/samples/source_with_exclude_paths/ignore_me'),
-          Pathname('spec/samples/source_with_exclude_paths/nested/ignore_me_as_well')
+          Pathname.new('spec/samples/source_with_exclude_paths/ignore_me'),
+          Pathname.new('spec/samples/source_with_exclude_paths/nested/ignore_me_as_well')
         ]
       end
     end

--- a/spec/reek/configuration/app_configuration_spec.rb
+++ b/spec/reek/configuration/app_configuration_spec.rb
@@ -5,7 +5,7 @@ require_relative '../../../lib/reek/smells/smell_repository'
 
 RSpec.describe Reek::Configuration::AppConfiguration do
   let(:sample_configuration_path) do
-    Pathname.new('spec/samples/configuration/simple_configuration.reek')
+    SAMPLES_PATH.join('configuration/simple_configuration.reek')
   end
   let(:sample_configuration_loaded) do
     {
@@ -51,14 +51,14 @@ RSpec.describe Reek::Configuration::AppConfiguration do
 
   describe '.exclude_paths' do
     let(:config_path) do
-      Pathname.new('spec/samples/configuration/with_excluded_paths.reek')
+      SAMPLES_PATH.join('configuration/with_excluded_paths.reek')
     end
 
     it 'should return all paths to exclude' do
       with_test_config(config_path) do
         expect(described_class.exclude_paths).to eq [
-          Pathname.new('spec/samples/source_with_exclude_paths/ignore_me'),
-          Pathname.new('spec/samples/source_with_exclude_paths/nested/ignore_me_as_well')
+          SAMPLES_PATH.join('source_with_exclude_paths/ignore_me'),
+          SAMPLES_PATH.join('source_with_exclude_paths/nested/ignore_me_as_well')
         ]
       end
     end

--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -16,44 +16,44 @@ RSpec.describe Reek::Configuration::ConfigurationFileFinder do
 
     it 'returns the file in current dir if config_file is nil' do
       options = double(config_file: nil)
-      current = Pathname('spec/samples')
+      current = Pathname.new('spec/samples')
       found = described_class.find(options: options, current: current)
-      expect(found).to eq(Pathname('spec/samples/exceptions.reek'))
+      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
     end
 
     it 'returns the file in current dir if options is nil' do
-      current = Pathname('spec/samples')
+      current = Pathname.new('spec/samples')
       found = described_class.find(current: current)
-      expect(found).to eq(Pathname('spec/samples/exceptions.reek'))
+      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
     end
 
     it 'returns the file in a parent dir if none in current dir' do
-      current = Pathname('spec/samples/no_config_file')
+      current = Pathname.new('spec/samples/no_config_file')
       found = described_class.find(current: current)
-      expect(found).to eq(Pathname('spec/samples/exceptions.reek'))
+      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
     end
 
     it 'returns the file even if it’s just ‘.reek’' do
-      current = Pathname('spec/samples/masked_by_dotfile')
+      current = Pathname.new('spec/samples/masked_by_dotfile')
       found = described_class.find(current: current)
-      expect(found).to eq(Pathname('spec/samples/masked_by_dotfile/.reek'))
+      expect(found).to eq(Pathname.new('spec/samples/masked_by_dotfile/.reek'))
     end
 
     it 'returns the file in home if traversing from the current dir fails' do
       skip_if_a_config_in_tempdir
       Dir.mktmpdir do |tempdir|
-        current = Pathname(tempdir)
-        home    = Pathname('spec/samples')
+        current = Pathname.new(tempdir)
+        home    = Pathname.new('spec/samples')
         found = described_class.find(current: current, home: home)
-        expect(found).to eq(Pathname('spec/samples/exceptions.reek'))
+        expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
       end
     end
 
     it 'returns nil when there are no files to find' do
       skip_if_a_config_in_tempdir
       Dir.mktmpdir do |tempdir|
-        current = Pathname(tempdir)
-        home    = Pathname(tempdir)
+        current = Pathname.new(tempdir)
+        home    = Pathname.new(tempdir)
         found = described_class.find(current: current, home: home)
         expect(found).to be_nil
       end
@@ -61,8 +61,8 @@ RSpec.describe Reek::Configuration::ConfigurationFileFinder do
 
     it 'works with paths that need escaping' do
       Dir.mktmpdir("ma\ngic d*r") do |tempdir|
-        config = Pathname("#{tempdir}/ma\ngic f*le.reek")
-        subdir = Pathname("#{tempdir}/ma\ngic subd*r")
+        config = Pathname.new("#{tempdir}/ma\ngic f*le.reek")
+        subdir = Pathname.new("#{tempdir}/ma\ngic subd*r")
         FileUtils.touch config
         FileUtils.mkdir subdir
         found = described_class.find(current: subdir)
@@ -73,7 +73,7 @@ RSpec.describe Reek::Configuration::ConfigurationFileFinder do
     private
 
     def skip_if_a_config_in_tempdir
-      found = described_class.find(current: Pathname(Dir.tmpdir))
+      found = described_class.find(current: Pathname.new(Dir.tmpdir))
       skip "skipped: #{found} exists and would fail this test" if found
     end
   end

--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -16,36 +16,31 @@ RSpec.describe Reek::Configuration::ConfigurationFileFinder do
 
     it 'returns the file in current dir if config_file is nil' do
       options = double(config_file: nil)
-      current = Pathname.new('spec/samples')
-      found = described_class.find(options: options, current: current)
-      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
+      found = described_class.find(options: options, current: SAMPLES_PATH)
+      expect(found).to eq(SAMPLES_PATH.join('exceptions.reek'))
     end
 
     it 'returns the file in current dir if options is nil' do
-      current = Pathname.new('spec/samples')
-      found = described_class.find(current: current)
-      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
+      found = described_class.find(current: SAMPLES_PATH)
+      expect(found).to eq(SAMPLES_PATH.join('exceptions.reek'))
     end
 
     it 'returns the file in a parent dir if none in current dir' do
-      current = Pathname.new('spec/samples/no_config_file')
-      found = described_class.find(current: current)
-      expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
+      found = described_class.find(current: SAMPLES_PATH.join('no_config_file'))
+      expect(found).to eq(SAMPLES_PATH.join('exceptions.reek'))
     end
 
     it 'returns the file even if it’s just ‘.reek’' do
-      current = Pathname.new('spec/samples/masked_by_dotfile')
-      found = described_class.find(current: current)
-      expect(found).to eq(Pathname.new('spec/samples/masked_by_dotfile/.reek'))
+      found = described_class.find(current: SAMPLES_PATH.join('masked_by_dotfile'))
+      expect(found).to eq(SAMPLES_PATH.join('masked_by_dotfile/.reek'))
     end
 
     it 'returns the file in home if traversing from the current dir fails' do
       skip_if_a_config_in_tempdir
       Dir.mktmpdir do |tempdir|
         current = Pathname.new(tempdir)
-        home    = Pathname.new('spec/samples')
-        found = described_class.find(current: current, home: home)
-        expect(found).to eq(Pathname.new('spec/samples/exceptions.reek'))
+        found = described_class.find(current: current, home: SAMPLES_PATH)
+        expect(found).to eq(SAMPLES_PATH.join('exceptions.reek'))
       end
     end
 

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -46,13 +46,13 @@ RSpec.describe Reek::Examiner do
 
   context 'with a partially masked smelly File' do
     around(:each) do |example|
-      with_test_config('spec/samples/all_but_one_masked/masked.reek') do
+      with_test_config(SAMPLES_PATH.join('all_but_one_masked/masked.reek')) do
         example.run
       end
     end
 
     before :each do
-      smelly_file = File.new(Dir['spec/samples/all_but_one_masked/d*.rb'][0])
+      smelly_file = Pathname.glob(SAMPLES_PATH.join('all_but_one_masked/d*.rb')).first
       @examiner = described_class.new(smelly_file)
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Reek::Examiner do
 
   context 'with a fragrant File' do
     before :each do
-      clean_file = File.new(Dir['spec/samples/three_clean_files/*.rb'][0])
+      clean_file = Pathname.glob(SAMPLES_PATH.join('three_clean_files/*.rb')).first
       @examiner = described_class.new(clean_file)
     end
 

--- a/spec/reek/report/xml_report_spec.rb
+++ b/spec/reek/report/xml_report_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Reek::Report::XMLReport do
     end
 
     it 'prints non-empty checkstyle xml' do
-      sample_path = Pathname("#{__dir__}/../../samples/checkstyle.xml")
+      sample_path = Pathname.new("#{__dir__}/../../samples/checkstyle.xml")
       expect { instance.show }.to output(sample_path.read).to_stdout
     end
   end

--- a/spec/reek/report/xml_report_spec.rb
+++ b/spec/reek/report/xml_report_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Reek::Report::XMLReport do
     end
 
     it 'prints non-empty checkstyle xml' do
-      sample_path = Pathname.new("#{__dir__}/../../samples/checkstyle.xml")
+      sample_path = SAMPLES_PATH.join('checkstyle.xml')
       expect { instance.show }.to output(sample_path.read).to_stdout
     end
   end

--- a/spec/reek/source/source_locator_spec.rb
+++ b/spec/reek/source/source_locator_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Reek::Source::SourceLocator do
     context 'applied to hidden directories' do
       let(:path) { 'spec/samples/source_with_hidden_directories' }
       let(:expected_paths) do
-        [Pathname('spec/samples/source_with_hidden_directories/' \
-                  'uncommunicative_parameter_name.rb')]
+        [Pathname.new('spec/samples/source_with_hidden_directories/' \
+                      'uncommunicative_parameter_name.rb')]
       end
       let(:paths_that_are_expected_to_be_ignored) do
-        [Pathname('spec/samples/source_with_hidden_directories/' \
-                  '.hidden/uncommunicative_method_name.rb')]
+        [Pathname.new('spec/samples/source_with_hidden_directories/' \
+                      '.hidden/uncommunicative_method_name.rb')]
       end
 
       it 'does not scan hidden directories' do
@@ -28,15 +28,15 @@ RSpec.describe Reek::Source::SourceLocator do
 
     context 'exclude paths' do
       let(:config) do
-        Pathname('spec/samples/configuration/with_excluded_paths.reek')
+        Pathname.new('spec/samples/configuration/with_excluded_paths.reek')
       end
       let(:path) { 'spec/samples/source_with_exclude_paths' }
       let(:paths_that_are_expected_to_be_ignored) do
         [
-          Pathname('spec/samples/source_with_exclude_paths/' \
-                   'ignore_me/uncommunicative_method_name.rb'),
-          Pathname('spec/samples/source_with_exclude_paths/' \
-                   'nested/ignore_me_as_well/irresponsible_module.rb')
+          Pathname.new('spec/samples/source_with_exclude_paths/' \
+                       'ignore_me/uncommunicative_method_name.rb'),
+          Pathname.new('spec/samples/source_with_exclude_paths/' \
+                       'nested/ignore_me_as_well/irresponsible_module.rb')
         ]
       end
 
@@ -47,8 +47,8 @@ RSpec.describe Reek::Source::SourceLocator do
           expect(sources).not_to include(*paths_that_are_expected_to_be_ignored)
 
           expect(sources).to eq [
-            Pathname('spec/samples/source_with_exclude_paths/' \
-                     'nested/uncommunicative_parameter_name.rb')
+            Pathname.new('spec/samples/source_with_exclude_paths/' \
+                         'nested/uncommunicative_parameter_name.rb')
           ]
         end
       end
@@ -57,13 +57,13 @@ RSpec.describe Reek::Source::SourceLocator do
     context 'non-ruby paths' do
       let(:path) { 'spec/samples/source_with_non_ruby_files' }
       let(:expected_sources) do
-        [Pathname('spec/samples/source_with_non_ruby_files/' \
-                  'uncommunicative_parameter_name.rb')]
+        [Pathname.new('spec/samples/source_with_non_ruby_files/' \
+                      'uncommunicative_parameter_name.rb')]
       end
       let(:paths_that_are_expected_to_be_ignored) do
         [
-          Pathname('spec/samples/source_with_non_ruby_files/gibberish'),
-          Pathname('spec/samples/source_with_non_ruby_files/python_source.py')
+          Pathname.new('spec/samples/source_with_non_ruby_files/gibberish'),
+          Pathname.new('spec/samples/source_with_non_ruby_files/python_source.py')
         ]
       end
 
@@ -78,12 +78,12 @@ RSpec.describe Reek::Source::SourceLocator do
 
     context 'passing "." or "./" as argument' do
       let(:expected_sources) do
-        [Pathname('spec/spec_helper.rb'), Pathname('lib/reek.rb')]
+        [Pathname.new('spec/spec_helper.rb'), Pathname.new('lib/reek.rb')]
       end
 
       it 'expands it correctly' do
-        sources_for_dot       = described_class.new([Pathname('.')]).sources
-        sources_for_dot_slash = described_class.new([Pathname('./')]).sources
+        sources_for_dot       = described_class.new([Pathname.new('.')]).sources
+        sources_for_dot_slash = described_class.new([Pathname.new('./')]).sources
 
         expect(sources_for_dot).to include(*expected_sources)
         expect(sources_for_dot).to eq(sources_for_dot_slash)

--- a/spec/reek/source/source_locator_spec.rb
+++ b/spec/reek/source/source_locator_spec.rb
@@ -6,14 +6,12 @@ require_relative '../../../lib/reek/source/source_locator'
 RSpec.describe Reek::Source::SourceLocator do
   describe '#sources' do
     context 'applied to hidden directories' do
-      let(:path) { 'spec/samples/source_with_hidden_directories' }
+      let(:path) { SAMPLES_PATH.join('source_with_hidden_directories') }
       let(:expected_paths) do
-        [Pathname.new('spec/samples/source_with_hidden_directories/' \
-                      'uncommunicative_parameter_name.rb')]
+        [SAMPLES_PATH.join('source_with_hidden_directories/uncommunicative_parameter_name.rb')]
       end
       let(:paths_that_are_expected_to_be_ignored) do
-        [Pathname.new('spec/samples/source_with_hidden_directories/' \
-                      '.hidden/uncommunicative_method_name.rb')]
+        [SAMPLES_PATH.join('source_with_hidden_directories/.hidden/uncommunicative_method_name.rb')]
       end
 
       it 'does not scan hidden directories' do
@@ -27,16 +25,13 @@ RSpec.describe Reek::Source::SourceLocator do
     end
 
     context 'exclude paths' do
-      let(:config) do
-        Pathname.new('spec/samples/configuration/with_excluded_paths.reek')
-      end
-      let(:path) { 'spec/samples/source_with_exclude_paths' }
+      let(:config) { SAMPLES_PATH.join('configuration/with_excluded_paths.reek') }
+      let(:path)   { SAMPLES_PATH.join('source_with_exclude_paths')              }
       let(:paths_that_are_expected_to_be_ignored) do
         [
-          Pathname.new('spec/samples/source_with_exclude_paths/' \
-                       'ignore_me/uncommunicative_method_name.rb'),
-          Pathname.new('spec/samples/source_with_exclude_paths/' \
-                       'nested/ignore_me_as_well/irresponsible_module.rb')
+          SAMPLES_PATH.join('source_with_exclude_paths/ignore_me/uncommunicative_method_name.rb'),
+          SAMPLES_PATH.join('source_with_exclude_paths/nested/' \
+                            'ignore_me_as_well/irresponsible_module.rb')
         ]
       end
 
@@ -47,23 +42,21 @@ RSpec.describe Reek::Source::SourceLocator do
           expect(sources).not_to include(*paths_that_are_expected_to_be_ignored)
 
           expect(sources).to eq [
-            Pathname.new('spec/samples/source_with_exclude_paths/' \
-                         'nested/uncommunicative_parameter_name.rb')
+            SAMPLES_PATH.join('source_with_exclude_paths/nested/uncommunicative_parameter_name.rb')
           ]
         end
       end
     end
 
     context 'non-ruby paths' do
-      let(:path) { 'spec/samples/source_with_non_ruby_files' }
+      let(:path) { SAMPLES_PATH.join('source_with_non_ruby_files') }
       let(:expected_sources) do
-        [Pathname.new('spec/samples/source_with_non_ruby_files/' \
-                      'uncommunicative_parameter_name.rb')]
+        [SAMPLES_PATH.join('source_with_non_ruby_files/uncommunicative_parameter_name.rb')]
       end
       let(:paths_that_are_expected_to_be_ignored) do
         [
-          Pathname.new('spec/samples/source_with_non_ruby_files/gibberish'),
-          Pathname.new('spec/samples/source_with_non_ruby_files/python_source.py')
+          SAMPLES_PATH.join('source_with_non_ruby_files/gibberish'),
+          SAMPLES_PATH.join('source_with_non_ruby_files/python_source.py')
         ]
       end
 

--- a/spec/reek/spec/should_reek_of_spec.rb
+++ b/spec/reek/spec/should_reek_of_spec.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require_relative '../../spec_helper'
 require_relative '../../../lib/reek/spec'
 
@@ -56,8 +57,8 @@ RSpec.describe Reek::Spec::ShouldReekOf do
 
   context 'checking code in a File' do
     before :each do
-      @clean_file = File.new(Dir['spec/samples/three_clean_files/*.rb'][0])
-      @smelly_file = File.new(Dir['spec/samples/two_smelly_files/*.rb'][0])
+      @clean_file = Pathname.glob("#{SAMPLES_PATH}/three_clean_files/*.rb").first
+      @smelly_file = Pathname.glob("#{SAMPLES_PATH}/two_smelly_files/*.rb").first
       @matcher = Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName,
                                               name: '@s')
     end

--- a/spec/reek/spec/should_reek_spec.rb
+++ b/spec/reek/spec/should_reek_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe Reek::Spec::ShouldReek do
   end
 
   describe 'checking code in a File' do
-    let(:clean_file) { File.new('spec/samples/three_clean_files/clean_one.rb') }
-    let(:smelly_file) { File.new('spec/samples/two_smelly_files/dirty_one.rb') }
-    let(:masked_file) { File.new('spec/samples/clean_due_to_masking/dirty_one.rb') }
+    let(:clean_file)  { SAMPLES_PATH.join('three_clean_files/clean_one.rb')    }
+    let(:smelly_file) { SAMPLES_PATH.join('two_smelly_files/dirty_one.rb')     }
+    let(:masked_file) { SAMPLES_PATH.join('clean_due_to_masking/dirty_one.rb') }
 
     it 'matches a smelly File' do
       expect(matcher.matches?(smelly_file)).to be_truthy
@@ -36,7 +36,7 @@ RSpec.describe Reek::Spec::ShouldReek do
     end
 
     it 'masks smells using the relevant configuration' do
-      with_test_config('spec/samples/clean_due_to_masking/masked.reek') do
+      with_test_config(SAMPLES_PATH.join('clean_due_to_masking/masked.reek')) do
         expect(matcher.matches?(masked_file)).to be_falsey
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ end
 
 FactoryGirl.find_definitions
 
-SAMPLES_DIR = 'spec/samples'
+SAMPLES_PATH = Pathname.new("#{__dir__}/samples").relative_path_from(Pathname.pwd)
 
 # Simple helpers for our specs.
 module Helpers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ module Helpers
         @configuration = config
       end
     when Pathname, String
-      Reek::Configuration::AppConfiguration.load_from_file(Pathname(config))
+      Reek::Configuration::AppConfiguration.load_from_file(Pathname.new(config))
     else
       raise "Unknown config given in `with_test_config`: #{config.inspect}"
     end


### PR DESCRIPTION
Four changes requested by @mvz in a post-merge review of #596:

* `Pathname` → `Pathname.new` switch,
* proper expansion of `$HOME` for Aruba-based features,
* single `flat_map` call in `SourceLocator#initialize`,
* switching all specs to (once-computed) `SAMPLES_PATH`.

I’ll do the ‘`SourceCode.from` should just take `IO` objects’ in a separate PR.

As these are four fairly disjunct fixes I made four commits; let me know if that’s too many because `<%= reasons %>`. ;)