### PR TITLE
Use private_attr to silence ‘private attribute?’ warnings and refactor SmellRepository a bit

### DIFF
--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'private_attr/everywhere'
 require_relative './configuration_file_finder'
 
 module Reek
@@ -40,9 +41,9 @@ module Reek
       #                      config_file = #<Pathname:config/defaults.reek>,
       #                      argv = [ "lib/reek/spec" ]>
       def initialize(options = nil)
-        self.directory_directives = {}
-        self.default_directive    = {}
-        self.exclude_paths        = []
+        @directory_directives = {}
+        @default_directive    = {}
+        @exclude_paths        = []
 
         load options
       end
@@ -56,7 +57,7 @@ module Reek
 
       private
 
-      attr_writer :exclude_paths, :default_directive, :directory_directives
+      private_attr_writer :exclude_paths
 
       # @param source_via [String] - the source of the code inspected
       # Might be a string, STDIN or Filename / Pathname. We're only interested in the source

--- a/lib/reek/smells/smell_repository.rb
+++ b/lib/reek/smells/smell_repository.rb
@@ -1,3 +1,4 @@
+require 'private_attr/everywhere'
 require_relative '../smells'
 require_relative 'smell_detector'
 require_relative '../configuration/app_configuration'
@@ -16,10 +17,10 @@ module Reek
       def initialize(source_description: nil,
                      smell_types: self.class.smell_types,
                      configuration: Configuration::AppConfiguration.new)
-        self.source_via         = source_description
-        self.typed_detectors    = nil
-        self.configuration      = configuration
-        self.smell_types        = smell_types
+        @source_via      = source_description
+        @typed_detectors = nil
+        @configuration   = configuration
+        @smell_types     = smell_types
 
         configuration.directive_for(source_via).each do |klass, config|
           configure klass, config
@@ -54,11 +55,11 @@ module Reek
 
       private
 
-      attr_accessor :typed_detectors, :configuration, :source_via, :smell_types
+      private_attr_reader :configuration, :source_via, :smell_types, :typed_detectors
 
       def smell_listeners
         unless typed_detectors
-          self.typed_detectors = Hash.new { |hash, key| hash[key] = [] }
+          @typed_detectors = Hash.new { |hash, key| hash[key] = [] }
           detectors.each_value { |detector| detector.register(typed_detectors) }
         end
         typed_detectors

--- a/lib/reek/smells/smell_repository.rb
+++ b/lib/reek/smells/smell_repository.rb
@@ -17,10 +17,9 @@ module Reek
       def initialize(source_description: nil,
                      smell_types: self.class.smell_types,
                      configuration: Configuration::AppConfiguration.new)
-        @source_via      = source_description
-        @typed_detectors = nil
-        @configuration   = configuration
-        @smell_types     = smell_types
+        @source_via    = source_description
+        @configuration = configuration
+        @smell_types   = smell_types
 
         configuration.directive_for(source_via).each do |klass, config|
           configure klass, config
@@ -51,14 +50,12 @@ module Reek
 
       private
 
-      private_attr_reader :configuration, :source_via, :smell_types, :typed_detectors
+      private_attr_reader :configuration, :source_via, :smell_types
 
       def smell_listeners
-        unless typed_detectors
-          @typed_detectors = Hash.new { |hash, key| hash[key] = [] }
-          detectors.each_value { |detector| detector.register(typed_detectors) }
+        @smell_listeners ||= Hash.new { |hash, key| hash[key] = [] }.tap do |listeners|
+          detectors.each_value { |detector| detector.register(listeners) }
         end
-        typed_detectors
       end
     end
   end

--- a/lib/reek/smells/smell_repository.rb
+++ b/lib/reek/smells/smell_repository.rb
@@ -44,13 +44,9 @@ module Reek
       end
 
       def detectors
-        @initialized_detectors ||= begin
-          @detectors = {}
-          smell_types.each do |klass|
-            @detectors[klass] = klass.new(source_via)
-          end
-          @detectors
-        end
+        @initialized_detectors ||= smell_types.map do |klass|
+          { klass => klass.new(source_via) }
+        end.reduce({}, :merge)
       end
 
       private

--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -1,5 +1,6 @@
 require 'find'
 require 'pathname'
+require 'private_attr/everywhere'
 
 module Reek
   module Source
@@ -12,11 +13,11 @@ module Reek
       #
       # paths - a list of paths as Strings
       def initialize(paths, configuration: Configuration::AppConfiguration.new)
-        self.paths = paths.flat_map do |string|
+        @paths = paths.flat_map do |string|
           path = Pathname.new(string)
           current_directory?(path) ? path.entries : path
         end
-        self.configuration = configuration
+        @configuration = configuration
       end
 
       # Traverses all paths we initialized the SourceLocator with, finds
@@ -29,7 +30,7 @@ module Reek
 
       private
 
-      attr_accessor :paths, :configuration
+      private_attr_reader :configuration, :paths
 
       def source_paths
         paths.each_with_object([]) do |given_path, relevant_paths|

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -22,9 +22,10 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
   s.summary = 'Code smell detector for Ruby'
 
-  s.add_runtime_dependency 'parser',   '~> 2.2.2.5'
-  s.add_runtime_dependency 'rainbow',  '~> 2.0'
-  s.add_runtime_dependency 'unparser', '~> 0.2.2'
+  s.add_runtime_dependency 'parser',       '~> 2.2.2.5'
+  s.add_runtime_dependency 'private_attr', '~> 1.1'
+  s.add_runtime_dependency 'rainbow',      '~> 2.0'
+  s.add_runtime_dependency 'unparser',     '~> 0.2.2'
 
   s.add_development_dependency 'activesupport', '~> 4.2'
   s.add_development_dependency 'aruba',         '~> 0.7.2'


### PR DESCRIPTION
Current master is no longer warning-clean, as it started throwing warnings about private attributes (don’t get me started how wrong the warning is).

This makes this warning go away by using the private_attr gem. This also includes some related refactorings of `SmellRepository`.