### PR TITLE
Attributes smell no readers

### DIFF
--- a/config/defaults.reek
+++ b/config/defaults.reek
@@ -1,6 +1,6 @@
 ---
 Attribute:
-  enabled: false
+  enabled: true
   exclude: []
 BooleanParameter:
   enabled: true

--- a/docs/Attribute.md
+++ b/docs/Attribute.md
@@ -2,7 +2,11 @@
 
 ## Introduction
 
-A class that publishes a getter or setter for an instance variable invites client classes to become too intimate with its inner workings, and in particular with its representation of state.
+A class that publishes a setter for an instance variable invites
+client classes to become too intimate with its inner workings, and in
+particular with its representation of state.
+
+The same holds to a lesser extent for getters, but Reek doesn't flag those.
 
 ## Example
 
@@ -20,24 +24,16 @@ end
 reek test.rb
 
 test.rb -- 1 warning:
-  [2]:Klass declares the attribute dummy (Attribute)
+  [2]:Klass declares the writable attribute dummy (Attribute)
 ```
 
 ## Support in Reek
 
-Right now this smell is disabled by default since it is highly subjective.
+This detector it raises a warning for every public `attr_writer`,
+`attr_accessor`, and `attr` with the writable flag set to `true`.
 
-When this detector is enabled it raises a warning for every `attr`, `attr_reader`, `attr_writer` and `attr_accessor` -- including those that are private.
+Reek does not raise warnings for read-only attributes.
 
 ## Configuration
-
-If you want to enable it you can do so by placing
-
-```yaml
-Attribute:
-  enabled: true
-```
-
-in your reek configuration file.
 
 `Attribute` supports only the [Basic Smell Options](Basic-Smell-Options.md).

--- a/features/samples.feature
+++ b/features/samples.feature
@@ -63,7 +63,14 @@ Feature: Basic smell detection
     Then the exit status indicates smells
     And it reports:
     """
-    optparse.rb -- 111 warnings:
+    optparse.rb -- 119 warnings:
+      OptionParser declares the writable attribute banner (Attribute)
+      OptionParser declares the writable attribute default_argv (Attribute)
+      OptionParser declares the writable attribute program_name (Attribute)
+      OptionParser declares the writable attribute release (Attribute)
+      OptionParser declares the writable attribute summary_indent (Attribute)
+      OptionParser declares the writable attribute summary_width (Attribute)
+      OptionParser declares the writable attribute version (Attribute)
       OptionParser has at least 42 methods (TooManyMethods)
       OptionParser has the variable name 'f' (UncommunicativeVariableName)
       OptionParser has the variable name 'k' (UncommunicativeVariableName)
@@ -148,6 +155,7 @@ Feature: Basic smell detection
       OptionParser::List#update has 5 parameters (LongParameterList)
       OptionParser::List#update has approx 10 statements (TooManyStatements)
       OptionParser::List#update has the variable name 'o' (UncommunicativeVariableName)
+      OptionParser::ParseError declares the writable attribute reason (Attribute)
       OptionParser::ParseError#set_option is controlled by argument eq (ControlParameter)
       OptionParser::Switch#add_banner has the variable name 's' (UncommunicativeVariableName)
       OptionParser::Switch#initialize has 7 parameters (LongParameterList)
@@ -183,7 +191,13 @@ Feature: Basic smell detection
     Then the exit status indicates smells
     And it reports:
     """
-    redcloth.rb -- 95 warnings:
+    redcloth.rb -- 101 warnings:
+      RedCloth declares the writable attribute filter_html (Attribute)
+      RedCloth declares the writable attribute filter_styles (Attribute)
+      RedCloth declares the writable attribute hard_breaks (Attribute)
+      RedCloth declares the writable attribute lite_mode (Attribute)
+      RedCloth declares the writable attribute no_span_caps (Attribute)
+      RedCloth declares the writable attribute rules (Attribute)
       RedCloth has at least 44 methods (TooManyMethods)
       RedCloth has the variable name 'a' (UncommunicativeVariableName)
       RedCloth has the variable name 'b' (UncommunicativeVariableName)

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -21,8 +21,6 @@ module Reek
       VISIBILITY_MODIFIERS = [:private, :public, :protected]
 
       def initialize(*args)
-        @visiblity_tracker = {}
-        @visiblity_mode = :public
         super
       end
 
@@ -36,6 +34,8 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
+        @visiblity_tracker = {}
+        @visiblity_mode = :public
         attributes_in(ctx).map do |attribute, line|
           SmellWarning.new self,
                            context: ctx.full_name,

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -9,8 +9,8 @@ module Reek
     # invites client classes to become too intimate with its inner workings,
     # and in particular with its representation of state.
     #
-    # This detector raises a warning for every
-    # +attr_writer+ and +attr_accessor+
+    # This detector raises a warning for every public +attr_writer+,
+    # +attr_accessor+, and +attr+ with the writable flag set to +true+.
     #
     # See {file:docs/Attribute.md} for details.
     # @api private
@@ -48,18 +48,38 @@ module Reek
       private
 
       def attributes_in(module_ctx)
-        result = Set.new
+        attributes = Set.new
         module_ctx.local_nodes(:send) do |call_node|
-          if visibility_modifier?(call_node)
-            track_visibility(call_node)
-          elsif ATTR_DEFN_METHODS.include?(call_node.method_name)
-            call_node.arg_names.each do |arg|
-              @visiblity_tracker[arg] = @visiblity_mode
-              result << [arg, call_node.line]
-            end
-          end
+          attributes += track_attributes(call_node)
         end
-        result.select { |args| recorded_public_methods.include?(args[0]) }
+        attributes.select { |name, _line| recorded_public_methods.include?(name) }
+      end
+
+      def track_attributes(call_node)
+        if attribute_writer? call_node
+          return track_arguments call_node.args, call_node.line
+        end
+        track_visibility call_node if visibility_modifier? call_node
+        []
+      end
+
+      def attribute_writer?(call_node)
+        ATTR_DEFN_METHODS.include?(call_node.method_name) ||
+          attr_with_writable_flag?(call_node)
+      end
+
+      def attr_with_writable_flag?(call_node)
+        call_node.method_name == :attr && call_node.args.last.type == :true
+      end
+
+      def track_arguments(args, line)
+        args.select { |arg| arg.type == :sym }.map { |arg| track_argument(arg, line) }
+      end
+
+      def track_argument(arg, line)
+        arg_name = arg.children.first
+        @visiblity_tracker[arg_name] = @visiblity_mode
+        [arg_name, line]
       end
 
       def visibility_modifier?(call_node)

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -12,83 +12,109 @@ RSpec.describe Reek::Smells::Attribute do
 
   context 'with no attributes' do
     it 'records nothing' do
-      expect('
+      src = <<-EOS
         class Klass
         end
-      ').to_not reek_of(:Attribute, {})
+      EOS
+      expect(src).to_not reek_of(:Attribute)
     end
   end
 
   context 'with attributes' do
-    it 'records nothing' do
-      expect('
+    it 'records nothing for attribute readers' do
+      src = <<-EOS
         class Klass
-          attr :super_private, :super_private2
-          private :super_private, :super_private2
-          private
-          attr :super_thing
-          public
-          attr :super_thing2
-          private
-          attr :super_thing2
+          attr :my_attr
+          attr_reader :my_attr2
         end
-      ').to_not reek_of(:Attribute, {})
-    end
-
-    it 'records attr_writer attribute in a module' do
-      expect('
-        module Mod
-          attr_writer :my_attr
-        end
-      ').to reek_of(:Attribute, name: 'my_attr')
+      EOS
+      expect(src).to_not reek_of(:Attribute)
     end
 
     it 'records writer attribute' do
-      expect('
+      src = <<-EOS
         class Klass
           attr_writer :my_attr
         end
-      ').to reek_of(:Attribute, name: 'my_attr')
+      EOS
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
+    end
+
+    it 'records attr_writer attribute in a module' do
+      src = <<-EOS
+        module Mod
+          attr_writer :my_attr
+        end
+      EOS
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
     end
 
     it 'records accessor attribute' do
-      expect('
+      src = <<-EOS
         class Klass
           attr_accessor :my_attr
         end
-      ').to reek_of(:Attribute, name: 'my_attr')
+      EOS
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
     end
 
-    it 'records attr_writer attribute after switching visbility' do
-      expect('
+    it 'records attr defining a writer' do
+      src = <<-EOS
         class Klass
-          private
-          attr_writer :my_attr
-          public :my_attr
-          private :my_attr
-          public :my_attr
+          attr :my_attr, true
         end
-      ').to reek_of(:Attribute, name: 'my_attr')
+      EOS
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
     end
 
     it "doesn't record protected attributes" do
       src = '
         class Klass
           protected
-          attr :iam_protected
+          attr_writer :attr1
+          attr_accessor :attr2
+          attr :attr3
+          attr :attr4, true
+          attr_reader :attr5
         end
       '
-      expect(src).to_not reek_of(:Attribute, name: 'iam_protected')
+      expect(src).to_not reek_of(:Attribute)
     end
 
     it "doesn't record private attributes" do
       src = '
         class Klass
           private
-          attr :iam_private
+          attr_writer :attr1
+          attr_accessor :attr2
+          attr :attr3
+          attr :attr4, true
+          attr_reader :attr5
         end
       '
-      expect(src).to_not reek_of(:Attribute, name: 'iam_private')
+      expect(src).to_not reek_of(:Attribute)
+    end
+
+    it 'records attr_writer defined in public section' do
+      src = <<-EOS
+        class Klass
+          private
+          public
+          attr_writer :my_attr
+        end
+      EOS
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
+    end
+
+    it 'records attr_writer after switching visbility to public' do
+      src = <<-EOS
+        class Klass
+          private
+          attr_writer :my_attr
+          public :my_attr
+        end
+      EOS
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
     end
   end
 end

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -1,16 +1,8 @@
 require_relative '../../spec_helper'
 require_relative '../../../lib/reek/smells/attribute'
-require_relative '../../../lib/reek/smells/smell_configuration'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::Attribute do
-  let(:config) do
-    {
-      Reek::Smells::Attribute => { Reek::Smells::SmellConfiguration::ENABLED_KEY => true }
-    }
-  end
-  let(:configuration) { test_configuration_for(config) }
-
   before(:each) do
     @source_name = 'dummy_source'
     @detector = build(:smell_detector, smell_type: :Attribute, source: @source_name)
@@ -23,7 +15,7 @@ RSpec.describe Reek::Smells::Attribute do
       expect('
         class Klass
         end
-      ').to_not reek_of(:Attribute, {}, configuration)
+      ').to_not reek_of(:Attribute, {})
     end
   end
 
@@ -40,31 +32,15 @@ RSpec.describe Reek::Smells::Attribute do
           private
           attr :super_thing2
         end
-      ').to_not reek_of(:Attribute, {}, configuration)
+      ').to_not reek_of(:Attribute, {})
     end
 
-    it 'records attr attribute in a module' do
+    it 'records attr_writer attribute in a module' do
       expect('
         module Mod
-          attr :my_attr
+          attr_writer :my_attr
         end
-      ').to reek_of(:Attribute, { name: 'my_attr' }, configuration)
-    end
-
-    it 'records attr attribute' do
-      expect('
-        class Klass
-          attr :my_attr
-        end
-      ').to reek_of(:Attribute, { name: 'my_attr' }, configuration)
-    end
-
-    it 'records reader attribute' do
-      expect('
-        class Klass
-          attr_reader :my_attr
-        end
-      ').to reek_of(:Attribute, { name: 'my_attr' }, configuration)
+      ').to reek_of(:Attribute, name: 'my_attr')
     end
 
     it 'records writer attribute' do
@@ -72,7 +48,7 @@ RSpec.describe Reek::Smells::Attribute do
         class Klass
           attr_writer :my_attr
         end
-      ').to reek_of(:Attribute, { name: 'my_attr' }, configuration)
+      ').to reek_of(:Attribute, name: 'my_attr')
     end
 
     it 'records accessor attribute' do
@@ -80,19 +56,19 @@ RSpec.describe Reek::Smells::Attribute do
         class Klass
           attr_accessor :my_attr
         end
-      ').to reek_of(:Attribute, { name: 'my_attr' }, configuration)
+      ').to reek_of(:Attribute, name: 'my_attr')
     end
 
-    it 'records attr attribute after switching visbility' do
+    it 'records attr_writer attribute after switching visbility' do
       expect('
         class Klass
           private
-          attr :my_attr
+          attr_writer :my_attr
           public :my_attr
           private :my_attr
           public :my_attr
         end
-      ').to reek_of(:Attribute, { name: 'my_attr' }, configuration)
+      ').to reek_of(:Attribute, name: 'my_attr')
     end
 
     it "doesn't record protected attributes" do
@@ -102,7 +78,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr :iam_protected
         end
       '
-      expect(src).to_not reek_of(:Attribute, { name: 'iam_protected' }, configuration)
+      expect(src).to_not reek_of(:Attribute, name: 'iam_protected')
     end
 
     it "doesn't record private attributes" do
@@ -112,7 +88,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr :iam_private
         end
       '
-      expect(src).to_not reek_of(:Attribute, { name: 'iam_private' }, configuration)
+      expect(src).to_not reek_of(:Attribute, name: 'iam_private')
     end
   end
 end

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -116,5 +116,19 @@ RSpec.describe Reek::Smells::Attribute do
       EOS
       expect(src).to reek_of(:Attribute, name: 'my_attr')
     end
+
+    it 'resets visibility in new contexts' do
+      src = '
+        class Klass
+          private
+          attr_writer :attr1
+        end
+
+        class OtherKlass
+          attr_writer :attr1
+        end
+      '
+      expect(src).to reek_of(:Attribute)
+    end
   end
 end


### PR DESCRIPTION
Follow-up for #574.

This one cleans things up and adds support for `attr :foo, true`.

I've left @beanieboi's work, with some trivial fixes to make the build green, in a separate commit.

I'd like to unify the visibility handlers, but I'll leave that for a separate PR.