### PR TITLE
Reimplement yardoc spec and fix a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,8 +206,8 @@
 
 ### Major Changes
 * Smell detectors can be configured or disabled in code comments
-  * Comment with :reek:smell_name disables the named smell for a class, module or method
-  * Comment with :reek:smell_name:{...} for more detailed configuration
+  * Comment with `:reek:smell_name` disables the named smell for a class, module or method
+  * Comment with `:reek:smell_name:{...}` for more detailed configuration
 * Additional config file(s) can be specified:
   * on the command-line using -c
   * via Reek::Rake::Task in the rakefile

--- a/spec/gem/yard_spec.rb
+++ b/spec/gem/yard_spec.rb
@@ -1,14 +1,11 @@
+require 'open3'
 require_relative '../spec_helper'
-require 'tempfile'
 
 RSpec.describe 'yardoc' do
-  before :each do
-    stderr_file = Tempfile.new('yardoc')
-    stderr_file.close
-    @stdout = `yardoc 2> #{stderr_file.path}`
-    @stderr = IO.read(stderr_file.path)
-  end
-  it 'raises no warnings' do
-    expect(@stderr).to eq('')
+  it 'executes successfully with no warnings' do
+    stdout, stderr, status = Open3.capture3('yardoc')
+    expect(stdout).to_not include('[warn]')
+    expect(stderr).to be_empty
+    expect(status).to be_success
   end
 end


### PR DESCRIPTION
This PR fixes a `yardoc` warning, reimplements its call’s spec and checks the call for a successful return.

(Interestingly, we don’t seem to ever execute it, as we only ever run `spec/reek/**/*_spec.rb` files.)