### PR TITLE
I accidentally the whole XMLReport

### DIFF
--- a/spec/reek/report/xml_report_spec.rb
+++ b/spec/reek/report/xml_report_spec.rb
@@ -1,35 +1,25 @@
-require 'pathname'
 require_relative '../../spec_helper'
 require_relative '../../../lib/reek/examiner'
 require_relative '../../../lib/reek/report/report'
-require_relative '../../../lib/reek/report/formatter'
 
 RSpec.describe Reek::Report::XMLReport do
-  let(:instance) { Reek::Report::XMLReport.new }
+  let(:xml_report) { Reek::Report::XMLReport.new }
 
   context 'empty source' do
-    let(:examiner) { Reek::Examiner.new('') }
-
-    before do
-      instance.add_examiner examiner
-    end
-
-    it 'prints empty checkstyle xml' do
-      expect { instance.show }.to output("<?xml version='1.0'?>\n<checkstyle/>\n").to_stdout
+    it 'prints empty checkstyle XML' do
+      xml_report.add_examiner Reek::Examiner.new('')
+      xml = "<?xml version='1.0'?>\n<checkstyle/>\n"
+      expect { xml_report.show }.to output(xml).to_stdout
     end
   end
 
   context 'source with voliations' do
-    let(:examiner) { Reek::Examiner.new('def simple(a) a[0] end') }
-
-    before do
-      allow(File).to receive(:realpath).and_return('/some/path')
-      instance.add_examiner examiner
-    end
-
-    it 'prints non-empty checkstyle xml' do
-      sample_path = SAMPLES_PATH.join('checkstyle.xml')
-      expect { instance.show }.to output(sample_path.read).to_stdout
+    it 'prints non-empty checkstyle XML' do
+      path = SAMPLES_PATH.join('two_smelly_files/dirty_one.rb')
+      xml_report.add_examiner Reek::Examiner.new(path)
+      xml = SAMPLES_PATH.join('checkstyle.xml').read
+      xml = xml.gsub(path.to_s, path.expand_path.to_s)
+      expect { xml_report.show }.to output(xml).to_stdout
     end
   end
 end

--- a/spec/samples/checkstyle.xml
+++ b/spec/samples/checkstyle.xml
@@ -1,2 +1,13 @@
 <?xml version='1.0'?>
-<checkstyle><file name='/some/path'><error column='0' line='1' message='doesn&apos;t depend on instance state' severity='warning' source='UtilityFunction'/><error column='0' line='1' message='has the parameter name &apos;a&apos;' severity='warning' source='UncommunicativeParameterName'/></file></checkstyle>
+<checkstyle>
+  <file name='spec/samples/two_smelly_files/dirty_one.rb'>
+    <error column='0' line='5' message='has the variable name &apos;@s&apos;' severity='warning' source='UncommunicativeVariableName'/>
+    <error column='0' line='4' message='calls @s.title 2 times' severity='warning' source='DuplicateMethodCall'/>
+    <error column='0' line='6' message='calls @s.title 2 times' severity='warning' source='DuplicateMethodCall'/>
+    <error column='0' line='4' message='calls puts(@s.title) 2 times' severity='warning' source='DuplicateMethodCall'/>
+    <error column='0' line='6' message='calls puts(@s.title) 2 times' severity='warning' source='DuplicateMethodCall'/>
+    <error column='0' line='5' message='contains iterators nested 2 deep' severity='warning' source='NestedIterators'/>
+    <error column='0' line='3' message='has the name &apos;a&apos;' severity='warning' source='UncommunicativeMethodName'/>
+    <error column='0' line='5' message='has the variable name &apos;x&apos;' severity='warning' source='UncommunicativeVariableName'/>
+  </file>
+</checkstyle>


### PR DESCRIPTION
So I wanted to make the spec for `XMLReport` a bit more readable and parallelisable (fewer indirections, no `File` stubbing) and ended up with a new `XMLReport` that’s a bit more object-oriented and builds the output lazily rather than procedurally.

Notable changes:

* when a smell is reported for multiple lines we now include a separate `<error>` for every line;
* the XML is now human-readable.

I don’t think they are backward-incompatible, but I’ll reopen against `reek-4` if you believe so.

I’ll squash this one after a review. :)