### PR TITLE
Refactor configuration loading and make AppConfiguration's initializer more flexible.

### DIFF
--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -1,4 +1,8 @@
-require 'parser'
+require_relative '../cli/silencer'
+
+Reek::CLI::Silencer.silently stderr: true, stdout: true do
+  require 'parser'
+end
 
 module Reek
   # @api private

--- a/lib/reek/ast/sexp_formatter.rb
+++ b/lib/reek/ast/sexp_formatter.rb
@@ -1,5 +1,6 @@
 require_relative '../cli/silencer'
-Reek::CLI::Silencer.silently do
+
+Reek::CLI::Silencer.silently stderr: true, stdout: true do
   require 'unparser'
 end
 

--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -22,7 +22,7 @@ module Reek
         begin
           options = options_parser.parse
           @command = ReekCommand.new(OptionInterpreter.new(options))
-          @configuration = Configuration::AppConfiguration.new(options)
+          @configuration = Configuration::AppConfiguration.from_path(options.config_file)
         rescue OptionParser::InvalidOption, Reek::Configuration::ConfigFileException => error
           $stderr.puts "Error: #{error}"
           @status = STATUS_ERROR

--- a/lib/reek/cli/silencer.rb
+++ b/lib/reek/cli/silencer.rb
@@ -3,11 +3,18 @@ module Reek
     # CLI silencer
     # @api private
     module Silencer
-      def self.silently
-        old_verbose, $VERBOSE = $VERBOSE, nil
-        yield if block_given?
+      module_function
+
+      def silently(stderr: nil, stdout: nil)
+        old_verbose = $VERBOSE
+        $VERBOSE = false
+        $stderr = StringIO.new if stderr
+        $stdout = StringIO.new if stdout
+        yield
       ensure
         $VERBOSE = old_verbose
+        $stderr = STDERR
+        $stdout = STDOUT
       end
     end
   end

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -1,5 +1,9 @@
 require 'pathname'
 require_relative './configuration_file_finder'
+require_relative './configuration_validator'
+require_relative './default_directive'
+require_relative './directory_directives'
+require_relative './excluded_paths'
 
 module Reek
   # @api private
@@ -10,134 +14,94 @@ module Reek
     #
     # @api private
     class AppConfiguration
+      include ConfigurationValidator
       EXCLUDE_PATHS_KEY = 'exclude_paths'
-      attr_reader :exclude_paths, :default_directive, :directory_directives
+      private_attr_writer :directory_directives, :default_directive, :excluded_paths
 
-      # Given this configuration file:
+      # Instantiate a configuration via given path.
       #
-      # ---
-      # IrresponsibleModule:
-      #   enabled: false
-      # "app/helpers":
-      #   UtilityFunction:
-      #     enabled: false
-      # exclude_paths:
-      #   - "app/controllers"
+      # @param path [Pathname] the path to the config file
       #
-      # this would result in the following configuration:
-      #
-      # exclude_paths = [ Pathname('spec/samples/two_smelly_files') ]
-      # default_directive = { Reek::Smells::IrresponsibleModule => { "enabled" => false } }
-      # directory_directives = { Pathname("spec/samples/three_clean_files/") =>
-      #                          { Reek::Smells::UtilityFunction => { "enabled" => false } } }
-      #
-      #
-      # @param options [OpenStruct]
-      #   e.g.: #<OpenStruct report_format =: text,
-      #                      location_format =: numbers,
-      #                      colored = true,
-      #                      smells_to_detect = [],
-      #                      config_file = #<Pathname:config/defaults.reek>,
-      #                      argv = [ "lib/reek/spec" ]>
-      def initialize(options = nil)
-        @directory_directives = {}
-        @default_directive    = {}
-        @exclude_paths        = []
-
-        load options
+      # @return [AppConfiguration]
+      def self.from_path(path = nil)
+        allocate.tap do |instance|
+          instance.instance_eval { find_and_load(path: path) }
+        end
       end
 
-      # @param source_via [String] - the source of the code inspected
-      # @return [Hash] the directory directive for the source or, if there is
-      # none, the default directive
-      def directive_for(source_via)
-        directory_directive_for_source(source_via) || default_directive
-      end
-
-      private
-
-      private_attr_writer :exclude_paths
-
-      # @param source_via [String] - the source of the code inspected
-      # Might be a string, STDIN or Filename / Pathname. We're only interested in the source
-      # when it's coming from file since a directory_directive doesn't make sense
-      # for anything else.
-      # @return [Hash | nil] the configuration for the source or nil
-      def directory_directive_for_source(source_via)
-        return unless source_via
-        source_base_dir = Pathname.new(source_via).dirname
-        hit = best_directory_match_for source_base_dir
-        directory_directives[hit]
-      end
-
-      def load(options)
-        configuration_file = ConfigurationFileFinder.find_and_load(options: options)
-
-        configuration_file.each do |key, value|
-          case
-          when key == EXCLUDE_PATHS_KEY
-            handle_exclude_paths(value)
-          when smell_type?(key)
-            handle_default_directive(key, value)
-          else
-            handle_directory_directive(key, value)
+      # Instantiate a configuration by passing everything in.
+      #
+      # @param map [Hash] can have the following 3 keys:
+      # 1.) directory_directives [Hash] for instance:
+      #   { Pathname("spec/samples/three_clean_files/") =>
+      #     { Reek::Smells::UtilityFunction => { "enabled" => false } } }
+      # 2.) default_directive [Hash] for instance:
+      #   { Reek::Smells::IrresponsibleModule => { "enabled" => false } }
+      # 3.) excluded_paths [Array] for instance:
+      #   [ Pathname('spec/samples/two_smelly_files') ]
+      #
+      # @return [AppConfiguration]
+      def self.from_map(map = {})
+        allocate.tap do |instance|
+          instance.instance_eval do
+            self.directory_directives = map.fetch(:directory_directives, {}).
+              extend(DirectoryDirectives)
+            self.default_directive = map.fetch(:default_directive, {}).extend(DefaultDirective)
+            self.excluded_paths = map.fetch(:excluded_paths, []).extend(ExcludedPaths)
           end
         end
       end
 
-      def handle_exclude_paths(paths)
-        self.exclude_paths = paths.map do |path|
-          pathname = Pathname.new path.chomp('/')
-          raise ArgumentError, "Excluded directory #{path} does not exists" unless pathname.exist?
-          pathname
+      def self.default
+        from_path nil
+      end
+
+      def self.new(*)
+        raise NotImplementedError,
+              'Calling `new` is not supported, please use one of the factory methods'
+      end
+
+      # Returns the directive for a given directory.
+      #
+      # @param source_via [String] - the source of the code inspected
+      #
+      # @return [Hash] the directory directive for the source or, if there is
+      # none, the default directive
+      def directive_for(source_via)
+        directory_directives.directive_for(source_via) || default_directive
+      end
+
+      def path_excluded?(path)
+        excluded_paths.include?(path)
+      end
+
+      private
+
+      def directory_directives
+        @directory_directives ||= {}.extend(DirectoryDirectives)
+      end
+
+      def default_directive
+        @default_directive ||= {}.extend(DefaultDirective)
+      end
+
+      def excluded_paths
+        @excluded_paths ||= [].extend(ExcludedPaths)
+      end
+
+      def find_and_load(path: nil)
+        configuration_file = ConfigurationFileFinder.find_and_load(path: path)
+
+        configuration_file.each do |key, value|
+          case
+          when key == EXCLUDE_PATHS_KEY
+            excluded_paths.add value
+          when smell_type?(key)
+            default_directive.add key, value
+          else
+            directory_directives.add key, value
+          end
         end
-      end
-
-      def handle_default_directive(key, config)
-        klass = Reek::Smells.const_get(key)
-        default_directive[klass] = config
-      end
-
-      def handle_directory_directive(path, config)
-        pathname = Pathname.new path.chomp('/')
-        validate_directive pathname
-
-        directory_directives[pathname] = config.each_with_object({}) do |(key, value), hash|
-          abort(error_message_for_invalid_smell_type(key)) unless smell_type?(key)
-          hash[Reek::Smells.const_get(key)] = value
-        end
-      end
-
-      def best_directory_match_for(source_base_dir)
-        directory_directives.
-          keys.
-          select { |pathname| source_base_dir.to_s =~ /#{pathname}/ }.
-          max_by { |pathname| pathname.to_s.length }
-      end
-
-      def smell_type?(key)
-        Reek::Smells.const_get key
-      rescue NameError
-        false
-      end
-
-      def error_message_for_invalid_smell_type(klass)
-        "You are trying to configure smell type #{klass} but we can't find one with that name.\n" \
-          "Please make sure you spelled it right (see 'config/defaults.reek' in the reek\n" \
-          'repository for a list of all available smell types.'
-      end
-
-      def error_message_for_missing_directory(pathname)
-        "Configuration error: Directory `#{pathname}` does not exist"
-      end
-
-      def error_message_for_file_given(pathname)
-        "Configuration error: `#{pathname}` is supposed to be a directory but is a file"
-      end
-
-      def validate_directive(pathname)
-        abort(error_message_for_missing_directory(pathname)) unless pathname.exist?
-        abort(error_message_for_file_given(pathname)) unless pathname.directory?
       end
     end
   end

--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -18,21 +18,12 @@ module Reek
     module ConfigurationFileFinder
       module_function
 
-      def find_and_load(params = {})
-        load_from_file(find(params))
+      def find_and_load(path: nil)
+        load_from_file(find(path: path))
       end
 
-      # FIXME: switch to kwargs on upgrade to Ruby 2 and drop `params.fetch` calls:
-      # def find(options: nil, current: Pathname.pwd, home: Pathname.new(Dir.home))
-      def find(params = {})
-        options = params.fetch(:options) { nil                    }
-        current = params.fetch(:current) { Pathname.pwd           }
-        home    = params.fetch(:home)    { Pathname.new(Dir.home) }
-        find_by_cli(options) || find_by_dir(current) || find_by_dir(home)
-      end
-
-      def find_by_cli(options)
-        options && options.config_file
+      def find(path: nil, current: Pathname.pwd, home: Pathname.new(Dir.home))
+        path || find_by_dir(current) || find_by_dir(home)
       end
 
       def find_by_dir(start)

--- a/lib/reek/configuration/configuration_validator.rb
+++ b/lib/reek/configuration/configuration_validator.rb
@@ -1,0 +1,35 @@
+module Reek
+  module Configuration
+    #
+    # Configuration validator module.
+    #
+    module ConfigurationValidator
+      private
+
+      def smell_type?(key)
+        Reek::Smells.const_get key
+      rescue NameError
+        false
+      end
+
+      def error_message_for_missing_directory(pathname)
+        "Configuration error: Directory `#{pathname}` does not exist"
+      end
+
+      def error_message_for_file_given(pathname)
+        "Configuration error: `#{pathname}` is supposed to be a directory but is a file"
+      end
+
+      def validate_directory(pathname)
+        abort(error_message_for_missing_directory(pathname)) unless pathname.exist?
+        abort(error_message_for_file_given(pathname)) if pathname.file?
+      end
+
+      def with_valid_directory(path)
+        directory = Pathname.new path.to_s.chomp('/')
+        validate_directory directory
+        yield directory if block_given?
+      end
+    end
+  end
+end

--- a/lib/reek/configuration/default_directive.rb
+++ b/lib/reek/configuration/default_directive.rb
@@ -1,0 +1,12 @@
+module Reek
+  module Configuration
+    #
+    # Hash extension for the default directive.
+    #
+    module DefaultDirective
+      def add(key, config)
+        self[Reek::Smells.const_get(key)] = config
+      end
+    end
+  end
+end

--- a/lib/reek/configuration/directory_directives.rb
+++ b/lib/reek/configuration/directory_directives.rb
@@ -1,0 +1,54 @@
+require_relative './configuration_validator'
+
+module Reek
+  module Configuration
+    #
+    # Hash extension for directory directives.
+    #
+    module DirectoryDirectives
+      include ConfigurationValidator
+
+      # Returns the directive for a given source.
+      #
+      # @param source_via [String] the source of the code inspected
+      #
+      # @return [Hash | nil] the configuration for the source or nil
+      def directive_for(source_via)
+        return unless source_via
+        source_base_dir = Pathname.new(source_via).dirname
+        hit = best_match_for source_base_dir
+        self[hit]
+      end
+
+      # Adds a directive and returns self.
+      #
+      # @param path [Pathname] the path
+      # @param config [Hash] the configuration
+      #
+      # @return [self]
+      def add(path, config)
+        with_valid_directory(path) do |directory|
+          self[directory] = config.each_with_object({}) do |(key, value), hash|
+            abort(error_message_for_invalid_smell_type(key)) unless smell_type?(key)
+            hash[Reek::Smells.const_get(key)] = value
+          end
+        end
+        self
+      end
+
+      private
+
+      def best_match_for(source_base_dir)
+        keys.
+          select { |pathname| source_base_dir.to_s.match(/#{Regexp.escape(pathname.to_s)}/) }.
+          max_by { |pathname| pathname.to_s.length }
+      end
+
+      def error_message_for_invalid_smell_type(klass)
+        "You are trying to configure smell type #{klass} but we can't find one with that name.\n" \
+          "Please make sure you spelled it right (see 'config/defaults.reek' in the reek\n" \
+          'repository for a list of all available smell types.'
+      end
+    end
+  end
+end

--- a/lib/reek/configuration/excluded_paths.rb
+++ b/lib/reek/configuration/excluded_paths.rb
@@ -1,0 +1,18 @@
+require_relative './configuration_validator'
+
+module Reek
+  module Configuration
+    #
+    # Hash extension for excluded paths.
+    #
+    module ExcludedPaths
+      include ConfigurationValidator
+
+      def add(paths)
+        paths.each do |path|
+          with_valid_directory(path) { |directory| self << directory }
+        end
+      end
+    end
+  end
+end

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -26,7 +26,7 @@ module Reek
     #
     def initialize(source,
                    filter_by_smells = [],
-                   configuration: Configuration::AppConfiguration.new)
+                   configuration: Configuration::AppConfiguration.default)
       @source        = Source::SourceCode.from(source)
       @configuration = configuration
       @collector     = CLI::WarningCollector.new

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -40,7 +40,7 @@ module Reek
           SmellWarning.new self,
                            context: ctx.full_name,
                            lines: [line],
-                           message:  "declares the writable attribute #{attribute}",
+                           message: "declares the writable attribute #{attribute}",
                            parameters: { name: attribute.to_s }
         end
       end

--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -130,7 +130,7 @@ module Reek
     end
 
     def name
-      defn.name.to_s     # BUG: should report the symbols!
+      defn.name.to_s # BUG: should report the symbols!
     end
 
     private

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -37,7 +37,7 @@ module Reek
 
       BLOCK_GIVEN_CONDITION = ::Parser::AST::Node.new(:send, [nil, :block_given?])
 
-      def self.contexts      # :nodoc:
+      def self.contexts # :nodoc:
         [:class]
       end
 

--- a/lib/reek/smells/smell_detector.rb
+++ b/lib/reek/smells/smell_detector.rb
@@ -74,7 +74,7 @@ module Reek
         end
       end
 
-      attr_reader :smells_found   # SMELL: only published for tests
+      attr_reader :smells_found # SMELL: only published for tests
 
       def initialize(source, config = self.class.default_config)
         @source = source

--- a/lib/reek/smells/smell_repository.rb
+++ b/lib/reek/smells/smell_repository.rb
@@ -15,7 +15,7 @@ module Reek
 
       def initialize(source_description: nil,
                      smell_types: self.class.smell_types,
-                     configuration: Configuration::AppConfiguration.new)
+                     configuration: Configuration::AppConfiguration.default)
         @source_via    = source_description
         @configuration = configuration
         @smell_types   = smell_types

--- a/lib/reek/smells/too_many_methods.rb
+++ b/lib/reek/smells/too_many_methods.rb
@@ -47,7 +47,7 @@ module Reek
         [SmellWarning.new(self,
                           context: ctx.full_name,
                           lines: [ctx.exp.line],
-                          message:  "has at least #{actual} methods",
+                          message: "has at least #{actual} methods",
                           parameters: { count: actual })]
       end
     end

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -41,7 +41,7 @@ module Reek
         )
       end
 
-      def self.contexts      # :nodoc:
+      def self.contexts # :nodoc:
         [:module, :class]
       end
 

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -41,7 +41,7 @@ module Reek
         )
       end
 
-      def self.contexts      # :nodoc:
+      def self.contexts # :nodoc:
         [:module, :class, :def, :defs]
       end
 

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -43,7 +43,7 @@ module Reek
       end
 
       class << self
-        def contexts      # :nodoc:
+        def contexts # :nodoc:
           [:def]
         end
       end

--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -11,7 +11,7 @@ module Reek
       # Initialize with the paths we want to search.
       #
       # paths - a list of paths as Strings
-      def initialize(paths, configuration: Configuration::AppConfiguration.new)
+      def initialize(paths, configuration: Configuration::AppConfiguration.default)
         @paths = paths.flat_map do |string|
           path = Pathname.new(string)
           current_directory?(path) ? path.entries : path
@@ -45,7 +45,7 @@ module Reek
       end
 
       def path_excluded?(path)
-        configuration.exclude_paths.include?(path)
+        configuration.path_excluded?(path)
       end
 
       def print_no_such_file_error(path)

--- a/lib/reek/spec.rb
+++ b/lib/reek/spec.rb
@@ -87,7 +87,7 @@ module Reek
     #
     def reek_of(smell_category,
                 smell_details = {},
-                configuration = Configuration::AppConfiguration.new)
+                configuration = Configuration::AppConfiguration.default)
       ShouldReekOf.new(smell_category, smell_details, configuration)
     end
 
@@ -98,14 +98,14 @@ module Reek
     #   1.) "reek_of" doesn't mind if there are other smells of a different category.
     #       "reek_only_of" will fail in that case.
     #   2.) "reek_only_of" doesn't support the additional smell_details hash.
-    def reek_only_of(smell_category, configuration = Configuration::AppConfiguration.new)
+    def reek_only_of(smell_category, configuration = Configuration::AppConfiguration.default)
       ShouldReekOnlyOf.new(smell_category, configuration)
     end
 
     #
     # Returns +true+ if and only if the target source code contains smells.
     #
-    def reek(configuration = Configuration::AppConfiguration.new)
+    def reek(configuration = Configuration::AppConfiguration.default)
       ShouldReek.new configuration
     end
   end

--- a/lib/reek/spec/should_reek.rb
+++ b/lib/reek/spec/should_reek.rb
@@ -8,7 +8,7 @@ module Reek
     #
     # @api private
     class ShouldReek
-      def initialize(configuration = Configuration::AppConfiguration.new)
+      def initialize(configuration = Configuration::AppConfiguration.default)
         @configuration = configuration
       end
 

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -10,7 +10,7 @@ module Reek
     class ShouldReekOf
       def initialize(smell_category,
                      smell_details = {},
-                     configuration = Configuration::AppConfiguration.new)
+                     configuration = Configuration::AppConfiguration.default)
         @smell_category = normalize smell_category
         @smell_details  = smell_details
         @configuration  = configuration

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
   s.email = ['timo.roessner@googlemail.com']
-  s.extra_rdoc_files = ['CHANGELOG', 'License.txt']
+  s.extra_rdoc_files = ['CHANGELOG.md', 'License.txt']
   s.files = `git ls-files -z`.split("\0")
   s.executables = s.files.grep(%r{^bin/}).map { |path| File.basename(path) }
   s.homepage = 'https://github.com/troessner/reek/wiki'

--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -7,16 +7,14 @@ require_relative '../../spec_helper'
 
 RSpec.describe Reek::Configuration::ConfigurationFileFinder do
   describe '.find' do
-    it 'returns the config_file if it’s set' do
-      config_file = double
-      options = double(config_file: config_file)
-      found = described_class.find(options: options)
-      expect(found).to eq(config_file)
+    it 'returns the path if it’s set' do
+      path = Pathname.new 'foo/bar'
+      found = described_class.find(path: path)
+      expect(found).to eq(path)
     end
 
     it 'returns the file in current dir if config_file is nil' do
-      options = double(config_file: nil)
-      found = described_class.find(options: options, current: SAMPLES_PATH)
+      found = described_class.find(current: SAMPLES_PATH)
       expect(found).to eq(SAMPLES_PATH.join('exceptions.reek'))
     end
 

--- a/spec/reek/configuration/default_directive_spec.rb
+++ b/spec/reek/configuration/default_directive_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../spec_helper'
+require_relative '../../../lib/reek/configuration/default_directive'
+
+RSpec.describe Reek::Configuration::DefaultDirective do
+  describe '#add' do
+    subject { {}.extend(described_class) }
+
+    it 'adds a smell configuration' do
+      subject.add :UncommunicativeVariableName, enabled: false
+      expect(subject).to eq(Reek::Smells::UncommunicativeVariableName => { enabled: false })
+    end
+  end
+end

--- a/spec/reek/configuration/directory_directives_spec.rb
+++ b/spec/reek/configuration/directory_directives_spec.rb
@@ -1,0 +1,89 @@
+require_relative '../../spec_helper'
+require_relative '../../../lib/reek/configuration/directory_directives'
+
+RSpec.describe Reek::Configuration::DirectoryDirectives do
+  describe '#directive_for' do
+    let(:baz_config)  { { Reek::Smells::IrresponsibleModule => { enabled: false } } }
+    let(:bang_config) { { Reek::Smells::Attribute => { enabled: true } } }
+    subject do
+      {
+        Pathname.new('foo/bar/baz')  => baz_config,
+        Pathname.new('foo/bar/bang') => bang_config
+      }.extend(described_class)
+    end
+    let(:source_via) { 'foo/bar/bang/dummy.rb' }
+
+    context 'our source is in a directory for which we have a directive' do
+      it 'returns the corresponding directive' do
+        expect(subject.directive_for(source_via)).to eq(bang_config)
+      end
+    end
+
+    context 'our source is not in a directory for which we have a directive' do
+      it 'returns nil' do
+        expect(subject.directive_for('does/not/exist')).to eq(nil)
+      end
+    end
+  end
+
+  describe '#add' do
+    subject do
+      {}.extend(described_class)
+    end
+    let(:empty_config) { Hash.new }
+
+    context 'one of given paths does not exist' do
+      let(:bogus_path) { Pathname('does/not/exist') }
+
+      it 'raises an error' do
+        Reek::CLI::Silencer.silently(stderr: true) do
+          expect { subject.add(bogus_path, {}) }.to raise_error(SystemExit)
+        end
+      end
+    end
+
+    context 'one of given paths is a file' do
+      let(:file_as_path) { SAMPLES_PATH.join('inline.rb') }
+
+      it 'raises an error' do
+        Reek::CLI::Silencer.silently(stderr: true) do
+          expect { subject.add(file_as_path, {}) }.to raise_error(SystemExit)
+        end
+      end
+    end
+  end
+
+  describe '#best_match_for' do
+    subject do
+      {
+        Pathname.new('foo/bar/baz')  => {},
+        Pathname.new('foo/bar')      => {},
+        Pathname.new('bar/boo')      => {}
+      }.extend(described_class)
+    end
+
+    it 'returns the corresponding directory when source_base_dir is a leaf' do
+      source_base_dir = 'foo/bar/baz/bang'
+      hit = subject.send :best_match_for, source_base_dir
+      expect(hit.to_s).to eq('foo/bar/baz')
+    end
+
+    it 'returns the corresponding directory when source_base_dir is in the middle of the tree' do
+      source_base_dir = 'foo/bar'
+      hit = subject.send :best_match_for, source_base_dir
+      expect(hit.to_s).to eq('foo/bar')
+    end
+
+    it 'returns nil we are on top of the tree and all other directories are below' do
+      source_base_dir = 'foo'
+      hit = subject.send :best_match_for, source_base_dir
+      expect(hit).to be_nil
+    end
+
+    it 'returns nil when source_base_dir is not part of any directory directive at all' do
+      source_base_dir = 'non/existent'
+      hit = subject.send :best_match_for, source_base_dir
+      expect(hit).to be_nil
+    end
+  end
+end

--- a/spec/reek/configuration/excluded_paths_spec.rb
+++ b/spec/reek/configuration/excluded_paths_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../../spec_helper'
+require_relative '../../../lib/reek/configuration/excluded_paths'
+
+RSpec.describe Reek::Configuration::ExcludedPaths do
+  describe '#add' do
+    subject { [].extend(described_class) }
+
+    context 'one of the given paths does not exist' do
+      let(:bogus_path) { Pathname('does/not/exist') }
+      let(:paths) { [SAMPLES_PATH, bogus_path] }
+
+      it 'raises an error' do
+        Reek::CLI::Silencer.silently(stderr: true) do
+          expect { subject.add(paths) }.to raise_error(SystemExit)
+        end
+      end
+    end
+
+    context 'one of given paths is a file' do
+      let(:file_as_path) { SAMPLES_PATH.join('inline.rb') }
+      let(:paths) { [SAMPLES_PATH, file_as_path] }
+
+      it 'raises an error if one of the given paths is a file' do
+        Reek::CLI::Silencer.silently(stderr: true) do
+          expect { subject.add(paths) }.to raise_error(SystemExit)
+        end
+      end
+    end
+  end
+end

--- a/spec/reek/context/code_context_spec.rb
+++ b/spec/reek/context/code_context_spec.rb
@@ -5,7 +5,7 @@ require_relative '../../../lib/reek/context/module_context'
 RSpec.describe Reek::Context::CodeContext do
   context 'name recognition' do
     before :each do
-      @exp_name = 'random_name'    # SMELL: could use a String.random here
+      @exp_name = 'random_name' # SMELL: could use a String.random here
       @full_name = "::::::::::::::::::::#{@exp_name}"
       @exp = double('exp')
       allow(@exp).to receive(:name).and_return(@exp_name)

--- a/spec/reek/context/module_context_spec.rb
+++ b/spec/reek/context/module_context_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Reek::Context::ModuleContext do
       module Fred
         def simple(x) x + 1; end
       end
-    ').to reek_of(:UncommunicativeParameterName,  name: 'x')
+    ').to reek_of(:UncommunicativeParameterName, name: 'x')
   end
 
   it 'should not report module with empty class' do

--- a/spec/reek/smells/smell_warning_spec.rb
+++ b/spec/reek/smells/smell_warning_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Reek::Smells::SmellWarning do
 
     context 'smells differing only by context' do
       before :each do
-        @first  = build(:smell_warning, smell_detector: duplication_detector,
-                                        context: 'first')
+        @first = build(:smell_warning, smell_detector: duplication_detector,
+                                       context: 'first')
         @second = build(:smell_warning, smell_detector: duplication_detector,
                                         context: 'second')
       end
@@ -45,9 +45,9 @@ RSpec.describe Reek::Smells::SmellWarning do
 
     context 'smells differing only by message' do
       before :each do
-        @first  = build(:smell_warning, smell_detector: duplication_detector,
-                                        context: 'ctx',
-                                        message: 'first message')
+        @first = build(:smell_warning, smell_detector: duplication_detector,
+                                       context: 'ctx',
+                                       message: 'first message')
         @second = build(:smell_warning, smell_detector: duplication_detector,
                                         context: 'ctx',
                                         message: 'second message')
@@ -58,8 +58,8 @@ RSpec.describe Reek::Smells::SmellWarning do
 
     context 'message takes precedence over smell name' do
       before :each do
-        @first  = build(:smell_warning, smell_detector: utility_function_detector,
-                                        message: 'first message')
+        @first = build(:smell_warning, smell_detector: utility_function_detector,
+                                       message: 'first message')
         @second = build(:smell_warning, smell_detector: feature_envy_detector,
                                         message: 'second message')
       end
@@ -75,9 +75,9 @@ RSpec.describe Reek::Smells::SmellWarning do
         duplication_detector = build(:smell_detector,
                                      smell_type: 'DuplicateMethodCall',
                                      source: false)
-        @first  = build(:smell_warning, smell_detector: uncommunicative_name_detector,
-                                        context: 'Dirty',
-                                        message: "has the variable name '@s'")
+        @first = build(:smell_warning, smell_detector: uncommunicative_name_detector,
+                                       context: 'Dirty',
+                                       message: "has the variable name '@s'")
         @second = build(:smell_warning, smell_detector: duplication_detector,
                                         context: 'Dirty#a',
                                         message: 'calls @s.title twice')

--- a/spec/reek/smells/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_module_name_spec.rb
@@ -17,15 +17,15 @@ RSpec.describe Reek::Smells::UncommunicativeModuleName do
     end
 
     it 'reports one-letter name' do
-      expect("#{type} X; end").to reek_of(:UncommunicativeModuleName,  name: 'X')
+      expect("#{type} X; end").to reek_of(:UncommunicativeModuleName, name: 'X')
     end
 
     it 'reports name of the form "x2"' do
-      expect("#{type} X2; end").to reek_of(:UncommunicativeModuleName,  name: 'X2')
+      expect("#{type} X2; end").to reek_of(:UncommunicativeModuleName, name: 'X2')
     end
 
     it 'reports long name ending in a number' do
-      expect("#{type} Printer2; end").to reek_of(:UncommunicativeModuleName,  name: 'Printer2')
+      expect("#{type} Printer2; end").to reek_of(:UncommunicativeModuleName, name: 'Printer2')
     end
 
     it 'reports a bad scoped name' do

--- a/spec/reek/smells/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_variable_name_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
     end
     it 'reports one-letter fieldname in assignment' do
       src = 'class Thing; def simple(fred) @x = fred end end'
-      expect(src).to reek_of(:UncommunicativeVariableName,  name: '@x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: '@x')
     end
   end
 
@@ -67,7 +67,7 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
     end
 
     it 'reports variable name outside any method' do
-      expect('class Simple; x = jim(45); end').to reek_of(:UncommunicativeVariableName,  name: 'x')
+      expect('class Simple; x = jim(45); end').to reek_of(:UncommunicativeVariableName, name: 'x')
     end
   end
 

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
 
   context 'with only one call' do
     it 'reports a call to a parameter' do
-      expect('def simple(arga) arga.to_s end').to reek_of(:UtilityFunction,  name: 'simple')
+      expect('def simple(arga) arga.to_s end').to reek_of(:UtilityFunction, name: 'simple')
     end
 
     it 'reports a call to a constant' do
@@ -169,7 +169,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
   context 'with two or more calls' do
     it 'reports two calls' do
       src = 'def simple(arga) arga.to_s + arga.to_i end'
-      expect(src).to reek_of(:UtilityFunction,  name: 'simple')
+      expect(src).to reek_of(:UtilityFunction, name: 'simple')
       expect(src).not_to reek_of(:FeatureEnvy)
     end
 
@@ -194,7 +194,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
 
     it 'should report message chain' do
       src = 'def simple(arga) arga.b.c end'
-      expect(src).to reek_of(:UtilityFunction,  name: 'simple')
+      expect(src).to reek_of(:UtilityFunction, name: 'simple')
       expect(src).not_to reek_of(:FeatureEnvy)
     end
 

--- a/spec/reek/spec/should_reek_of_spec.rb
+++ b/spec/reek/spec/should_reek_of_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Reek::Spec::ShouldReekOf do
     end
 
     it 'reports duplicate calls to @other.thing' do
-      expect(@ruby).to reek_of(:Duplication,  name: '@other.thing')
+      expect(@ruby).to reek_of(:Duplication, name: '@other.thing')
     end
 
     it 'reports duplicate calls to @other.thing.foo' do
-      expect(@ruby).to reek_of(:Duplication,  name: '@other.thing.foo')
+      expect(@ruby).to reek_of(:Duplication, name: '@other.thing.foo')
     end
 
     it 'does not report any feature envy' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,10 +25,9 @@ SAMPLES_PATH = Pathname.new("#{__dir__}/samples").relative_path_from(Pathname.pw
 module Helpers
   def test_configuration_for(config)
     if config.is_a? Pathname
-      configuration = Reek::Configuration::AppConfiguration.new OpenStruct.new(config_file: config)
+      configuration = Reek::Configuration::AppConfiguration.from_path(config)
     elsif config.is_a? Hash
-      configuration = Reek::Configuration::AppConfiguration.new
-      configuration.instance_variable_set :@default_directive, config
+      configuration = Reek::Configuration::AppConfiguration.from_map default_directive: config
     else
       raise "Unknown config given in `test_configuration_for`: #{config.inspect}"
     end


### PR DESCRIPTION
This makes AppConfiguration's initializer more flexible than before by allowing to pass in hashes as well.
It also refactors quite a lot: Instead of cramming everything into AppConfiguration with hashes and arrays it uses composition and kind of an DCI approach by extending hashes and arrays at runtime to give them the desired behaviour.
More code overall but I believe this is significantly better architecture than before with higher cohesion.
It will also make it significantly easier to maintain this code and to extend it, e.g. with new configuration options.
Precondition for #623 