### PR TITLE
Bump Aruba

### DIFF
--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -27,7 +27,7 @@ end
 
 Given(/^the "(.*?)" sample file exists$/) do |file_name|
   full_path = Pathname.new("#{__dir__}/../../spec/samples/#{file_name}")
-  in_current_directory { FileUtils.cp full_path, file_name }
+  cd('.') { FileUtils.cp full_path, file_name }
 end
 
 Given(/^a directory called 'clean_files' containing some clean files$/) do
@@ -135,7 +135,7 @@ When(/^I run "reek (.*?)" in the subdirectory$/) do |args|
 end
 
 Given(/^a masking configuration file in the HOME directory$/) do
-  set_env 'HOME', Pathname.new("#{current_directory}/home").expand_path.to_s
+  set_environment_variable 'HOME', Pathname.new("#{expand_path('.')}/home")
   write_file('home/config.reek', <<-EOS.strip_heredoc)
     ---
     DuplicateMethodCall:

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'unparser',     '~> 0.2.2'
 
   s.add_development_dependency 'activesupport', '~> 4.2'
-  s.add_development_dependency 'aruba',         '~> 0.7.2'
+  s.add_development_dependency 'aruba',         '~> 0.8.0'
   s.add_development_dependency 'ataru',         '~> 0.2.0'
   s.add_development_dependency 'bundler',       '~> 1.1'
   s.add_development_dependency 'cucumber',      '~> 2.0'


### PR DESCRIPTION
This bumps Aruba to 0.8 and fixes our step definitions to make it green (and not spew deprecation warnings). Hopefully it also fixes JRuby build. ಠ_ರೃ