### PR TITLE
Instance variable access clean-up

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
-require 'rake/clean'
 require 'bundler/gem_tasks'
+require 'private_attr/everywhere'
+require 'rake/clean'
 
 Dir['tasks/**/*.rake'].each { |t| load t }
 

--- a/bin/reek
+++ b/bin/reek
@@ -6,6 +6,7 @@
 # Author: Kevin Rutherford
 #
 
+require_relative '../lib/reek'
 require_relative '../lib/reek/cli/application'
 
 exit Reek::CLI::Application.new(ARGV).execute

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,3 +1,4 @@
+require_relative '../../lib/reek'
 require_relative '../../lib/reek/cli/application'
 require 'aruba/cucumber'
 require 'active_support/core_ext/string/strip'

--- a/lib/reek.rb
+++ b/lib/reek.rb
@@ -1,6 +1,7 @@
 #
 # Reek's core functionality
 #
+require 'private_attr/everywhere'
 require_relative 'reek/version'
 require_relative 'reek/examiner'
 require_relative 'reek/report/report'

--- a/lib/reek/ast/ast_node_class_map.rb
+++ b/lib/reek/ast/ast_node_class_map.rb
@@ -13,7 +13,7 @@ module Reek
       end
 
       def klass_for(type)
-        @klass_map[type] ||= Class.new(Node).tap do |klass|
+        klass_map[type] ||= Class.new(Node).tap do |klass|
           extension = extension_map[type]
           klass.send :include, extension if extension
         end
@@ -31,6 +31,10 @@ module Reek
             Hash[assoc]
           end
       end
+
+      private
+
+      private_attr_reader :klass_map
     end
   end
 end

--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -17,12 +17,12 @@ module Reek
       end
 
       def full_comment
-        @comments.map(&:text).join("\n")
+        comments.map(&:text).join("\n")
       end
 
       def leading_comment
         line = location.line
-        comment_lines = @comments.select do |comment|
+        comment_lines = comments.select do |comment|
           comment.location.line < line
         end
         comment_lines.map(&:text).join("\n")
@@ -119,6 +119,8 @@ module Reek
       end
 
       private
+
+      private_attr_reader :comments
 
       def each_sexp
         children.each { |elem| yield elem if elem.is_a? ::Parser::AST::Node }

--- a/lib/reek/ast/object_refs.rb
+++ b/lib/reek/ast/object_refs.rb
@@ -11,21 +11,25 @@ module Reek
       end
 
       def most_popular
-        max = @refs.values.map(&:size).max
-        @refs.select { |_name, refs| refs.size == max }
+        max = refs.values.map(&:size).max
+        refs.select { |_name, refs| refs.size == max }
       end
 
       def record_reference_to(name, line: nil)
-        @refs[name] << ObjectRef.new(name, line)
+        refs[name] << ObjectRef.new(name, line)
       end
 
       def references_to(name)
-        @refs[name]
+        refs[name]
       end
 
       def self_is_max?
-        @refs.empty? || most_popular.keys.include?(:self)
+        refs.empty? || most_popular.keys.include?(:self)
       end
+
+      private
+
+      private_attr_reader :refs
     end
   end
 end

--- a/lib/reek/ast/reference_collector.rb
+++ b/lib/reek/ast/reference_collector.rb
@@ -18,14 +18,16 @@ module Reek
 
       private
 
+      private_attr_reader :ast
+
       def explicit_self_calls
         [:self, :zsuper, :ivar, :ivasgn].flat_map do |node_type|
-          @ast.each_node(node_type, STOP_NODES)
+          ast.each_node(node_type, STOP_NODES)
         end
       end
 
       def implicit_self_calls
-        @ast.each_node(:send, STOP_NODES).reject(&:receiver)
+        ast.each_node(:send, STOP_NODES).reject(&:receiver)
       end
     end
   end

--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -20,9 +20,9 @@ module Reek
         @status = STATUS_SUCCESS
         options_parser = Options.new(argv)
         begin
-          @options = options_parser.parse
-          @command = ReekCommand.new(OptionInterpreter.new(@options))
-          @configuration = Configuration::AppConfiguration.new @options
+          options = options_parser.parse
+          @command = ReekCommand.new(OptionInterpreter.new(options))
+          @configuration = Configuration::AppConfiguration.new(options)
         rescue OptionParser::InvalidOption, Reek::Configuration::ConfigFileException => error
           $stderr.puts "Error: #{error}"
           @status = STATUS_ERROR
@@ -30,9 +30,9 @@ module Reek
       end
 
       def execute
-        return @status if error_occured?
-        @command.execute self
-        @status
+        return status if error_occured?
+        command.execute self
+        status
       end
 
       def output(text)
@@ -40,17 +40,20 @@ module Reek
       end
 
       def report_success
-        @status = STATUS_SUCCESS
+        self.status = STATUS_SUCCESS
       end
 
       def report_smells
-        @status = STATUS_SMELLS
+        self.status = STATUS_SMELLS
       end
 
       private
 
+      private_attr_accessor :status
+      private_attr_reader :command
+
       def error_occured?
-        @status == STATUS_ERROR
+        status == STATUS_ERROR
       end
     end
   end

--- a/lib/reek/cli/command.rb
+++ b/lib/reek/cli/command.rb
@@ -10,6 +10,10 @@ module Reek
       def initialize(options)
         @options = options
       end
+
+      private
+
+      private_attr_reader :options
     end
   end
 end

--- a/lib/reek/cli/input.rb
+++ b/lib/reek/cli/input.rb
@@ -26,9 +26,9 @@ module Reek
       end
 
       def no_source_files_given?
-        # At this point we have deleted all options from @argv. The only remaining entries
-        # are paths to the source files. If @argv is empty, this means that no files were given.
-        @argv.empty?
+        # At this point we have deleted all options from argv. The only remaining entries
+        # are paths to the source files. If argv is empty, this means that no files were given.
+        argv.empty?
       end
 
       def working_directory_as_source
@@ -36,7 +36,7 @@ module Reek
       end
 
       def sources_from_argv
-        Source::SourceLocator.new(@argv).sources
+        Source::SourceLocator.new(argv).sources
       end
 
       def source_from_pipe

--- a/lib/reek/cli/option_interpreter.rb
+++ b/lib/reek/cli/option_interpreter.rb
@@ -13,11 +13,11 @@ module Reek
 
       extend Forwardable
 
-      def_delegators :@options, :smells_to_detect
+      def_delegators :options, :smells_to_detect
 
       def initialize(options)
         @options = options
-        @argv = @options.argv
+        @argv = options.argv
       end
 
       def reporter
@@ -30,7 +30,7 @@ module Reek
       end
 
       def report_class
-        Report.report_class(@options.report_format)
+        Report.report_class(options.report_format)
       end
 
       def warning_formatter
@@ -38,20 +38,24 @@ module Reek
       end
 
       def warning_formatter_class
-        Report.warning_formatter_class(@options.show_links ? :wiki_links : :simple)
+        Report.warning_formatter_class(options.show_links ? :wiki_links : :simple)
       end
 
       def location_formatter
-        Report.location_formatter(@options.location_format)
+        Report.location_formatter(options.location_format)
       end
 
       def heading_formatter
-        Report.heading_formatter(@options.show_empty ? :verbose : :quiet)
+        Report.heading_formatter(options.show_empty ? :verbose : :quiet)
       end
 
       def sort_by_issue_count
-        @options.sorting == :smelliness
+        options.sorting == :smelliness
       end
+
+      private
+
+      private_attr_reader :argv, :options
     end
   end
 end

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -23,13 +23,15 @@ module Reek
       end
 
       def parse
-        @parser.parse!(@argv)
-        @options.argv = @argv
-        Rainbow.enabled = @options.colored
-        @options
+        parser.parse!(argv)
+        options.argv = argv
+        Rainbow.enabled = options.colored
+        options
       end
 
       private
+
+      private_attr_reader :argv, :options, :parser
 
       def color_support?
         $stdout.tty?
@@ -44,8 +46,8 @@ module Reek
       end
 
       def set_banner
-        program_name = @parser.program_name
-        @parser.banner = <<-EOB.gsub(/^[ ]+/, '')
+        program_name = parser.program_name
+        parser.banner = <<-EOB.gsub(/^[ ]+/, '')
           Usage: #{program_name} [options] [files]
 
           Examples:
@@ -60,29 +62,29 @@ module Reek
       end
 
       def set_alternative_formatter_options
-        @parser.separator "\nReport format:"
-        @parser.on(
+        parser.separator "\nReport format:"
+        parser.on(
           '-f', '--format FORMAT', [:html, :text, :yaml, :json, :xml],
           'Report smells in the given format:',
           '  html', '  text (default)', '  yaml', '  json', '  xml'
         ) do |opt|
-          @options.report_format = opt
+          options.report_format = opt
         end
       end
 
       def set_configuration_options
-        @parser.separator 'Configuration:'
-        @parser.on('-c', '--config FILE', 'Read configuration options from FILE') do |file|
+        parser.separator 'Configuration:'
+        parser.on('-c', '--config FILE', 'Read configuration options from FILE') do |file|
           raise ArgumentError, "Config file #{file} doesn't exist" unless File.exist?(file)
-          @options.config_file = Pathname.new(file)
+          options.config_file = Pathname.new(file)
         end
-        @parser.on('--smell SMELL', 'Detect smell SMELL (default: all enabled smells)') do |smell|
-          @options.smells_to_detect << smell
+        parser.on('--smell SMELL', 'Detect smell SMELL (default: all enabled smells)') do |smell|
+          options.smells_to_detect << smell
         end
       end
 
       def set_report_formatting_options
-        @parser.separator "\nText format options:"
+        parser.separator "\nText format options:"
         set_up_color_option
         set_up_verbosity_options
         set_up_location_formatting_options
@@ -90,50 +92,50 @@ module Reek
       end
 
       def set_up_color_option
-        @parser.on('--[no-]color', 'Use colors for the output (default: true)') do |opt|
-          @options.colored = opt
+        parser.on('--[no-]color', 'Use colors for the output (default: true)') do |opt|
+          options.colored = opt
         end
       end
 
       def set_up_verbosity_options
-        @parser.on('-V', '--[no-]empty-headings',
-                   'Show headings for smell-free source files (default: false)') do |show_empty|
-          @options.show_empty = show_empty
+        parser.on('-V', '--[no-]empty-headings',
+                  'Show headings for smell-free source files (default: false)') do |show_empty|
+          options.show_empty = show_empty
         end
-        @parser.on('-U', '--[no-]wiki-links',
-                   'Show link to related wiki page for each smell (default: false)') do |show_links|
-          @options.show_links = show_links
+        parser.on('-U', '--[no-]wiki-links',
+                  'Show link to related wiki page for each smell (default: false)') do |show_links|
+          options.show_links = show_links
         end
       end
 
       def set_up_location_formatting_options
-        @parser.on('-n', '--[no-]line-numbers',
-                   'Show line numbers in the output (default: true)') do |show_numbers|
-          @options.location_format = show_numbers ? :numbers : :plain
+        parser.on('-n', '--[no-]line-numbers',
+                  'Show line numbers in the output (default: true)') do |show_numbers|
+          options.location_format = show_numbers ? :numbers : :plain
         end
-        @parser.on('-s', '--single-line',
-                   'Show location in editor-compatible single-line-per-smell format') do
-          @options.location_format = :single_line
+        parser.on('-s', '--single-line',
+                  'Show location in editor-compatible single-line-per-smell format') do
+          options.location_format = :single_line
         end
       end
 
       def set_up_sorting_option
-        @parser.on('--sort-by SORTING', [:smelliness, :none],
-                   'Sort reported files by the given criterium:',
-                   '  smelliness ("smelliest" files first)',
-                   '  none (default - output in processing order)') do |sorting|
-                     @options.sorting = sorting
-                   end
+        parser.on('--sort-by SORTING', [:smelliness, :none],
+                  'Sort reported files by the given criterium:',
+                  '  smelliness ("smelliest" files first)',
+                  '  none (default - output in processing order)') do |sorting|
+          options.sorting = sorting
+        end
       end
 
       def set_utility_options
-        @parser.separator "\nUtility options:"
-        @parser.on_tail('-h', '--help', 'Show this message') do
-          puts @parser
+        parser.separator "\nUtility options:"
+        parser.on_tail('-h', '--help', 'Show this message') do
+          puts parser
           exit
         end
-        @parser.on_tail('-v', '--version', 'Show version') do
-          puts "#{@parser.program_name} #{Reek::Version::STRING}\n"
+        parser.on_tail('-v', '--version', 'Show version') do
+          puts "#{parser.program_name} #{Reek::Version::STRING}\n"
           exit
         end
       end

--- a/lib/reek/cli/reek_command.rb
+++ b/lib/reek/cli/reek_command.rb
@@ -10,7 +10,7 @@ module Reek
     # @api private
     class ReekCommand < Command
       def execute(app)
-        @options.sources.each do |source|
+        options.sources.each do |source|
           reporter.add_examiner Examiner.new(source, smell_names, configuration: app.configuration)
         end
         reporter.smells? ? app.report_smells : app.report_success
@@ -20,11 +20,11 @@ module Reek
       private
 
       def reporter
-        @reporter ||= @options.reporter
+        @reporter ||= options.reporter
       end
 
       def smell_names
-        @smell_names ||= @options.smells_to_detect
+        @smell_names ||= options.smells_to_detect
       end
     end
   end

--- a/lib/reek/cli/warning_collector.rb
+++ b/lib/reek/cli/warning_collector.rb
@@ -8,16 +8,20 @@ module Reek
     # @api private
     class WarningCollector
       def initialize
-        @warnings = Set.new
+        @warnings_set = Set.new
       end
 
       def found_smell(warning)
-        @warnings.add(warning)
+        warnings_set.add(warning)
       end
 
       def warnings
-        @warnings.to_a.sort
+        warnings_set.to_a.sort
       end
+
+      private
+
+      private_attr_reader :warnings_set
     end
   end
 end

--- a/lib/reek/code_comment.rb
+++ b/lib/reek/code_comment.rb
@@ -21,7 +21,7 @@ module Reek
     end
 
     def descriptive?
-      @text.split(/\s+/).length >= 2
+      text.split(/\s+/).length >= 2
     end
 
     protected
@@ -32,5 +32,9 @@ module Reek
       # TODO: extend this to all configs -------------------^
       # TODO: extend to allow configuration of whole smell class, not just subclass
     end
+
+    private
+
+    private_attr_reader :text
   end
 end

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -1,5 +1,4 @@
 require 'pathname'
-require 'private_attr/everywhere'
 require_relative './configuration_file_finder'
 
 module Reek

--- a/lib/reek/context/code_context.rb
+++ b/lib/reek/context/code_context.rb
@@ -70,11 +70,11 @@ module Reek
       # @param child [CodeContext] the child context to register
       def append_child_context(child)
         child.visibility = tracked_visibility
-        @children << child
+        children << child
       end
 
       def count_statements(num)
-        @num_statements += num
+        self.num_statements += num
       end
 
       def record_call_to(exp)
@@ -83,19 +83,19 @@ module Reek
         case type
         when :lvar, :lvasgn
           unless exp.object_creation_call?
-            @refs.record_reference_to(receiver.name, line: exp.line)
+            refs.record_reference_to(receiver.name, line: exp.line)
           end
         when :self
-          @refs.record_reference_to(:self, line: exp.line)
+          refs.record_reference_to(:self, line: exp.line)
         end
       end
 
       def record_use_of_self
-        @refs.record_reference_to(:self)
+        refs.record_reference_to(:self)
       end
 
       def name
-        @exp.name
+        exp.name
       end
 
       def local_nodes(type, &blk)
@@ -103,7 +103,7 @@ module Reek
       end
 
       def each_node(type, ignoring, &blk)
-        @exp.each_node(type, ignoring, &blk)
+        exp.each_node(type, ignoring, &blk)
       end
 
       def matches?(candidates)
@@ -119,8 +119,7 @@ module Reek
       end
 
       def full_name
-        context = @context ? @context.full_name : ''
-        exp.full_name(context)
+        exp.full_name(context ? context.full_name : '')
       end
 
       def config_for(detector_class)
@@ -140,46 +139,49 @@ module Reek
       # @param names [Array<Symbol>]
       def track_visibility(visibility, names = [])
         if names.any?
-          @children.each do |child|
+          children.each do |child|
             child.visibility = visibility if names.include? child.name
           end
         else
-          @tracked_visibility = visibility
+          self.tracked_visibility = visibility
         end
       end
 
       def type
-        @exp.type
+        exp.type
       end
 
       # Iterate over +self+ and child contexts.
       def each(&block)
         yield self
-        @children.each do |child|
+        children.each do |child|
           child.each(&block)
         end
       end
 
       protected
 
-      attr_writer :visibility
+      attr_writer :num_statements, :visibility
 
       private
+
+      private_attr_writer :tracked_visibility
+      private_attr_reader :context, :refs
 
       def tracked_visibility
         @tracked_visibility ||= :public
       end
 
       def config
-        @config ||= if @exp
-                      CodeComment.new(@exp.full_comment || '').config
+        @config ||= if exp
+                      CodeComment.new(exp.full_comment || '').config
                     else
                       {}
                     end
       end
 
       def context_config_for(detector_class)
-        @context ? @context.config_for(detector_class) : {}
+        context ? context.config_for(detector_class) : {}
       end
     end
   end

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -39,14 +39,14 @@ module Reek
     # @return [String] description of the source being analysed
     #
     def description
-      @description ||= @source.description
+      @description ||= source.description
     end
 
     #
     # @return [Array<SmellWarning>] the smells found in the source
     #
     def smells
-      @smells ||= @collector.warnings
+      @smells ||= collector.warnings
     end
 
     #
@@ -65,13 +65,15 @@ module Reek
 
     private
 
+    private_attr_reader :configuration, :collector, :smell_types, :source
+
     def run
       smell_repository = Smells::SmellRepository.new(source_description: description,
-                                                     smell_types: @smell_types,
-                                                     configuration: @configuration)
-      syntax_tree = @source.syntax_tree
+                                                     smell_types: smell_types,
+                                                     configuration: configuration)
+      syntax_tree = source.syntax_tree
       TreeWalker.new(smell_repository, syntax_tree).walk if syntax_tree
-      smell_repository.report_on(@collector)
+      smell_repository.report_on(collector)
     end
 
     def eligible_smell_types(filter_by_smells = [])

--- a/lib/reek/rake/task.rb
+++ b/lib/reek/rake/task.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'private_attr/everywhere'
 require 'rake'
 require 'rake/tasklib'
 require 'pathname'

--- a/lib/reek/report/formatter.rb
+++ b/lib/reek/report/formatter.rb
@@ -35,7 +35,7 @@ module Reek
       end
 
       def format(warning)
-        "#{@location_formatter.format(warning)}#{base_format(warning)}"
+        "#{location_formatter.format(warning)}#{base_format(warning)}"
       end
 
       private
@@ -43,6 +43,10 @@ module Reek
       def base_format(warning)
         "#{warning.context} #{warning.message} (#{warning.smell_type})"
       end
+
+      private
+
+      private_attr_reader :location_formatter
     end
 
     #

--- a/lib/reek/report/report.rb
+++ b/lib/reek/report/report.rb
@@ -30,8 +30,8 @@ module Reek
       #
       # @param [Reek::Examiner] examiner object to report on
       def add_examiner(examiner)
-        @total_smell_count += examiner.smells_count
-        @examiners << examiner
+        self.total_smell_count += examiner.smells_count
+        examiners << examiner
         self
       end
 
@@ -42,13 +42,22 @@ module Reek
 
       # @api private
       def smells?
-        @total_smell_count > 0
+        total_smell_count > 0
       end
 
       # @api private
       def smells
-        @examiners.map(&:smells).flatten
+        examiners.map(&:smells).flatten
       end
+
+      protected
+
+      attr_accessor :total_smell_count
+
+      private
+
+      private_attr_reader :examiners, :options, :report_formatter,
+                          :sort_by_issue_count, :warning_formatter
     end
 
     #
@@ -64,7 +73,7 @@ module Reek
       private
 
       def smell_summaries
-        @examiners.map { |ex| summarize_single_examiner(ex) }.reject(&:empty?)
+        examiners.map { |ex| summarize_single_examiner(ex) }.reject(&:empty?)
       end
 
       def display_summary
@@ -72,33 +81,33 @@ module Reek
       end
 
       def display_total_smell_count
-        return unless @examiners.size > 1
+        return unless examiners.size > 1
         print total_smell_count_message
       end
 
       def summarize_single_examiner(examiner)
         result = heading_formatter.header(examiner)
         if examiner.smelly?
-          formatted_list = @report_formatter.format_list(examiner.smells,
-                                                         @warning_formatter)
+          formatted_list = report_formatter.format_list(examiner.smells,
+                                                        warning_formatter)
           result += ":\n#{formatted_list}"
         end
         result
       end
 
       def sort_examiners
-        @examiners.sort_by!(&:smells_count).reverse! if @sort_by_issue_count
+        examiners.sort_by!(&:smells_count).reverse! if sort_by_issue_count
       end
 
       def total_smell_count_message
         colour = smells? ? WARNINGS_COLOR : NO_WARNINGS_COLOR
-        s = @total_smell_count == 1 ? '' : 's'
-        Rainbow("#{@total_smell_count} total warning#{s}\n").color(colour)
+        s = total_smell_count == 1 ? '' : 's'
+        Rainbow("#{total_smell_count} total warning#{s}\n").color(colour)
       end
 
       def heading_formatter
         @heading_formatter ||=
-          @options.fetch(:heading_formatter, HeadingFormatter::Quiet).new(@report_formatter)
+          options.fetch(:heading_formatter, HeadingFormatter::Quiet).new(report_formatter)
       end
     end
 
@@ -118,7 +127,7 @@ module Reek
       def show
         print ::JSON.generate(
           smells.map do |smell|
-            smell.yaml_hash(@warning_formatter)
+            smell.yaml_hash(warning_formatter)
           end
         )
       end

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -34,8 +34,8 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        @visiblity_tracker = {}
-        @visiblity_mode = :public
+        self.visiblity_tracker = {}
+        self.visiblity_mode = :public
         attributes_in(ctx).map do |attribute, line|
           SmellWarning.new self,
                            context: ctx.full_name,
@@ -46,6 +46,9 @@ module Reek
       end
 
       private
+
+      private_attr_accessor :visiblity_mode, :visiblity_tracker
+      private_attr_reader :result
 
       def attributes_in(module_ctx)
         attributes = Set.new
@@ -78,7 +81,7 @@ module Reek
 
       def track_argument(arg, line)
         arg_name = arg.children.first
-        @visiblity_tracker[arg_name] = @visiblity_mode
+        visiblity_tracker[arg_name] = visiblity_mode
         [arg_name, line]
       end
 
@@ -88,14 +91,14 @@ module Reek
 
       def track_visibility(call_node)
         if call_node.arg_names.any?
-          call_node.arg_names.each { |arg| @visiblity_tracker[arg] = call_node.method_name }
+          call_node.arg_names.each { |arg| visiblity_tracker[arg] = call_node.method_name }
         else
-          @visiblity_mode = call_node.method_name
+          self.visiblity_mode = call_node.method_name
         end
       end
 
       def recorded_public_methods
-        @visiblity_tracker.select { |_, visbility| visbility == :public }
+        visiblity_tracker.select { |_, visbility| visbility == :public }
       end
     end
   end

--- a/lib/reek/smells/control_parameter.rb
+++ b/lib/reek/smells/control_parameter.rb
@@ -73,16 +73,20 @@ module Reek
         end
 
         def smells?
-          @occurences.any?
+          occurences.any?
         end
 
         def lines
-          @occurences.map(&:line)
+          occurences.map(&:line)
         end
 
         def name
-          @param.to_s
+          param.to_s
         end
+
+        private
+
+        private_attr_reader :occurences, :param
       end
 
       # Finds cases of ControlParameter in a particular node for a particular parameter
@@ -108,13 +112,15 @@ module Reek
 
         private
 
+        private_attr_reader :node, :param
+
         def conditional_nodes
-          @node.body_nodes(CONDITIONAL_NODE_TYPES)
+          node.body_nodes(CONDITIONAL_NODE_TYPES)
         end
 
         def nested_finders
           @nested_finders ||= conditional_nodes.flat_map do |node|
-            self.class.new(node, @param)
+            self.class.new(node, param)
           end
         end
 
@@ -129,12 +135,12 @@ module Reek
 
         def uses_of_param_in_condition
           return [] unless condition
-          condition.each_node(:lvar).select { |inner| inner.var_name == @param }
+          condition.each_node(:lvar).select { |inner| inner.var_name == param }
         end
 
         def condition
-          return nil unless CONDITIONAL_NODE_TYPES.include? @node.type
-          @node.condition
+          return nil unless CONDITIONAL_NODE_TYPES.include? node.type
+          node.condition
         end
 
         def regular_call_involving_param?(call_node)
@@ -150,12 +156,12 @@ module Reek
         end
 
         def call_involving_param?(call_node)
-          call_node.each_node(:lvar).any? { |it| it.var_name == @param }
+          call_node.each_node(:lvar).any? { |it| it.var_name == param }
         end
 
         def uses_param_in_body?
-          nodes = @node.body_nodes([:lvar], [:if, :case, :and, :or])
-          nodes.any? { |lvar_node| lvar_node.var_name == @param }
+          nodes = node.body_nodes([:lvar], [:if, :case, :and, :or])
+          nodes.any? { |lvar_node| lvar_node.var_name == param }
         end
       end
 
@@ -175,12 +181,14 @@ module Reek
 
         private
 
+        private_attr_reader :context
+
         def potential_parameters
-          @context.exp.parameter_names
+          context.exp.parameter_names
         end
 
         def find_matches(param)
-          ControlParameterFinder.new(@context.exp, param).find_matches
+          ControlParameterFinder.new(context.exp, param).find_matches
         end
       end
     end

--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -52,9 +52,9 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        @max_copies = value(MAX_COPIES_KEY, ctx, DEFAULT_MAX_COPIES)
-        @min_clump_size = value(MIN_CLUMP_SIZE_KEY, ctx, DEFAULT_MIN_CLUMP_SIZE)
-        MethodGroup.new(ctx, @min_clump_size, @max_copies).clumps.map do |clump, methods|
+        max_copies = value(MAX_COPIES_KEY, ctx, DEFAULT_MAX_COPIES)
+        min_clump_size = value(MIN_CLUMP_SIZE_KEY, ctx, DEFAULT_MIN_CLUMP_SIZE)
+        MethodGroup.new(ctx, min_clump_size, max_copies).clumps.map do |clump, methods|
           print_clump = DataClump.print_clump(clump)
           SmellWarning.new self,
                            context: ctx.full_name,
@@ -88,10 +88,10 @@ module Reek
     end
 
     def candidate_clumps
-      @candidate_methods.each_cons(@max_copies + 1).map do |methods|
+      candidate_methods.each_cons(max_copies + 1).map do |methods|
         common_argument_names_for(methods)
       end.select do |clump|
-        clump.length >= @min_clump_size
+        clump.length >= min_clump_size
       end.uniq
     end
 
@@ -100,7 +100,7 @@ module Reek
     end
 
     def methods_containing_clump(clump)
-      @candidate_methods.select { |method| clump & method.arg_names == clump }
+      candidate_methods.select { |method| clump & method.arg_names == clump }
     end
 
     def clumps
@@ -108,6 +108,10 @@ module Reek
         [clump, methods_containing_clump(clump)]
       end
     end
+
+    private
+
+    private_attr_reader :candidate_methods, :max_copies, :min_clump_size
   end
 
   # A method definition and a copy of its parameters
@@ -118,15 +122,19 @@ module Reek
     end
 
     def arg_names
-      @arg_names ||= @defn.arg_names.compact.sort
+      @arg_names ||= defn.arg_names.compact.sort
     end
 
     def line
-      @defn.line
+      defn.line
     end
 
     def name
-      @defn.name.to_s     # BUG: should report the symbols!
+      defn.name.to_s     # BUG: should report the symbols!
     end
+
+    private
+
+    private_attr_reader :defn
   end
 end

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -68,20 +68,24 @@ module Reek
         end
 
         def record(occurence)
-          @occurences.push occurence
+          occurences.push occurence
         end
 
         def call
-          @call ||= @call_node.format_to_ruby
+          @call ||= call_node.format_to_ruby
         end
 
         def occurs
-          @occurences.length
+          occurences.length
         end
 
         def lines
-          @occurences.map(&:line)
+          occurences.map(&:line)
         end
+
+        private
+
+        private_attr_reader :call_node, :occurences
       end
 
       # Collects all calls in a given context
@@ -106,6 +110,8 @@ module Reek
 
         private
 
+        private_attr_reader :allow_calls, :max_allowed_calls
+
         def collect_calls(result)
           context.each_node(:send, [:mlhs]) do |call_node|
             next if call_node.object_creation_call?
@@ -118,7 +124,7 @@ module Reek
         end
 
         def smelly_call?(found_call)
-          found_call.occurs > @max_allowed_calls && !allow_calls?(found_call.call)
+          found_call.occurs > max_allowed_calls && !allow_calls?(found_call.call)
         end
 
         def simple_method_call?(call_node)
@@ -126,7 +132,7 @@ module Reek
         end
 
         def allow_calls?(method)
-          @allow_calls.any? { |allow| /#{allow}/ =~ method }
+          allow_calls.any? { |allow| /#{allow}/ =~ method }
         end
       end
     end

--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -35,9 +35,9 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        @max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, ctx, DEFAULT_MAX_ALLOWED_PARAMS)
+        max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, ctx, DEFAULT_MAX_ALLOWED_PARAMS)
         count = ctx.exp.arg_names.length
-        return [] if count <= @max_allowed_params
+        return [] if count <= max_allowed_params
         [SmellWarning.new(self,
                           context: ctx.full_name,
                           lines: [ctx.exp.line],

--- a/lib/reek/smells/long_yield_list.rb
+++ b/lib/reek/smells/long_yield_list.rb
@@ -29,11 +29,11 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(method_ctx)
-        @max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY,
-                                    method_ctx,
-                                    DEFAULT_MAX_ALLOWED_PARAMS)
+        max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY,
+                                   method_ctx,
+                                   DEFAULT_MAX_ALLOWED_PARAMS)
         method_ctx.local_nodes(:yield).select do |yield_node|
-          yield_node.args.length > @max_allowed_params
+          yield_node.args.length > max_allowed_params
         end.map do |yield_node|
           count = yield_node.args.length
           SmellWarning.new self,

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -50,8 +50,10 @@ module Reek
 
       private
 
+      private_attr_accessor :ignore_iterators
+
       def find_deepest_iterator(ctx)
-        @ignore_iterators = value(IGNORE_ITERATORS_KEY, ctx, DEFAULT_IGNORE_ITERATORS)
+        self.ignore_iterators = value(IGNORE_ITERATORS_KEY, ctx, DEFAULT_IGNORE_ITERATORS)
 
         find_iters(ctx.exp, 1).sort_by { |item| item[1] }.last
       end
@@ -73,7 +75,7 @@ module Reek
 
       def ignored_iterator?(exp)
         name = exp.call.method_name.to_s
-        @ignore_iterators.any? { |pattern| /#{pattern}/ =~ name }
+        ignore_iterators.any? { |pattern| /#{pattern}/ =~ name }
       end
     end
   end

--- a/lib/reek/smells/nil_check.rb
+++ b/lib/reek/smells/nil_check.rb
@@ -36,10 +36,14 @@ module Reek
         end
 
         def smelly_nodes
-          @nodes.select do |when_node|
-            @detector.detect(when_node)
+          nodes.select do |when_node|
+            detector.detect(when_node)
           end
         end
+
+        private
+
+        private_attr_reader :detector, :nodes
       end
 
       # Detect 'call' nodes which perform a nil check.

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -51,9 +51,9 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        @max_identical_ifs = value(MAX_IDENTICAL_IFS_KEY, ctx, DEFAULT_MAX_IFS)
+        max_identical_ifs = value(MAX_IDENTICAL_IFS_KEY, ctx, DEFAULT_MAX_IFS)
         conditional_counts(ctx).select do |_key, lines|
-          lines.length > @max_identical_ifs
+          lines.length > max_identical_ifs
         end.map do |key, lines|
           occurs = lines.length
           expression = key.format_to_ruby

--- a/lib/reek/smells/smell_configuration.rb
+++ b/lib/reek/smells/smell_configuration.rb
@@ -17,8 +17,8 @@ module Reek
         @options = hash
       end
 
-      def merge!(options)
-        @options.merge!(options)
+      def merge!(new_options)
+        options.merge!(new_options)
       end
 
       #
@@ -26,11 +26,11 @@ module Reek
       #--
       #  SMELL: Getter
       def enabled?
-        @options[ENABLED_KEY]
+        options[ENABLED_KEY]
       end
 
       def overrides_for(context)
-        Overrides.new(@options.fetch(OVERRIDES_KEY, {})).for_context(context)
+        Overrides.new(options.fetch(OVERRIDES_KEY, {})).for_context(context)
       end
 
       # Retrieves the value, if any, for the given +key+.
@@ -39,8 +39,12 @@ module Reek
       #
       def value(key, context, fall_back)
         overrides_for(context).each { |conf| return conf[key] if conf.key?(key) }
-        @options.fetch(key, fall_back)
+        options.fetch(key, fall_back)
       end
+
+      private
+
+      private_attr_reader :options
     end
 
     #
@@ -54,9 +58,13 @@ module Reek
 
       # Find any overrides that match the supplied context
       def for_context(context)
-        contexts = @hash.keys.select { |ckey| context.matches?([ckey]) }
-        contexts.map { |exc| @hash[exc] }
+        contexts = hash.keys.select { |ckey| context.matches?([ckey]) }
+        contexts.map { |exc| hash[exc] }
       end
+
+      private
+
+      private_attr_reader :hash
     end
   end
 end

--- a/lib/reek/smells/smell_detector.rb
+++ b/lib/reek/smells/smell_detector.rb
@@ -38,12 +38,17 @@ module Reek
         end
 
         def inherited(subclass)
-          @subclasses ||= []
-          @subclasses << subclass
+          subclasses << subclass
         end
 
         def descendants
-          @subclasses
+          subclasses
+        end
+
+        private
+
+        def subclasses
+          @subclasses ||= []
         end
       end
 
@@ -78,17 +83,17 @@ module Reek
       end
 
       def register(hooks)
-        return unless @config.enabled?
+        return unless config.enabled?
         self.class.contexts.each { |ctx| hooks[ctx] << self }
       end
 
       # SMELL: Getter (only used in 1 test)
       def enabled?
-        @config.enabled?
+        config.enabled?
       end
 
-      def configure_with(config)
-        @config.merge!(config)
+      def configure_with(new_config)
+        config.merge!(new_config)
       end
 
       def examine(context)
@@ -96,7 +101,7 @@ module Reek
         return if exception?(context)
 
         sm = examine_context(context)
-        @smells_found += sm
+        self.smells_found += sm
       end
 
       def enabled_for?(context)
@@ -108,16 +113,24 @@ module Reek
       end
 
       def report_on(report)
-        @smells_found.each { |smell| smell.report_on(report) }
+        smells_found.each { |smell| smell.report_on(report) }
       end
 
       def value(key, ctx, fall_back)
-        config_for(ctx)[key] || @config.value(key, ctx, fall_back)
+        config_for(ctx)[key] || config.value(key, ctx, fall_back)
       end
 
       def config_for(ctx)
         ctx.config_for(self.class)
       end
+
+      protected
+
+      attr_writer :smells_found
+
+      private
+
+      private_attr_reader :config
     end
   end
 end

--- a/lib/reek/smells/smell_repository.rb
+++ b/lib/reek/smells/smell_repository.rb
@@ -1,4 +1,3 @@
-require 'private_attr/everywhere'
 require_relative '../smells'
 require_relative 'smell_detector'
 require_relative '../configuration/app_configuration'

--- a/lib/reek/smells/smell_warning.rb
+++ b/lib/reek/smells/smell_warning.rb
@@ -8,15 +8,15 @@ module Reek
     class SmellWarning
       include Comparable
       extend Forwardable
-      attr_accessor :smell_detector, :context, :lines, :message, :parameters
+      attr_reader :context, :lines, :message, :parameters, :smell_detector
       def_delegators :smell_detector, :smell_category, :smell_type, :source
 
       def initialize(smell_detector, options = {})
-        self.smell_detector = smell_detector
-        self.context        = options.fetch(:context, '').to_s
-        self.lines          = options.fetch(:lines)
-        self.message        = options.fetch(:message)
-        self.parameters     = options.fetch(:parameters, {})
+        @smell_detector = smell_detector
+        @context        = options.fetch(:context, '').to_s
+        @lines          = options.fetch(:lines)
+        @message        = options.fetch(:message)
+        @parameters     = options.fetch(:parameters, {})
       end
 
       def hash

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -39,9 +39,9 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        @max_allowed_ivars = value(MAX_ALLOWED_IVARS_KEY, ctx, DEFAULT_MAX_IVARS)
+        max_allowed_ivars = value(MAX_ALLOWED_IVARS_KEY, ctx, DEFAULT_MAX_IVARS)
         count = ctx.local_nodes(:ivasgn).map { |ivasgn| ivasgn[1] }.uniq.length
-        return [] if count <= @max_allowed_ivars
+        return [] if count <= max_allowed_ivars
         [SmellWarning.new(self,
                           context: ctx.full_name,
                           lines: [ctx.exp.line],

--- a/lib/reek/smells/too_many_methods.rb
+++ b/lib/reek/smells/too_many_methods.rb
@@ -41,9 +41,9 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        @max_allowed_methods = value(MAX_ALLOWED_METHODS_KEY, ctx, DEFAULT_MAX_METHODS)
+        max_allowed_methods = value(MAX_ALLOWED_METHODS_KEY, ctx, DEFAULT_MAX_METHODS)
         actual = ctx.node_instance_methods.length
-        return [] if actual <= @max_allowed_methods
+        return [] if actual <= max_allowed_methods
         [SmellWarning.new(self,
                           context: ctx.full_name,
                           lines: [ctx.exp.line],

--- a/lib/reek/smells/too_many_statements.rb
+++ b/lib/reek/smells/too_many_statements.rb
@@ -33,11 +33,11 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        @max_allowed_statements = value(MAX_ALLOWED_STATEMENTS_KEY,
-                                        ctx,
-                                        DEFAULT_MAX_STATEMENTS)
+        max_allowed_statements = value(MAX_ALLOWED_STATEMENTS_KEY,
+                                       ctx,
+                                       DEFAULT_MAX_STATEMENTS)
         count = ctx.num_statements
-        return [] if count <= @max_allowed_statements
+        return [] if count <= max_allowed_statements
         [SmellWarning.new(self,
                           context: ctx.full_name,
                           lines: [ctx.exp.line],

--- a/lib/reek/smells/uncommunicative_method_name.rb
+++ b/lib/reek/smells/uncommunicative_method_name.rb
@@ -47,13 +47,13 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        @reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
-        @accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
+        reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
+        accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
         name = ctx.name.to_s
-        return [] if @accept_names.include?(ctx.full_name)
+        return [] if accept_names.include?(ctx.full_name)
         var = name.gsub(/^[@\*\&]*/, '')
-        return [] if @accept_names.include?(var)
-        return [] unless @reject_names.find { |patt| patt =~ var }
+        return [] if accept_names.include?(var)
+        return [] unless reject_names.find { |patt| patt =~ var }
         [SmellWarning.new(self,
                           context: ctx.full_name,
                           lines: [ctx.exp.line],

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -52,15 +52,15 @@ module Reek
       #
       # :reek:Duplication { allow_calls: [ to_s ] }
       def examine_context(ctx)
-        @reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
-        @accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
+        reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
+        accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
         exp = ctx.exp
         full_name = ctx.full_name
         name = exp.simple_name.to_s
-        return [] if @accept_names.include?(full_name)
+        return [] if accept_names.include?(full_name)
         var = name.gsub(/^[@\*\&]*/, '')
-        return [] if @accept_names.include?(var)
-        return [] unless @reject_names.find { |patt| patt =~ var }
+        return [] if accept_names.include?(var)
+        return [] unless reject_names.find { |patt| patt =~ var }
         [SmellWarning.new(self,
                           context: full_name,
                           lines: [exp.line],

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -47,8 +47,8 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        @reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
-        @accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
+        self.reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
+        self.accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
         context_expression = ctx.exp
         context_expression.parameter_names.select do |name|
           bad_name?(name) && ctx.uses_param?(name)
@@ -63,9 +63,13 @@ module Reek
 
       def bad_name?(name)
         var = name.to_s.gsub(/^[@\*\&]*/, '')
-        return false if var == '*' || @accept_names.include?(var)
-        @reject_names.find { |patt| patt =~ var }
+        return false if var == '*' || accept_names.include?(var)
+        reject_names.find { |patt| patt =~ var }
       end
+
+      private
+
+      private_attr_accessor :accept_names, :reject_names
     end
   end
 end

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -51,8 +51,8 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        @reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
-        @accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
+        self.reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
+        self.accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
         variable_names(ctx.exp).select do |name, _lines|
           bad_name?(name, ctx)
         end.map do |name, lines|
@@ -66,8 +66,8 @@ module Reek
 
       def bad_name?(name, _ctx)
         var = name.to_s.gsub(/^[@\*\&]*/, '')
-        return false if @accept_names.include?(var)
-        @reject_names.find { |patt| patt =~ var }
+        return false if accept_names.include?(var)
+        reject_names.find { |patt| patt =~ var }
       end
 
       def variable_names(exp)
@@ -121,6 +121,10 @@ module Reek
         var = varname.to_sym
         accumulator[var].push(exp.line)
       end
+
+      private
+
+      private_attr_accessor :accept_names, :reject_names
     end
   end
 end

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -82,7 +82,7 @@ module Reek
         @syntax_tree ||=
           begin
             begin
-              ast, comments = @parser.parse_with_comments(@source, @description)
+              ast, comments = parser.parse_with_comments(source, description)
             rescue Racc::ParseError, Parser::SyntaxError => error
               $stderr.puts "#{description}: #{error.class.name}: #{error}"
             end
@@ -92,6 +92,10 @@ module Reek
             TreeDresser.new.dress(ast, comment_map)
           end
       end
+
+      private
+
+      private_attr_reader :parser, :source
     end
   end
 end

--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -1,6 +1,5 @@
 require 'find'
 require 'pathname'
-require 'private_attr/everywhere'
 
 module Reek
   module Source

--- a/lib/reek/spec/should_reek.rb
+++ b/lib/reek/spec/should_reek.rb
@@ -13,18 +13,23 @@ module Reek
       end
 
       def matches?(actual)
-        @examiner = Examiner.new(actual, configuration: @configuration)
-        @examiner.smelly?
+        self.examiner = Examiner.new(actual, configuration: configuration)
+        examiner.smelly?
       end
 
       def failure_message
-        "Expected #{@examiner.description} to reek, but it didn't"
+        "Expected #{examiner.description} to reek, but it didn't"
       end
 
       def failure_message_when_negated
-        rpt = Report::Formatter.format_list(@examiner.smells)
+        rpt = Report::Formatter.format_list(examiner.smells)
         "Expected no smells, but got:\n#{rpt}"
       end
+
+      private
+
+      private_attr_reader :configuration
+      private_attr_accessor :examiner
     end
   end
 end

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -17,20 +17,23 @@ module Reek
       end
 
       def matches?(actual)
-        @examiner = Examiner.new(actual, configuration: @configuration)
-        @all_smells = @examiner.smells
-        @all_smells.any? { |warning| warning.matches?(@smell_category, @smell_details) }
+        self.examiner = Examiner.new(actual, configuration: configuration)
+        self.all_smells = examiner.smells
+        all_smells.any? { |warning| warning.matches?(smell_category, smell_details) }
       end
 
       def failure_message
-        "Expected #{@examiner.description} to reek of #{@smell_category}, but it didn't"
+        "Expected #{examiner.description} to reek of #{smell_category}, but it didn't"
       end
 
       def failure_message_when_negated
-        "Expected #{@examiner.description} not to reek of #{@smell_category}, but it did"
+        "Expected #{examiner.description} not to reek of #{smell_category}, but it did"
       end
 
       private
+
+      private_attr_reader :configuration, :smell_category, :smell_details
+      private_attr_accessor :all_smells, :examiner
 
       def normalize(smell_category_or_type)
         # In theory, users can give us many different types of input (see the documentation for

--- a/lib/reek/spec/should_reek_only_of.rb
+++ b/lib/reek/spec/should_reek_only_of.rb
@@ -10,24 +10,28 @@ module Reek
     # @api private
     class ShouldReekOnlyOf < ShouldReekOf
       def matches?(actual)
-        matches_examiner?(Examiner.new(actual, configuration: @configuration))
+        matches_examiner?(Examiner.new(actual, configuration: configuration))
       end
 
       def matches_examiner?(examiner)
-        @examiner = examiner
-        @warnings = @examiner.smells
-        return false if @warnings.empty?
-        @warnings.all? { |warning| warning.matches?(@smell_category) }
+        self.examiner = examiner
+        self.warnings = examiner.smells
+        return false if warnings.empty?
+        warnings.all? { |warning| warning.matches?(smell_category) }
       end
 
       def failure_message
-        rpt = Report::Formatter.format_list(@warnings)
-        "Expected #{@examiner.description} to reek only of #{@smell_category}, but got:\n#{rpt}"
+        rpt = Report::Formatter.format_list(warnings)
+        "Expected #{examiner.description} to reek only of #{smell_category}, but got:\n#{rpt}"
       end
 
       def failure_message_when_negated
-        "Expected #{@examiner.description} not to reek only of #{@smell_category}, but it did"
+        "Expected #{examiner.description} not to reek only of #{smell_category}, but it did"
       end
+
+      private
+
+      private_attr_accessor :warnings
     end
   end
 end

--- a/lib/reek/tree_dresser.rb
+++ b/lib/reek/tree_dresser.rb
@@ -25,8 +25,12 @@ module Reek
       type = sexp.type
       children = sexp.children.map { |child| dress(child, comment_map, sexp) }
       comments = comment_map[sexp]
-      @klass_map.klass_for(type).new(type, children,
-                                     location: sexp.loc, comments: comments, parent: parent)
+      klass_map.klass_for(type).new(type, children,
+                                    location: sexp.loc, comments: comments, parent: parent)
     end
+
+    private
+
+    private_attr_reader :klass_map
   end
 end

--- a/lib/reek/tree_walker.rb
+++ b/lib/reek/tree_walker.rb
@@ -24,13 +24,19 @@ module Reek
     end
 
     def walk
-      @result ||= process(@exp)
-      @result.each do |element|
-        @smell_repository.examine(element)
+      result.each do |element|
+        smell_repository.examine(element)
       end
     end
 
     private
+
+    private_attr_accessor :element
+    private_attr_reader :exp, :smell_repository
+
+    def result
+      @result ||= process(exp)
+    end
 
     def process(exp)
       context_processor = "process_#{exp.type}"
@@ -39,7 +45,7 @@ module Reek
       else
         process_default exp
       end
-      @element
+      element
     end
 
     def process_module(exp)
@@ -86,28 +92,28 @@ module Reek
 
     def process_send(exp)
       if visibility_modifier? exp
-        @element.track_visibility(exp.method_name, exp.arg_names)
+        element.track_visibility(exp.method_name, exp.arg_names)
       end
-      @element.record_call_to(exp)
+      element.record_call_to(exp)
       process_default(exp)
     end
 
     def process_attrasgn(exp)
-      @element.record_call_to(exp)
+      element.record_call_to(exp)
       process_default(exp)
     end
 
     alias_method :process_op_asgn, :process_attrasgn
 
     def process_ivar(exp)
-      @element.record_use_of_self
+      element.record_use_of_self
       process_default(exp)
     end
 
     alias_method :process_ivasgn, :process_ivar
 
     def process_self(_)
-      @element.record_use_of_self
+      element.record_use_of_self
     end
 
     alias_method :process_zsuper, :process_self
@@ -123,7 +129,7 @@ module Reek
 
     def process_begin(exp)
       count_statement_list(exp.children)
-      @element.count_statements(-1)
+      element.count_statements(-1)
       process_default(exp)
     end
 
@@ -132,13 +138,13 @@ module Reek
     def process_if(exp)
       count_clause(exp[2])
       count_clause(exp[3])
-      @element.count_statements(-1)
+      element.count_statements(-1)
       process_default(exp)
     end
 
     def process_while(exp)
       count_clause(exp[2])
-      @element.count_statements(-1)
+      element.count_statements(-1)
       process_default(exp)
     end
 
@@ -146,13 +152,13 @@ module Reek
 
     def process_for(exp)
       count_clause(exp[3])
-      @element.count_statements(-1)
+      element.count_statements(-1)
       process_default(exp)
     end
 
     def process_rescue(exp)
       count_clause(exp[1])
-      @element.count_statements(-1)
+      element.count_statements(-1)
       process_default(exp)
     end
 
@@ -163,7 +169,7 @@ module Reek
 
     def process_case(exp)
       count_clause(exp.else_body)
-      @element.count_statements(-1)
+      element.count_statements(-1)
       process_default(exp)
     end
 
@@ -177,16 +183,16 @@ module Reek
     end
 
     def count_clause(sexp)
-      @element.count_statements(1) if sexp
+      element.count_statements(1) if sexp
     end
 
     def count_statement_list(statement_list)
-      @element.count_statements statement_list.length
+      element.count_statements statement_list.length
     end
 
     def inside_new_context(klass, exp)
-      scope = klass.new(@element, exp)
-      @element.append_child_context(scope)
+      scope = klass.new(element, exp)
+      element.append_child_context(scope)
       push(scope) do
         yield
       end
@@ -194,10 +200,10 @@ module Reek
     end
 
     def push(scope)
-      orig = @element
-      @element = scope
+      orig = element
+      self.element = scope
       yield
-      @element = orig
+      self.element = orig
     end
 
     # FIXME: Move to SendNode?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require_relative '../lib/reek'
 require_relative '../lib/reek/spec'
 require_relative '../lib/reek/ast/ast_node_class_map'
 require_relative '../lib/reek/configuration/app_configuration'


### PR DESCRIPTION
This normalises our access to instance variables in `lib` – we only use ivars directly in constructors and for memoization.

A separate PR for cleaning up instance variables in `spec` is forthcoming. :)