### PR TITLE
Check casgn value responds to type

### DIFF
--- a/lib/reek/ast/sexp_extensions.rb
+++ b/lib/reek/ast/sexp_extensions.rb
@@ -405,6 +405,7 @@ module Reek
         MODULE_DEFINERS = [:Class, :Struct]
 
         def defines_module?
+          return false if value.nil?
           call = case value.type
                  when :block
                    value.call
@@ -420,8 +421,18 @@ module Reek
           SexpFormatter.format(children[1])
         end
 
+        # there are two valid forms of the casgn sexp
+        # (casgn <namespace> <name> <value>) and
+        # (casgn <namespace> <name>) used in or-asgn and mlhs
+        #
+        # source = "class Hi; THIS ||= 3; end"
+        # (class
+        #   (const nil :Hi) nil
+        #   (or-asgn
+        #    (casgn nil :THIS)
+        #    (int 3)))
         def value
-          children.last
+          children[2]
         end
       end
 

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -347,3 +347,15 @@ RSpec.describe Reek::AST::SexpExtensions::ModuleNode do
     end
   end
 end
+
+RSpec.describe Reek::AST::SexpExtensions::CasgnNode do
+  context 'with single assignment' do
+    subject do
+      s(:casgn, nil, :Foo)
+    end
+
+    it 'does not define a module' do
+      expect(subject.defines_module?).to eq(false)
+    end
+  end
+end

--- a/spec/reek/tree_walker_spec.rb
+++ b/spec/reek/tree_walker_spec.rb
@@ -95,6 +95,18 @@ RSpec.describe Reek::TreeWalker, 'statement counting' do
       expect(method.num_statements).to eq(6)
     end
 
+    it 'does not count constant assignment with or equals' do
+      source = 'class Hi; CONST ||= 1; end'
+      klass = process_method(source)
+      expect(klass.num_statements).to eq(0)
+    end
+
+    it 'does not count multi constant assignment' do
+      source = 'class Hi; CONST, OTHER_CONST = 1, 2; end'
+      klass = process_method(source)
+      expect(klass.num_statements).to eq(0)
+    end
+
     it 'does not count empty conditional expression' do
       method = process_method('def one() if val == 4; ; end; end')
       expect(method.num_statements).to eq(0)


### PR DESCRIPTION
Seems that the issue is `casgn`'s value did not respond to type when `tree_walker` is trying to decide if it `defines_module?`

since it doesn't respond to type, I think it is safe to say that it does not define a module.