### PR TITLE
Replace the highly misleading "SourceCode#description" with "origin".

### DIFF
--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -40,12 +40,13 @@ module Reek
       run
     end
 
+    # FIXME: Should be named "origin"
     #
     # @return [String] description of the source being analysed
     #
     # @public
     def description
-      @description ||= source.description
+      @description ||= source.origin
     end
 
     #

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -14,17 +14,17 @@ module Reek
       IO_IDENTIFIER     = 'STDIN'
       STRING_IDENTIFIER = 'string'
 
-      attr_reader :description
+      attr_reader :origin
 
       # Initializer.
       #
-      # code        - Ruby code as String
-      # description - 'STDIN', 'string' or a filepath as String
-      # parser      - the parser to use for generating AST's out of the given source
-      def initialize(code, description, parser: Parser::Ruby22)
-        @source      = code
-        @description = description
-        @parser      = parser
+      # code   - Ruby code as String
+      # origin - 'STDIN', 'string' or a filepath as String
+      # parser - the parser to use for generating AST's out of the given source
+      def initialize(code, origin, parser: Parser::Ruby22)
+        @source = code
+        @origin = origin
+        @parser = parser
       end
 
       # Initializes an instance of SourceCode given a source.
@@ -80,9 +80,9 @@ module Reek
         @syntax_tree ||=
           begin
             begin
-              ast, comments = parser.parse_with_comments(source, description)
+              ast, comments = parser.parse_with_comments(source, origin)
             rescue Racc::ParseError, Parser::SyntaxError => error
-              $stderr.puts "#{description}: #{error.class.name}: #{error}"
+              $stderr.puts "#{origin}: #{error.class.name}: #{error}"
             end
 
             # See https://whitequark.github.io/parser/Parser/Source/Comment/Associator.html

--- a/lib/reek/spec/should_reek.rb
+++ b/lib/reek/spec/should_reek.rb
@@ -25,8 +25,6 @@ module Reek
         "Expected no smells, but got:\n#{rpt}"
       end
 
-      private
-
       private_attr_reader :configuration
       private_attr_accessor :examiner
     end


### PR DESCRIPTION
Fixes #604 