### PR TITLE
Todos and fixmes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,10 @@ Metrics/MethodLength:
 Metrics/LineLength:
   Max: 120
 
+# Keyword arguments make long parameter lists readable
+Metrics/ParameterLists:
+  CountKeywordArgs: false
+
 # Indent one level for follow-up lines
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented

--- a/lib/reek/ast/ast_node_class_map.rb
+++ b/lib/reek/ast/ast_node_class_map.rb
@@ -15,6 +15,7 @@ module Reek
       def klass_for(type)
         klass_map[type] ||= Class.new(Node).tap do |klass|
           extension = extension_map[type]
+          # TODO: map node type to constant directly.
           klass.send :include, extension if extension
         end
       end

--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -62,6 +62,7 @@ module Reek
       #   context.each_node(:lvar).any? { |it| it.var_name == 'something' }
       #
       # Returns an array with all matching nodes.
+      # TODO: without a block, this doesn't do what one might expect
       def each_node(target_type, ignoring = [], &blk)
         if block_given?
           look_for_type(target_type, ignoring, &blk)

--- a/lib/reek/context/method_context.rb
+++ b/lib/reek/context/method_context.rb
@@ -9,11 +9,6 @@ module Reek
     class MethodContext < CodeContext
       attr_reader :refs
 
-      def envious_receivers
-        return {} if refs.self_is_max?
-        refs.most_popular
-      end
-
       def references_self?
         exp.depends_on_instance?
       end

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -70,9 +70,9 @@ module Reek
     private_attr_reader :configuration, :collector, :smell_types, :source
 
     def run
-      smell_repository = Smells::SmellRepository.new(source_description: description,
-                                                     smell_types: smell_types,
-                                                     configuration: configuration)
+      smell_repository = Smells::SmellRepository.new(
+        smell_types: smell_types,
+        configuration: configuration.directive_for(description))
       syntax_tree = source.syntax_tree
       TreeWalker.new(smell_repository, syntax_tree).walk if syntax_tree
       smell_repository.report_on(collector)

--- a/lib/reek/report/formatter.rb
+++ b/lib/reek/report/formatter.rb
@@ -39,13 +39,15 @@ module Reek
         "#{location_formatter.format(warning)}#{base_format(warning)}"
       end
 
+      def format_hash(warning)
+        warning.yaml_hash
+      end
+
       private
 
       def base_format(warning)
         "#{warning.context} #{warning.message} (#{warning.smell_type})"
       end
-
-      private
 
       private_attr_reader :location_formatter
     end
@@ -60,11 +62,17 @@ module Reek
 
       def format(warning)
         "#{super} " \
-          "[#{explanatory_link(warning)}.md]"
+          "[#{explanatory_link(warning)}]"
       end
 
+      def format_hash(warning)
+        super(warning).merge('wiki_link' => explanatory_link(warning))
+      end
+
+      private
+
       def explanatory_link(warning)
-        "#{BASE_URL_FOR_HELP_LINK}#{class_name_to_param(warning.smell_type)}"
+        "#{BASE_URL_FOR_HELP_LINK}#{class_name_to_param(warning.smell_type)}.md"
       end
 
       def class_name_to_param(name)

--- a/lib/reek/report/report.rb
+++ b/lib/reek/report/report.rb
@@ -25,6 +25,8 @@ module Reek
         @sort_by_issue_count = sort_by_issue_count
         @total_smell_count   = 0
         @warning_formatter   = warning_formatter
+
+        # TODO: Only used in TextReport and YAMLReport
       end
 
       # Add Examiner to report on. The report will output results for all
@@ -112,8 +114,8 @@ module Reek
     # Displays a list of smells in YAML format
     # YAML with empty array for 0 smells
     class YAMLReport < Base
-      def show
-        print smells.map(&:yaml_hash).to_yaml
+      def show(out = $stdout)
+        out.print smells.map { |smell| warning_formatter.format_hash(smell) }.to_yaml
       end
     end
 
@@ -121,12 +123,8 @@ module Reek
     # Displays a list of smells in JSON format
     # JSON with empty array for 0 smells
     class JSONReport < Base
-      def show
-        print ::JSON.generate(
-          smells.map do |smell|
-            smell.yaml_hash(warning_formatter)
-          end
-        )
+      def show(out = $stdout)
+        out.print ::JSON.generate smells.map { |smell| warning_formatter.format_hash(smell) }
       end
     end
 

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -32,11 +32,11 @@ module Reek
       #
       def examine_context(ctx)
         attributes_in(ctx).map do |attribute, line|
-          SmellWarning.new self,
-                           context: ctx.full_name,
-                           lines: [line],
-                           message: 'is a writable attribute',
-                           parameters: { name: attribute.to_s }
+          smell_warning(
+            context: ctx,
+            lines: [line],
+            message: 'is a writable attribute',
+            parameters: { name: attribute.to_s })
         end
       end
 

--- a/lib/reek/smells/boolean_parameter.rb
+++ b/lib/reek/smells/boolean_parameter.rb
@@ -23,15 +23,15 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def examine_context(method_ctx)
-        method_ctx.default_assignments.select do |_param, value|
+      def examine_context(ctx)
+        ctx.default_assignments.select do |_param, value|
           [:true, :false].include?(value[0])
         end.map do |parameter, _value|
-          SmellWarning.new self,
-                           context: method_ctx.full_name,
-                           lines: [method_ctx.exp.line],
-                           message: "has boolean parameter '#{parameter}'",
-                           parameters: { name: parameter.to_s }
+          smell_warning(
+            context: ctx,
+            lines: [ctx.exp.line],
+            message: "has boolean parameter '#{parameter}'",
+            parameters: { name: parameter.to_s })
         end
       end
     end

--- a/lib/reek/smells/class_variable.rb
+++ b/lib/reek/smells/class_variable.rb
@@ -26,11 +26,11 @@ module Reek
       #
       def examine_context(ctx)
         class_variables_in(ctx.exp).map do |variable, lines|
-          SmellWarning.new self,
-                           context: ctx.full_name,
-                           lines: lines,
-                           message: "declares the class variable #{variable}",
-                           parameters: { name: variable.to_s }
+          smell_warning(
+            context: ctx,
+            lines: lines,
+            message: "declares the class variable #{variable}",
+            parameters: { name: variable.to_s })
         end
       end
 

--- a/lib/reek/smells/control_parameter.rb
+++ b/lib/reek/smells/control_parameter.rb
@@ -55,11 +55,11 @@ module Reek
       #
       def examine_context(ctx)
         ControlParameterCollector.new(ctx).control_parameters.map do |control_parameter|
-          SmellWarning.new self,
-                           context: ctx.full_name,
-                           lines: control_parameter.lines,
-                           message: "is controlled by argument #{control_parameter.name}",
-                           parameters: { name: control_parameter.name.to_s }
+          smell_warning(
+            context: ctx,
+            lines: control_parameter.lines,
+            message: "is controlled by argument #{control_parameter.name}",
+            parameters: { name: control_parameter.name.to_s })
         end
       end
 
@@ -160,7 +160,7 @@ module Reek
         end
 
         def uses_param_in_body?
-          nodes = node.body_nodes([:lvar], [:if, :case, :and, :or])
+          nodes = node.body_nodes([:lvar], CONDITIONAL_NODE_TYPES)
           nodes.any? { |lvar_node| lvar_node.var_name == param }
         end
       end

--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -56,16 +56,16 @@ module Reek
         min_clump_size = value(MIN_CLUMP_SIZE_KEY, ctx, DEFAULT_MIN_CLUMP_SIZE)
         MethodGroup.new(ctx, min_clump_size, max_copies).clumps.map do |clump, methods|
           print_clump = DataClump.print_clump(clump)
-          SmellWarning.new self,
-                           context: ctx.full_name,
-                           lines: methods.map(&:line),
-                           message: "takes parameters #{print_clump} " \
-                                    "to #{methods.length} methods",
-                           parameters: {
-                             parameters: clump.map(&:to_s),
-                             count: methods.length,
-                             methods: methods.map(&:name)
-                           }
+          smell_warning(
+            context: ctx,
+            lines: methods.map(&:line),
+            message: "takes parameters #{print_clump} " \
+                     "to #{methods.length} methods",
+            parameters: {
+              parameters: clump.map(&:to_s),
+              count: methods.length,
+              methods: methods.map(&:name)
+            })
         end
       end
 
@@ -117,20 +117,17 @@ module Reek
   # A method definition and a copy of its parameters
   # @private
   class CandidateMethod
+    extend Forwardable
+
+    def_delegators :defn, :line, :name
+
     def initialize(defn_node)
       @defn = defn_node
     end
 
     def arg_names
+      # TODO: Is all this sorting still needed?
       @arg_names ||= defn.arg_names.compact.sort
-    end
-
-    def line
-      defn.line
-    end
-
-    def name
-      defn.name.to_s # BUG: should report the symbols!
     end
 
     private

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -52,11 +52,11 @@ module Reek
 
         collector = CallCollector.new(ctx, max_allowed_calls, allow_calls)
         collector.smelly_calls.map do |found_call|
-          SmellWarning.new self,
-                           context: ctx.full_name,
-                           lines: found_call.lines,
-                           message: "calls #{found_call.call} #{found_call.occurs} times",
-                           parameters: { name: found_call.call, count: found_call.occurs }
+          smell_warning(
+            context: ctx,
+            lines: found_call.lines,
+            message: "calls #{found_call.call} #{found_call.occurs} times",
+            parameters: { name: found_call.call, count: found_call.occurs })
         end
       end
 

--- a/lib/reek/smells/feature_envy.rb
+++ b/lib/reek/smells/feature_envy.rb
@@ -46,15 +46,23 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def examine_context(method_ctx)
-        return [] unless method_ctx.references_self?
-        method_ctx.envious_receivers.map do |name, refs|
-          SmellWarning.new self,
-                           context: method_ctx.full_name,
-                           lines: refs.map(&:line),
-                           message: "refers to #{name} more than self",
-                           parameters: { name: name.to_s, count: refs.size }
+      def examine_context(ctx)
+        return [] unless ctx.references_self?
+        envious_receivers(ctx).map do |name, refs|
+          smell_warning(
+            context: ctx,
+            lines: refs.map(&:line),
+            message: "refers to #{name} more than self",
+            parameters: { name: name.to_s, count: refs.size })
         end
+      end
+
+      private
+
+      def envious_receivers(ctx)
+        refs = ctx.refs
+        return {} if refs.self_is_max?
+        refs.most_popular
       end
     end
   end

--- a/lib/reek/smells/irresponsible_module.rb
+++ b/lib/reek/smells/irresponsible_module.rb
@@ -22,11 +22,11 @@ module Reek
       def examine_context(ctx)
         return [] if descriptive?(ctx) || ctx.namespace_module?
         expression = ctx.exp
-        [SmellWarning.new(self,
-                          context: ctx.full_name,
-                          lines: [expression.line],
-                          message: 'has no descriptive comment',
-                          parameters: { name: expression.name })]
+        [smell_warning(
+          context: ctx,
+          lines: [expression.line],
+          message: 'has no descriptive comment',
+          parameters: { name: expression.name })]
       end
 
       private

--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -38,11 +38,11 @@ module Reek
         max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, ctx, DEFAULT_MAX_ALLOWED_PARAMS)
         count = ctx.exp.arg_names.length
         return [] if count <= max_allowed_params
-        [SmellWarning.new(self,
-                          context: ctx.full_name,
-                          lines: [ctx.exp.line],
-                          message: "has #{count} parameters",
-                          parameters: { count: count })]
+        [smell_warning(
+          context: ctx,
+          lines: [ctx.exp.line],
+          message: "has #{count} parameters",
+          parameters: { count: count })]
       end
     end
   end

--- a/lib/reek/smells/long_yield_list.rb
+++ b/lib/reek/smells/long_yield_list.rb
@@ -28,19 +28,19 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def examine_context(method_ctx)
+      def examine_context(ctx)
         max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY,
-                                   method_ctx,
+                                   ctx,
                                    DEFAULT_MAX_ALLOWED_PARAMS)
-        method_ctx.local_nodes(:yield).select do |yield_node|
+        ctx.local_nodes(:yield).select do |yield_node|
           yield_node.args.length > max_allowed_params
         end.map do |yield_node|
           count = yield_node.args.length
-          SmellWarning.new self,
-                           context: method_ctx.full_name,
-                           lines: [yield_node.line],
-                           message: "yields #{count} parameters",
-                           parameters: { count: count }
+          smell_warning(
+            context: ctx,
+            lines: [yield_node.line],
+            message: "yields #{count} parameters",
+            parameters: { count: count })
         end
       end
     end

--- a/lib/reek/smells/module_initialize.rb
+++ b/lib/reek/smells/module_initialize.rb
@@ -20,13 +20,14 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def examine_context(module_ctx)
-        module_ctx.local_nodes(:def) do |node| # FIXME: also search for :defs?
+      def examine_context(ctx)
+        ctx.local_nodes(:def) do |node| # FIXME: also search for :defs?
           if node.name.to_s == 'initialize'
             return [
-              SmellWarning.new(self, context: module_ctx.full_name,
-                                     lines:   [module_ctx.exp.line],
-                                     message: 'has initialize method')
+              smell_warning(
+                context: ctx,
+                lines:   [ctx.exp.line],
+                message: 'has initialize method')
             ]
           end
         end

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -37,11 +37,11 @@ module Reek
         exp, depth = *find_deepest_iterator(ctx)
 
         if depth && depth > value(MAX_ALLOWED_NESTING_KEY, ctx, DEFAULT_MAX_ALLOWED_NESTING)
-          [SmellWarning.new(self,
-                            context: ctx.full_name,
-                            lines: [exp.line],
-                            message: "contains iterators nested #{depth} deep",
-                            parameters: { name: ctx.full_name, count: depth })]
+          [smell_warning(
+            context: ctx,
+            lines: [exp.line],
+            message: "contains iterators nested #{depth} deep",
+            parameters: { name: ctx.full_name, count: depth })]
         else
           []
         end

--- a/lib/reek/smells/nil_check.rb
+++ b/lib/reek/smells/nil_check.rb
@@ -19,10 +19,10 @@ module Reek
         smelly_nodes = call_node_finder.smelly_nodes + case_node_finder.smelly_nodes
 
         smelly_nodes.map do |node|
-          SmellWarning.new self,
-                           context: ctx.full_name,
-                           lines: [node.line],
-                           message: 'performs a nil-check'
+          smell_warning(
+            context: ctx,
+            lines: [node.line],
+            message: 'performs a nil-check')
         end
       end
 

--- a/lib/reek/smells/prima_donna_method.rb
+++ b/lib/reek/smells/prima_donna_method.rb
@@ -46,10 +46,10 @@ module Reek
 
         return if version_without_bang
 
-        SmellWarning.new self,
-                         context: ctx.full_name,
-                         lines: [ctx.exp.line],
-                         message: "has prima donna method `#{method_sexp.name}`"
+        smell_warning(
+          context: ctx,
+          lines: [ctx.exp.line],
+          message: "has prima donna method `#{method_sexp.name}`")
       end
     end
   end

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -57,11 +57,11 @@ module Reek
         end.map do |key, lines|
           occurs = lines.length
           expression = key.format_to_ruby
-          SmellWarning.new self,
-                           context: ctx.full_name,
-                           lines: lines,
-                           message: "tests #{expression} at least #{occurs} times",
-                           parameters: { name: expression, count: occurs }
+          smell_warning(
+            context: ctx,
+            lines: lines,
+            message: "tests #{expression} at least #{occurs} times",
+            parameters: { name: expression, count: occurs })
         end
       end
 

--- a/lib/reek/smells/smell_repository.rb
+++ b/lib/reek/smells/smell_repository.rb
@@ -13,44 +13,37 @@ module Reek
         Reek::Smells::SmellDetector.descendants.sort_by(&:name)
       end
 
-      def initialize(source_description: nil,
-                     smell_types: self.class.smell_types,
-                     configuration: Configuration::AppConfiguration.default)
-        @source_via    = source_description
+      def initialize(smell_types: self.class.smell_types,
+                     configuration: {})
         @configuration = configuration
         @smell_types   = smell_types
-
-        configuration.directive_for(source_via).each do |klass, config|
-          configure klass, config
-        end
-      end
-
-      def configure(klass, config)
-        detector = detectors[klass]
-        raise ArgumentError, "Unknown smell type #{klass} found in configuration" unless detector
-        detector.configure_with(config)
       end
 
       def report_on(listener)
         detectors.each_value { |detector| detector.report_on(listener) }
       end
 
-      def examine(scope)
-        smell_listeners[scope.type].each do |detector|
-          detector.examine(scope)
+      def examine(context)
+        smell_listeners[context.type].each do |detector|
+          detector.examine(context)
         end
       end
 
       def detectors
         @initialized_detectors ||= smell_types.map do |klass|
-          { klass => klass.new(source_via) }
+          { klass => klass.new(source_configuration_for(klass)) }
         end.reduce({}, :merge)
       end
 
       private
 
-      private_attr_reader :configuration, :source_via, :smell_types
+      private_attr_reader :configuration, :smell_types
 
+      def source_configuration_for(klass)
+        configuration[klass] || {}
+      end
+
+      # TODO: Make a method smell_detectors_for(scope)
       def smell_listeners
         @smell_listeners ||= Hash.new { |hash, key| hash[key] = [] }.tap do |listeners|
           detectors.each_value { |detector| detector.register(listeners) }

--- a/lib/reek/smells/smell_warning.rb
+++ b/lib/reek/smells/smell_warning.rb
@@ -8,13 +8,15 @@ module Reek
     class SmellWarning
       include Comparable
       extend Forwardable
-      attr_reader :context, :lines, :message, :parameters, :smell_detector
-      def_delegators :smell_detector, :smell_category, :smell_type, :source
+      attr_reader :context, :lines, :message, :parameters, :smell_detector, :source
+      attr_reader :source
+      def_delegators :smell_detector, :smell_category, :smell_type
 
       # FIXME: switch to required kwargs when dropping Ruby 2.0 compatibility
       def initialize(smell_detector, context: '', lines: raise, message: raise,
-                                     parameters: {})
+                                     source: raise, parameters: {})
         @smell_detector = smell_detector
+        @source         = source
         @context        = context.to_s
         @lines          = lines
         @message        = message
@@ -43,11 +45,10 @@ module Reek
         listener.found_smell(self)
       end
 
-      def yaml_hash(warning_formatter = nil)
+      def yaml_hash
         stringified_params = Hash[parameters.map { |key, val| [key.to_s, val] }]
         core_yaml_hash.
-          merge(stringified_params).
-          merge(wiki_link_hash(warning_formatter))
+          merge(stringified_params)
       end
 
       protected
@@ -85,18 +86,10 @@ module Reek
           'context'        => context,
           'lines'          => lines,
           'message'        => message,
-          'smell_category' => smell_detector.smell_category,
-          'smell_type'     => smell_detector.smell_type,
-          'source'         => smell_detector.source
+          'smell_category' => smell_category,
+          'smell_type'     => smell_type,
+          'source'         => source
         }
-      end
-
-      def wiki_link_hash(warning_formatter)
-        if warning_formatter.respond_to?(:explanatory_link)
-          { 'wiki_link' => warning_formatter.explanatory_link(smell_detector) }
-        else
-          {}
-        end
       end
     end
   end

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -42,11 +42,11 @@ module Reek
         max_allowed_ivars = value(MAX_ALLOWED_IVARS_KEY, ctx, DEFAULT_MAX_IVARS)
         count = ctx.local_nodes(:ivasgn).map { |ivasgn| ivasgn[1] }.uniq.length
         return [] if count <= max_allowed_ivars
-        [SmellWarning.new(self,
-                          context: ctx.full_name,
-                          lines: [ctx.exp.line],
-                          message: "has at least #{count} instance variables",
-                          parameters: { count: count })]
+        [smell_warning(
+          context: ctx,
+          lines: [ctx.exp.line],
+          message: "has at least #{count} instance variables",
+          parameters: { count: count })]
       end
     end
   end

--- a/lib/reek/smells/too_many_methods.rb
+++ b/lib/reek/smells/too_many_methods.rb
@@ -42,13 +42,14 @@ module Reek
       #
       def examine_context(ctx)
         max_allowed_methods = value(MAX_ALLOWED_METHODS_KEY, ctx, DEFAULT_MAX_METHODS)
+        # TODO: Only checks instance methods!
         actual = ctx.node_instance_methods.length
         return [] if actual <= max_allowed_methods
-        [SmellWarning.new(self,
-                          context: ctx.full_name,
-                          lines: [ctx.exp.line],
-                          message: "has at least #{actual} methods",
-                          parameters: { count: actual })]
+        [smell_warning(
+          context: ctx,
+          lines: [ctx.exp.line],
+          message: "has at least #{actual} methods",
+          parameters: { count: actual })]
       end
     end
   end

--- a/lib/reek/smells/too_many_statements.rb
+++ b/lib/reek/smells/too_many_statements.rb
@@ -38,11 +38,11 @@ module Reek
                                        DEFAULT_MAX_STATEMENTS)
         count = ctx.num_statements
         return [] if count <= max_allowed_statements
-        [SmellWarning.new(self,
-                          context: ctx.full_name,
-                          lines: [ctx.exp.line],
-                          message: "has approx #{count} statements",
-                          parameters: { count: count })]
+        [smell_warning(
+          context: ctx,
+          lines: [ctx.exp.line],
+          message: "has approx #{count} statements",
+          parameters: { count: count })]
       end
     end
   end

--- a/lib/reek/smells/uncommunicative_method_name.rb
+++ b/lib/reek/smells/uncommunicative_method_name.rb
@@ -54,11 +54,11 @@ module Reek
         var = name.gsub(/^[@\*\&]*/, '')
         return [] if accept_names.include?(var)
         return [] unless reject_names.find { |patt| patt =~ var }
-        [SmellWarning.new(self,
-                          context: ctx.full_name,
-                          lines: [ctx.exp.line],
-                          message: "has the name '#{name}'",
-                          parameters: { name: name })]
+        [smell_warning(
+          context: ctx,
+          lines: [ctx.exp.line],
+          message: "has the name '#{name}'",
+          parameters: { name: name })]
       end
     end
   end

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -55,17 +55,16 @@ module Reek
         reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
         accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
         exp = ctx.exp
-        full_name = ctx.full_name
         name = exp.simple_name.to_s
-        return [] if accept_names.include?(full_name)
+        return [] if accept_names.include?(ctx.full_name)
         var = name.gsub(/^[@\*\&]*/, '')
         return [] if accept_names.include?(var)
         return [] unless reject_names.find { |patt| patt =~ var }
-        [SmellWarning.new(self,
-                          context: full_name,
-                          lines: [exp.line],
-                          message: "has the name '#{name}'",
-                          parameters: { name: name })]
+        [smell_warning(
+          context: ctx,
+          lines: [exp.line],
+          message: "has the name '#{name}'",
+          parameters: { name: name })]
       end
     end
   end

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -53,11 +53,11 @@ module Reek
         context_expression.parameter_names.select do |name|
           bad_name?(name) && ctx.uses_param?(name)
         end.map do |name|
-          SmellWarning.new(self,
-                           context: ctx.full_name,
-                           lines: [context_expression.line],
-                           message: "has the parameter name '#{name}'",
-                           parameters: { name: name.to_s })
+          smell_warning(
+            context: ctx,
+            lines: [context_expression.line],
+            message: "has the parameter name '#{name}'",
+            parameters: { name: name.to_s })
         end
       end
 

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -56,11 +56,11 @@ module Reek
         variable_names(ctx.exp).select do |name, _lines|
           bad_name?(name, ctx)
         end.map do |name, lines|
-          SmellWarning.new(self,
-                           context: ctx.full_name,
-                           lines: lines,
-                           message: "has the variable name '#{name}'",
-                           parameters: { name: name.to_s })
+          smell_warning(
+            context: ctx,
+            lines: lines,
+            message: "has the variable name '#{name}'",
+            parameters: { name: name.to_s })
         end
       end
 

--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -18,14 +18,14 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def examine_context(method_ctx)
-        return [] if method_ctx.uses_super_with_implicit_arguments?
-        method_ctx.unused_params.map do |param|
-          SmellWarning.new(self,
-                           context: method_ctx.full_name,
-                           lines: [method_ctx.exp.line],
-                           message: "has unused parameter '#{param.name}'",
-                           parameters: { name: param.name.to_s })
+      def examine_context(ctx)
+        return [] if ctx.uses_super_with_implicit_arguments?
+        ctx.unused_params.map do |param|
+          smell_warning(
+            context: ctx,
+            lines: [ctx.exp.line],
+            message: "has unused parameter '#{param.name}'",
+            parameters: { name: param.name.to_s })
         end
       end
     end

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -53,17 +53,17 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def examine_context(method_ctx)
-        return [] if method_ctx.singleton_method?
-        return [] if method_ctx.num_statements == 0
-        return [] if method_ctx.references_self?
-        return [] if num_helper_methods(method_ctx).zero?
+      def examine_context(ctx)
+        return [] if ctx.singleton_method?
+        return [] if ctx.num_statements == 0
+        return [] if ctx.references_self?
+        return [] if num_helper_methods(ctx).zero?
 
-        [SmellWarning.new(self,
-                          context: method_ctx.full_name,
-                          lines: [method_ctx.exp.line],
-                          message: "doesn't depend on instance state",
-                          parameters: { name: method_ctx.full_name })]
+        [smell_warning(
+          context: ctx,
+          lines: [ctx.exp.line],
+          message: "doesn't depend on instance state",
+          parameters: { name: ctx.full_name })]
       end
 
       private

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -3,15 +3,23 @@ require_relative '../../lib/reek/smells/smell_detector'
 require_relative '../../lib/reek/smells/smell_warning'
 
 FactoryGirl.define do
+  factory :context, class: Reek::Context::CodeContext do
+    skip_create
+
+    initialize_with do
+      new(nil, nil)
+    end
+  end
+
   factory :smell_detector, class: Reek::Smells::SmellDetector do
     skip_create
     transient do
       smell_type 'FeatureEnvy'
+      source 'foo'
     end
-    source 'dummy_file'
 
     initialize_with do
-      ::Reek::Smells.const_get(smell_type).new(source)
+      ::Reek::Smells.const_get(smell_type).new
     end
   end
 
@@ -19,15 +27,18 @@ FactoryGirl.define do
     skip_create
     smell_detector
     context 'self'
+    source 'dummy_file'
     lines [42]
     message 'smell warning message'
     parameters { {} }
 
     initialize_with do
-      new(smell_detector, context: context,
-                          lines: lines,
-                          message: message,
-                          parameters: parameters)
+      new(smell_detector,
+          source: source,
+          context: context,
+          lines: lines,
+          message: message,
+          parameters: parameters)
     end
   end
 end

--- a/spec/reek/cli/warning_collector_spec.rb
+++ b/spec/reek/cli/warning_collector_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe Reek::CLI::WarningCollector do
 
   context 'with one warning' do
     it 'reports that warning' do
-      warning = Reek::Smells::SmellWarning.new(Reek::Smells::FeatureEnvy.new(''),
-                                               context: 'fred',
+      warning = Reek::Smells::SmellWarning.new(Reek::Smells::FeatureEnvy.new,
+                                               source:  'string',
+                                               context: 'foo',
                                                lines:   [1, 2, 3],
                                                message: 'hello')
       collector.found_smell(warning)

--- a/spec/reek/context/method_context_spec.rb
+++ b/spec/reek/context/method_context_spec.rb
@@ -22,32 +22,6 @@ RSpec.describe Reek::Context::MethodContext do
     end
   end
 
-  describe '#envious_receivers' do
-    let(:exp) { sexp(:def, :foo, sexp(:args, sexp(:arg, :bar)), nil) }
-
-    it 'should ignore ivars as refs to self' do
-      method_context.record_call_to sexp(:send, sexp(:ivar, :@cow), :feed_to)
-      expect(method_context.envious_receivers).to be_empty
-    end
-
-    it 'should ignore explicit calls to self' do
-      method_context.refs.record_reference_to :other
-      method_context.record_call_to sexp(:send, sexp(:self), :thing)
-      expect(method_context.envious_receivers).to be_empty
-    end
-
-    it 'should ignore implicit calls to self' do
-      method_context.record_call_to sexp(:send, sexp(:lvar, :text), :each, sexp(:arglist))
-      method_context.record_call_to sexp(:send, nil, :shelve, sexp(:arglist))
-      expect(method_context.envious_receivers).to be_empty
-    end
-
-    it 'should record envious calls' do
-      method_context.record_call_to sexp(:send, sexp(:lvar, :bar), :baz)
-      expect(method_context.envious_receivers).to include(:bar)
-    end
-  end
-
   describe '#default_assignments' do
     def assignments_from(src)
       exp = Reek::Source::SourceCode.from(src).syntax_tree

--- a/spec/reek/report/json_report_spec.rb
+++ b/spec/reek/report/json_report_spec.rb
@@ -3,18 +3,95 @@ require_relative '../../../lib/reek/examiner'
 require_relative '../../../lib/reek/report/report'
 require_relative '../../../lib/reek/report/formatter'
 
+require 'json'
+require 'stringio'
+
 RSpec.describe Reek::Report::JSONReport do
-  let(:instance) { Reek::Report::JSONReport.new }
+  let(:options) { {} }
+  let(:instance) { Reek::Report::JSONReport.new(options) }
+  let(:examiner) { Reek::Examiner.new(source) }
 
-  context 'empty source' do
-    let(:examiner) { Reek::Examiner.new('') }
+  before do
+    instance.add_examiner examiner
+  end
 
-    before do
-      instance.add_examiner examiner
-    end
+  context 'with empty source' do
+    let(:source) { '' }
 
     it 'prints empty json' do
       expect { instance.show }.to output(/^\[\]$/).to_stdout
+    end
+  end
+
+  context 'with smelly source' do
+    let(:source) { 'def simple(a) a[3] end' }
+
+    it 'prints smells as json' do
+      out = StringIO.new
+      instance.show(out)
+      out.rewind
+      result = JSON.parse(out.read)
+      expected = JSON.parse <<-EOS
+        [
+          {
+            "context":        "simple",
+            "lines":          [1],
+            "message":        "doesn't depend on instance state",
+            "smell_category": "LowCohesion",
+            "smell_type":     "UtilityFunction",
+            "source":         "string",
+            "name":           "simple"
+          },
+          {
+            "context":        "simple",
+            "lines":          [1],
+            "message":        "has the parameter name 'a'",
+            "smell_category": "UncommunicativeName",
+            "smell_type":     "UncommunicativeParameterName",
+            "source":         "string",
+            "name":           "a"
+          }
+        ]
+      EOS
+
+      expect(result).to eq expected
+    end
+
+    context 'with link formatter' do
+      let(:options) { { warning_formatter: Reek::Report::WikiLinkWarningFormatter.new } }
+
+      it 'prints documentation links' do
+        out = StringIO.new
+        instance.show(out)
+        out.rewind
+        result = JSON.parse(out.read)
+        expected = JSON.parse <<-EOS
+          [
+            {
+              "context":        "simple",
+              "lines":          [1],
+              "message":        "doesn't depend on instance state",
+              "smell_category": "LowCohesion",
+              "smell_type":     "UtilityFunction",
+              "source":         "string",
+              "name":           "simple",
+              "wiki_link":      "https://github.com/troessner/reek/blob/master/docs/Utility-Function.md"
+            },
+            {
+              "context":        "simple",
+              "lines":          [1],
+              "message":        "has the parameter name 'a'",
+              "smell_category": "UncommunicativeName",
+              "smell_type":     "UncommunicativeParameterName",
+              "source":         "string",
+              "name":           "a",
+              "wiki_link":      "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md"
+            }
+          ]
+        EOS
+
+        expect(result).to eq expected
+      end
     end
   end
 end

--- a/spec/reek/report/yaml_report_spec.rb
+++ b/spec/reek/report/yaml_report_spec.rb
@@ -3,18 +3,88 @@ require_relative '../../../lib/reek/examiner'
 require_relative '../../../lib/reek/report/report'
 require_relative '../../../lib/reek/report/formatter'
 
+require 'yaml'
+require 'stringio'
+
 RSpec.describe Reek::Report::YAMLReport do
-  let(:instance) { Reek::Report::YAMLReport.new }
+  let(:options) { {} }
+  let(:instance) { Reek::Report::YAMLReport.new(options) }
+  let(:examiner) { Reek::Examiner.new(source) }
 
-  context 'empty source' do
-    let(:examiner) { Reek::Examiner.new('') }
+  before do
+    instance.add_examiner examiner
+  end
 
-    before do
-      instance.add_examiner examiner
-    end
+  context 'with empty source' do
+    let(:source) { '' }
 
     it 'prints empty yaml' do
       expect { instance.show }.to output(/^--- \[\]\n.*$/).to_stdout
+    end
+  end
+
+  context 'with smelly source' do
+    let(:source) { 'def simple(a) a[3] end' }
+
+    it 'prints smells as yaml' do
+      out = StringIO.new
+      instance.show(out)
+      out.rewind
+      result = YAML.load(out.read)
+      expected = YAML.load <<-EOS
+---
+- context:        "simple"
+  lines:
+  - 1
+  message:        "doesn't depend on instance state"
+  smell_category: "LowCohesion"
+  smell_type:     "UtilityFunction"
+  source:         "string"
+  name:           "simple"
+- context:        "simple"
+  lines:
+  - 1
+  message:        "has the parameter name 'a'"
+  smell_category: "UncommunicativeName"
+  smell_type:     "UncommunicativeParameterName"
+  source:         "string"
+  name:           "a"
+      EOS
+
+      expect(result).to eq expected
+    end
+    context 'with link formatter' do
+      let(:options) { { warning_formatter: Reek::Report::WikiLinkWarningFormatter.new } }
+
+      it 'prints documentation links' do
+        out = StringIO.new
+        instance.show(out)
+        out.rewind
+        result = YAML.load(out.read)
+        expected = YAML.load <<-EOS
+---
+- context:        "simple"
+  lines:
+  - 1
+  message:        "doesn't depend on instance state"
+  smell_category: "LowCohesion"
+  smell_type:     "UtilityFunction"
+  source:         "string"
+  name:           "simple"
+  wiki_link:      "https://github.com/troessner/reek/blob/master/docs/Utility-Function.md"
+- context:        "simple"
+  lines:
+  - 1
+  message:        "has the parameter name 'a'"
+  smell_category: "UncommunicativeName"
+  smell_type:     "UncommunicativeParameterName"
+  source:         "string"
+  name:           "a"
+  wiki_link:      "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md"
+        EOS
+
+        expect(result).to eq expected
+      end
     end
   end
 end

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -4,7 +4,7 @@ require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::Attribute do
   let(:detector) { build(:smell_detector, smell_type: :Attribute, source: source_name) }
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'source' }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/boolean_parameter_spec.rb
+++ b/spec/reek/smells/boolean_parameter_spec.rb
@@ -67,15 +67,14 @@ RSpec.describe Reek::Smells::BooleanParameter do
 
   context 'when a smell is reported' do
     let(:detector) { build(:smell_detector, smell_type: :BooleanParameter, source: source_name) }
-    let(:source_name) { 'dummy_source' }
+    let(:source_name) { 'string' }
 
     it_should_behave_like 'SmellDetector'
 
     it 'reports the fields correctly' do
       src = 'def cc(arga = true) end'
       ctx = Reek::Context::MethodContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      detector.examine(ctx)
-      smells = detector.smells_found.to_a
+      smells = detector.examine_context(ctx)
       expect(smells.length).to eq(1)
       expect(smells[0].smell_category).to eq(described_class.smell_category)
       expect(smells[0].parameters[:name]).to eq('arga')

--- a/spec/reek/smells/class_variable_spec.rb
+++ b/spec/reek/smells/class_variable_spec.rb
@@ -6,7 +6,7 @@ require_relative 'smell_detector_shared'
 RSpec.describe Reek::Smells::ClassVariable do
   let(:class_variable) { '@@things' }
   let(:detector) { build(:smell_detector, smell_type: :ClassVariable, source: source_name) }
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'string' }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/control_parameter_spec.rb
+++ b/spec/reek/smells/control_parameter_spec.rb
@@ -4,7 +4,7 @@ require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::ControlParameter do
   let(:detector) { build(:smell_detector, smell_type: :ControlParameter, source: source_name) }
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'string' }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/data_clump_spec.rb
+++ b/spec/reek/smells/data_clump_spec.rb
@@ -42,7 +42,7 @@ RSpec.shared_examples_for 'a data clump detector' do
     end
 
     it 'reports all methods' do
-      expect(smells[0].parameters[:methods]).to eq(['first', 'second', 'third'])
+      expect(smells[0].parameters[:methods]).to eq([:first, :second, :third])
     end
 
     it 'reports the declaration line numbers' do

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -7,7 +7,7 @@ require_relative 'smell_detector_shared'
 RSpec.describe Reek::Smells::DuplicateMethodCall do
   context 'when a smell is reported' do
     let(:detector) { build(:smell_detector, smell_type: :DuplicateMethodCall, source: source_name) }
-    let(:source_name) { 'dummy_source' }
+    let(:source_name) { 'string' }
 
     let(:warning) do
       src = <<-EOS

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -3,6 +3,7 @@ require_relative '../../../lib/reek/smells/feature_envy'
 require_relative '../../../lib/reek/examiner'
 require_relative 'smell_detector_shared'
 
+# TODO: Bring specs in line with specs for other detectors
 RSpec.describe Reek::Smells::FeatureEnvy do
   context 'with no smell' do
     it 'should not report use of self' do

--- a/spec/reek/smells/irresponsible_module_spec.rb
+++ b/spec/reek/smells/irresponsible_module_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
 
   context 'when a smell is reported' do
     let(:detector) { build(:smell_detector, smell_type: :IrresponsibleModule, source: source_name) }
-    let(:source_name) { 'dummy_source' }
+    let(:source_name) { 'string' }
 
     it_should_behave_like 'SmellDetector'
   end

--- a/spec/reek/smells/long_parameter_list_spec.rb
+++ b/spec/reek/smells/long_parameter_list_spec.rb
@@ -75,7 +75,7 @@ end
 
 RSpec.describe Reek::Smells::LongParameterList do
   let(:detector) { build(:smell_detector, smell_type: :LongParameterList, source: source_name) }
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'string' }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/long_yield_list_spec.rb
+++ b/spec/reek/smells/long_yield_list_spec.rb
@@ -5,7 +5,7 @@ require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::LongYieldList do
   let(:detector) { build(:smell_detector, smell_type: :LongYieldList, source: source_name) }
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'string' }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -213,7 +213,7 @@ end
 
 RSpec.describe Reek::Smells::NestedIterators do
   let(:detector) { build(:smell_detector, smell_type: :NestedIterators, source: source_name) }
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'string' }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/repeated_conditional_spec.rb
+++ b/spec/reek/smells/repeated_conditional_spec.rb
@@ -6,7 +6,7 @@ require_relative '../../../lib/reek/source/source_code'
 
 RSpec.describe Reek::Smells::RepeatedConditional do
   let(:detector) { build(:smell_detector, smell_type: :RepeatedConditional, source: source_name) }
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'string' }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/smell_detector_shared.rb
+++ b/spec/reek/smells/smell_detector_shared.rb
@@ -1,5 +1,4 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/smell_configuration'
 
 RSpec.shared_examples_for 'SmellDetector' do
   context 'exception matching follows the context' do
@@ -15,14 +14,6 @@ RSpec.shared_examples_for 'SmellDetector' do
     it 'when true' do
       expect(ctx).to receive(:matches?).at_least(:once).and_return(true)
       expect(detector.exception?(ctx)).to eq(true)
-    end
-  end
-
-  context 'configuration' do
-    it 'becomes disabled when disabled' do
-      enabled_key = Reek::Smells::SmellConfiguration::ENABLED_KEY
-      detector.configure_with(enabled_key => false)
-      expect(detector).not_to be_enabled
     end
   end
 end

--- a/spec/reek/smells/smell_repository_spec.rb
+++ b/spec/reek/smells/smell_repository_spec.rb
@@ -18,12 +18,5 @@ RSpec.describe Reek::Smells::SmellRepository do
     it 'should return the smell types in alphabetic order' do
       expect(smell_types).to eq(smell_types.sort_by(&:name))
     end
-
-    it "should raise an ArgumentError if smell to configure doesn't exist" do
-      repository = described_class.new
-      expect { repository.configure('SomethingNonExistant', {}) }.
-        to raise_error ArgumentError,
-                       'Unknown smell type SomethingNonExistant found in configuration'
-    end
   end
 end

--- a/spec/reek/smells/smell_warning_spec.rb
+++ b/spec/reek/smells/smell_warning_spec.rb
@@ -108,12 +108,13 @@ RSpec.describe Reek::Smells::SmellWarning do
     end
 
     context 'with all details specified' do
-      let(:detector) { Reek::Smells::FeatureEnvy.new source }
+      let(:detector) { Reek::Smells::FeatureEnvy.new }
       let(:parameters) { { 'one' => 34, 'two' => 'second' } }
       let(:smell_type) { 'FeatureEnvy' }
       let(:source) { 'a/ruby/source/file.rb' }
       let(:yaml) do
-        warning = Reek::Smells::SmellWarning.new(detector, context: context_name,
+        warning = Reek::Smells::SmellWarning.new(detector, source: source,
+                                                           context: context_name,
                                                            lines: lines,
                                                            message: message,
                                                            parameters: parameters)

--- a/spec/reek/smells/too_many_instance_variables_spec.rb
+++ b/spec/reek/smells/too_many_instance_variables_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../../lib/reek/smells/too_many_instance_variables'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::TooManyInstanceVariables do
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'string' }
   let(:detector) do
     build(:smell_detector, smell_type: :TooManyInstanceVariables, source: source_name)
   end

--- a/spec/reek/smells/too_many_methods_spec.rb
+++ b/spec/reek/smells/too_many_methods_spec.rb
@@ -3,10 +3,8 @@ require_relative '../../../lib/reek/smells/too_many_methods'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::TooManyMethods do
-  let(:detector) { described_class.new(source_name) }
-  let(:source_name) { 'dummy_name' }
-
-  before(:each) { detector.configure_with 'max_methods' => 2 }
+  let(:detector) { described_class.new('max_methods' => 2) }
+  let(:source_name) { 'string' }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/uncommunicative_method_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_method_name_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../../lib/reek/smells/uncommunicative_method_name'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::UncommunicativeMethodName do
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'string' }
   let(:detector) do
     build(:smell_detector, smell_type: :UncommunicativeMethodName, source: source_name)
   end

--- a/spec/reek/smells/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_module_name_spec.rb
@@ -4,7 +4,7 @@ require_relative 'smell_detector_shared'
 require_relative '../../../lib/reek/context/code_context'
 
 RSpec.describe Reek::Smells::UncommunicativeModuleName do
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'string' }
   let(:detector) do
     build(:smell_detector, smell_type: :UncommunicativeModuleName, source: source_name)
   end

--- a/spec/reek/smells/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_parameter_name_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Reek::Smells::UncommunicativeParameterName do
   let(:detector) do
     build(:smell_detector, smell_type: :UncommunicativeParameterName, source: source_name)
   end
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'string' }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_variable_name_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../../lib/reek/smells/uncommunicative_variable_name'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::UncommunicativeVariableName do
-  let(:source_name) { 'dummy_source' }
+  let(:source_name) { 'string' }
   let(:detector) do
     build(:smell_detector, smell_type: :UncommunicativeVariableName, source: source_name)
   end

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -3,6 +3,7 @@ require_relative '../../../lib/reek/smells/utility_function'
 require_relative '../../../lib/reek/examiner'
 require_relative 'smell_detector_shared'
 
+# TODO: Bring specs in line with specs for other detectors
 RSpec.describe Reek::Smells::UtilityFunction do
   describe 'a detector' do
     let(:detector) { build(:smell_detector, smell_type: :UtilityFunction, source: source_name) }


### PR DESCRIPTION
This is a branch where I collected some nits I wanted to pick, but it got out of hand and now contains a breaking change that should go into Reek 4.

Highlights:
* Makes smell detectors not depend on the source to examine. They just get passed contexts, which could be all from the same source, or from different sources.
* Uses the parse result to fetch the source name. No more passing description/origin/target :smile:.
* Fully configure smell detectors on initialization, instead of using `#configure_with`.
* More FIXMEs fixed (and some added).

See #650 and #648.