### PR TITLE
Ensure full psych is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+* (mvz) Ensure all YAML methods are loaded (workaround for #653)
+
 ## 3.2.1 (2015-08-17)
 
-* Revert 864f0a9 to hotfix issues/642
+* (troessner) Revert 864f0a9 to hotfix #642
 
 ## 3.2.0 (2015-08-17)
 

--- a/lib/reek/code_comment.rb
+++ b/lib/reek/code_comment.rb
@@ -1,5 +1,8 @@
 require 'yaml'
 
+# NOTE: Work-around for https://github.com/tenderlove/psych/issues/223
+require 'psych.rb' if Object.const_defined?(:Psych)
+
 module Reek
   #
   # A comment header from an abstract syntax tree; found directly above


### PR DESCRIPTION
This is a workaround for #653 until https://github.com/tenderlove/psych/issues/223 is fixed.

I think we should release this as `3.2.2`, so I created a `stable-3.2` branch to handle this.