### PR TITLE
Use of StringIO requires stringio

### DIFF
--- a/lib/reek/cli/silencer.rb
+++ b/lib/reek/cli/silencer.rb
@@ -1,3 +1,5 @@
+require 'stringio'
+
 module Reek
   module CLI
     # CLI silencer


### PR DESCRIPTION
This doesn't show up in our tests. Perhaps because of bundler.