### PR TITLE
Ensure each file can be individually required

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require 'bundler/gem_tasks'
-require 'private_attr/everywhere'
 require 'rake/clean'
 
 Dir['tasks/**/*.rake'].each { |t| load t }

--- a/lib/reek.rb
+++ b/lib/reek.rb
@@ -1,7 +1,6 @@
 #
 # Reek's core functionality
 #
-require 'private_attr/everywhere'
 require_relative 'reek/version'
 require_relative 'reek/examiner'
 require_relative 'reek/report/report'

--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -1,3 +1,4 @@
+require 'private_attr/everywhere'
 require_relative '../cli/silencer'
 
 Reek::CLI::Silencer.silently stderr: true, stdout: true do

--- a/lib/reek/ast/object_refs.rb
+++ b/lib/reek/ast/object_refs.rb
@@ -1,3 +1,5 @@
+require 'private_attr/everywhere'
+
 module Reek
   # @api private
   module AST

--- a/lib/reek/ast/reference_collector.rb
+++ b/lib/reek/ast/reference_collector.rb
@@ -1,3 +1,5 @@
+require 'private_attr/everywhere'
+
 module Reek
   module AST
     #

--- a/lib/reek/cli/command.rb
+++ b/lib/reek/cli/command.rb
@@ -1,3 +1,5 @@
+require 'private_attr/everywhere'
+
 module Reek
   module CLI
     #

--- a/lib/reek/cli/warning_collector.rb
+++ b/lib/reek/cli/warning_collector.rb
@@ -1,3 +1,4 @@
+require 'private_attr/everywhere'
 require 'set'
 
 module Reek

--- a/lib/reek/code_comment.rb
+++ b/lib/reek/code_comment.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'private_attr/everywhere'
 
 module Reek
   #

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'private_attr/everywhere'
 require_relative './configuration_file_finder'
 require_relative './configuration_validator'
 require_relative './default_directive'

--- a/lib/reek/report/formatter.rb
+++ b/lib/reek/report/formatter.rb
@@ -1,3 +1,4 @@
+require 'private_attr/everywhere'
 require_relative 'location_formatter'
 
 module Reek

--- a/lib/reek/smells/smell_configuration.rb
+++ b/lib/reek/smells/smell_configuration.rb
@@ -1,3 +1,5 @@
+require 'private_attr/everywhere'
+
 module Reek
   module Smells
     #

--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -1,3 +1,4 @@
+require 'private_attr/everywhere'
 require 'find'
 require 'pathname'
 

--- a/lib/reek/spec/should_reek_only_of.rb
+++ b/lib/reek/spec/should_reek_only_of.rb
@@ -1,5 +1,6 @@
 require_relative '../examiner'
 require_relative '../report/formatter'
+require_relative 'should_reek_of'
 
 module Reek
   module Spec


### PR DESCRIPTION
We've always been careful to ensure each file `require`s its own requirements, but with `private_attr` we've failed to do so. This makes it hard to require individual reek files if needed.

This PR makes sure that for every file in reek's lib, `ruby -e "require '<file>'"` works. 