### PR TITLE
Increase rubocop's line length limit.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,9 +14,9 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Max: 15
 
-# Be a little more lenient with line length
+# Be rather lenient with line length
 Metrics/LineLength:
-  Max: 100
+  Max: 120
 
 # Indent one level for follow-up lines
 Style/MultilineOperationIndentation:


### PR DESCRIPTION
I'm sorry, but 100 characters max is driving me CRAZY.
Can we please use 120, pretty please? 