### PR TITLE
Attribute no longer disabled by default

### DIFF
--- a/docs/Code-Smells.md
+++ b/docs/Code-Smells.md
@@ -4,7 +4,7 @@ Smells are indicators of where your code might be hard to read, maintain or evol
 
 Reek currently includes checks for the following smells:
 
-* [Attribute](Attribute.md) (disabled by default)
+* [Attribute](Attribute.md)
 * [Class Variable](Class-Variable.md)
 * [Control Couple](Control-Couple.md), including
   * [Boolean Parameter](Boolean-Parameter.md)


### PR DESCRIPTION
I noticed that as of the latest gem that Attribute is no longer disabled by default so thought it a good idea to submit a pull request to update the docs - apologies in advance if this is not the correct procedure to adjust the docs