### PR TITLE
Ignore `Object#tap` for NestedIterators.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* (troessner) Ignore `Object#tap` for NestedIterators
 * (mvz) Ensure all YAML methods are loaded (workaround for #653)
 
 ## 3.3.0 (2015-08-23)

--- a/config/defaults.reek
+++ b/config/defaults.reek
@@ -45,7 +45,8 @@ NestedIterators:
   enabled: true
   exclude: []
   max_allowed_nesting: 1
-  ignore_iterators: []
+  ignore_iterators:
+  - tap
 NilCheck:
   enabled: true
   exclude: []

--- a/docs/Nested-Iterators.md
+++ b/docs/Nested-Iterators.md
@@ -32,6 +32,7 @@ test.rb -- 1 warning:
 ## Current Support in Reek
 
 Nested Iterators reports failing methods only once.
+`Object#tap` is ignored by default and thus does not count as iterator.
 
 ## Configuration
 

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -19,7 +19,7 @@ module Reek
       # The name of the config field that sets the names of any
       # methods for which nesting should not be considered
       IGNORE_ITERATORS_KEY = 'ignore_iterators'
-      DEFAULT_IGNORE_ITERATORS = []
+      DEFAULT_IGNORE_ITERATORS = ['tap']
 
       def self.default_config
         super.merge(

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe Reek::Smells::NestedIterators do
     expect(src).to reek_of(:NestedIterators)
   end
 
+  it 'should not report nested iterators for Object#tap' do
+    src = 'def do_stuff(*params); [].tap {|list| params.map {|param| list << (param + param)} } end'
+    expect(src).not_to reek_of(:NestedIterators)
+  end
+
   it 'should not report method with successive iterators' do
     src = <<-EOS
       def bad(fred)


### PR DESCRIPTION
Fixes #676 