### PR TITLE
Refactor UncommunicativeMethodName.

### DIFF
--- a/config/defaults.reek
+++ b/config/defaults.reek
@@ -85,7 +85,7 @@ UncommunicativeModuleName:
   - !ruby/regexp /^.$/
   - !ruby/regexp /[0-9]$/
   accept:
-  - Inline::C
+  - !ruby/regexp /Inline::C/
 UncommunicativeParameterName:
   enabled: true
   exclude: []

--- a/lib/reek/smells/smell_configuration.rb
+++ b/lib/reek/smells/smell_configuration.rb
@@ -22,10 +22,6 @@ module Reek
         options.merge!(new_options)
       end
 
-      #
-      # Is this smell detector active?
-      #--
-      #  SMELL: Getter
       def enabled?
         options[ENABLED_KEY]
       end

--- a/spec/reek/smells/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_module_name_spec.rb
@@ -40,11 +40,27 @@ RSpec.describe Reek::Smells::UncommunicativeModuleName do
     end
   end
 
-  context 'accepting names' do
-    it 'accepts Inline::C' do
+  context 'accept patterns' do
+    let(:configuration) do
+      default_directive_for_smell = {
+        UncommunicativeModuleName: {
+          accept: [/Inline::C/]
+        }
+      }
+      Reek::Configuration::AppConfiguration.from_map(default_directive_for_smell)
+    end
+
+    it 'make smelly name pass' do
       src = 'module Inline::C; end'
-      ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      expect(detector.examine_context(ctx)).to be_empty
+
+      expect(src).to_not reek_of(described_class, {}, configuration)
+    end
+
+
+    it 'reports names with typos' do
+      src = 'module Inline::K; end'
+
+      expect(src).to reek_of(described_class, {}, configuration)
     end
   end
 


### PR DESCRIPTION
Sooooo. On my quest to make reek smell-free I stumbled across UncommunicativeMethodName and decided to refactor it. 

I believe the implementation is now significantly clearer, simpler and more expressive since I introduced regexes for the "accept" pattern as well, which means #687 will be trivial to implement.