### PR TITLE
Fix or suppress all smells.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,4 @@ Dir['tasks/**/*.rake'].each { |t| load t }
 
 task default: :test
 task default: :rubocop unless RUBY_ENGINE == 'rbx'
+task default: 'test:quality'

--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -1,7 +1,7 @@
 require 'private_attr/everywhere'
 require_relative '../cli/silencer'
 
-Reek::CLI::Silencer.silently stderr: true, stdout: true do
+Reek::CLI::Silencer.silently do
   require 'parser'
 end
 

--- a/lib/reek/ast/sexp_formatter.rb
+++ b/lib/reek/ast/sexp_formatter.rb
@@ -1,6 +1,6 @@
 require_relative '../cli/silencer'
 
-Reek::CLI::Silencer.silently stderr: true, stdout: true do
+Reek::CLI::Silencer.silently do
   require 'unparser'
 end
 

--- a/lib/reek/cli/input.rb
+++ b/lib/reek/cli/input.rb
@@ -20,6 +20,7 @@ module Reek
 
       private
 
+      # :reek:UtilityFunction
       def input_was_piped?
         !$stdin.tty?
       end
@@ -30,6 +31,7 @@ module Reek
         argv.empty?
       end
 
+      # :reek:UtilityFunction
       def working_directory_as_source
         Source::SourceLocator.new(['.']).sources
       end

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -32,6 +32,7 @@ module Reek
 
       private_attr_reader :argv, :options, :parser
 
+      # :reek:UtilityFunction
       def color_support?
         $stdout.tty?
       end
@@ -71,6 +72,7 @@ module Reek
         end
       end
 
+      # :reek:TooManyStatements: { max_statements: 6 }
       def set_configuration_options
         parser.separator 'Configuration:'
         parser.on('-c', '--config FILE', 'Read configuration options from FILE') do |file|
@@ -127,6 +129,7 @@ module Reek
         end
       end
 
+      # :reek:TooManyStatements: { max_statements: 7 }
       def set_utility_options
         parser.separator "\nUtility options:"
         parser.on_tail('-h', '--help', 'Show this message') do

--- a/lib/reek/cli/silencer.rb
+++ b/lib/reek/cli/silencer.rb
@@ -6,11 +6,12 @@ module Reek
     module Silencer
       module_function
 
-      def silently(stderr: nil, stdout: nil)
+      # :reek:TooManyStatements: { max_statements: 7 }
+      def silently
         old_verbose = $VERBOSE
         $VERBOSE = false
-        $stderr = StringIO.new if stderr
-        $stdout = StringIO.new if stdout
+        $stderr = StringIO.new
+        $stdout = StringIO.new
         yield
       ensure
         $VERBOSE = old_verbose

--- a/lib/reek/code_comment.rb
+++ b/lib/reek/code_comment.rb
@@ -28,6 +28,7 @@ module Reek
 
     private
 
+    # :reek:UtilityFunction
     def add_to_config(smell, options)
       options ||= ': { enabled: false }'
       YAML.load(smell + options)

--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -22,10 +22,12 @@ module Reek
         load_from_file(find(path: path))
       end
 
+      # :reek:ControlParameter
       def find(path: nil, current: Pathname.pwd, home: Pathname.new(Dir.home))
         path || find_by_dir(current) || find_by_dir(home)
       end
 
+      # :reek:NestedIterators: { max_allowed_nesting: 2 }
       def find_by_dir(start)
         start.ascend do |dir|
           files = dir.children.select(&:file?).sort
@@ -34,6 +36,7 @@ module Reek
         end
       end
 
+      # :reek:TooManyStatements: { max_statements: 6 }
       def load_from_file(path)
         return {} unless path
         begin

--- a/lib/reek/configuration/configuration_validator.rb
+++ b/lib/reek/configuration/configuration_validator.rb
@@ -6,6 +6,7 @@ module Reek
     module ConfigurationValidator
       private
 
+      # :reek:UtilityFunction
       def smell_type?(key)
         Reek::Smells.const_get key
       rescue NameError

--- a/lib/reek/configuration/directory_directives.rb
+++ b/lib/reek/configuration/directory_directives.rb
@@ -26,6 +26,8 @@ module Reek
       # @param config [Hash] the configuration
       #
       # @return [self]
+      #
+      # :reek:NestedIterators: { max_allowed_nesting: 2 }
       def add(path, config)
         with_valid_directory(path) do |directory|
           self[directory] = config.each_with_object({}) do |(key, value), hash|
@@ -38,6 +40,8 @@ module Reek
 
       private
 
+      # :reek:DuplicateMethodCall: { max_calls: 2 }
+      # :reek:FeatureEnvy
       def best_match_for(source_base_dir)
         keys.
           select { |pathname| source_base_dir.to_s.match(/#{Regexp.escape(pathname.to_s)}/) }.

--- a/lib/reek/configuration/excluded_paths.rb
+++ b/lib/reek/configuration/excluded_paths.rb
@@ -3,11 +3,12 @@ require_relative './configuration_validator'
 module Reek
   module Configuration
     #
-    # Hash extension for excluded paths.
+    # Array extension for excluded paths.
     #
     module ExcludedPaths
       include ConfigurationValidator
 
+      # :reek:NestedIterators: { max_allowed_nesting: 2 }
       def add(paths)
         paths.each do |path|
           with_valid_directory(path) { |directory| self << directory }

--- a/lib/reek/context/code_context.rb
+++ b/lib/reek/context/code_context.rb
@@ -9,6 +9,8 @@ module Reek
     # code element. CodeContexts form a tree in the same way the code does,
     # with each context holding a reference to a unique outer context.
     #
+    # :reek:TooManyMethods: { max_methods: 18 }
+    # :reek:TooManyInstanceVariables: { max_instance_variables: 8 }
     class CodeContext
       attr_reader :exp
       attr_reader :num_statements
@@ -75,16 +77,19 @@ module Reek
         self.num_statements += num
       end
 
+      # :reek:TooManyStatements: { max_statements: 6 }
+      # :reek:FeatureEnvy
       def record_call_to(exp)
         receiver = exp.receiver
         type = receiver ? receiver.type : :self
+        line = exp.line
         case type
         when :lvar, :lvasgn
           unless exp.object_creation_call?
-            refs.record_reference_to(receiver.name, line: exp.line)
+            refs.record_reference_to(receiver.name, line: line)
           end
         when :self
-          refs.record_reference_to(:self, line: exp.line)
+          refs.record_reference_to(:self, line: line)
         end
       end
 

--- a/lib/reek/context/method_context.rb
+++ b/lib/reek/context/method_context.rb
@@ -16,6 +16,7 @@ module Reek
         local_nodes(:lvar).find { |node| node.var_name == param.to_sym }
       end
 
+      # :reek:FeatureEnvy
       def unused_params
         exp.arguments.select do |param|
           next if param.anonymous_splat?

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -14,6 +14,8 @@ module Reek
   # Applies all available smell detectors to a source.
   #
   # @public
+  #
+  # :reek:TooManyInstanceVariables: { max_instance_variables: 6 }
   class Examiner
     #
     # Creates an Examiner which scans the given +source+ for code smells.
@@ -35,7 +37,7 @@ module Reek
       @source        = Source::SourceCode.from(source)
       @configuration = configuration
       @collector     = CLI::WarningCollector.new
-      @smell_types   = eligible_smell_types(filter_by_smells)
+      @smell_types   = Smells::SmellRepository.eligible_smell_types(filter_by_smells)
 
       run
     end
@@ -84,16 +86,6 @@ module Reek
       syntax_tree = source.syntax_tree
       TreeWalker.new(smell_repository, syntax_tree).walk if syntax_tree
       smell_repository.report_on(collector)
-    end
-
-    def eligible_smell_types(filter_by_smells = [])
-      if filter_by_smells.any?
-        Smells::SmellRepository.smell_types.select do |klass|
-          filter_by_smells.include? klass.smell_type
-        end
-      else
-        Smells::SmellRepository.smell_types
-      end
     end
   end
 end

--- a/lib/reek/rake/task.rb
+++ b/lib/reek/rake/task.rb
@@ -35,6 +35,9 @@ module Reek
     #   rake reek REEK_OPTS=-s                   # sorts the report by smell
     #
     # @public
+    #
+    # :reek:TooManyInstanceVariables: { max_instance_variables: 6 }
+    # :reek:Attribute
     class Task < ::Rake::TaskLib
       # Name of reek task. Defaults to :reek.
       # @public
@@ -111,6 +114,7 @@ module Reek
           reject(&:empty?)
       end
 
+      # :reek:UtilityFunction
       def sys_call_failed?
         !$CHILD_STATUS.success?
       end

--- a/lib/reek/report/formatter.rb
+++ b/lib/reek/report/formatter.rb
@@ -37,6 +37,7 @@ module Reek
         "#{location_formatter.format(warning)}#{warning.base_message}"
       end
 
+      # :reek:UtilityFunction
       def format_hash(warning)
         warning.yaml_hash
       end
@@ -66,6 +67,7 @@ module Reek
         "#{BASE_URL_FOR_HELP_LINK}#{class_name_to_param(warning.smell_type)}.md"
       end
 
+      # :reek:UtilityFunction
       def class_name_to_param(name)
         name.split(/(?=[A-Z])/).join('-')
       end

--- a/lib/reek/report/heading_formatter.rb
+++ b/lib/reek/report/heading_formatter.rb
@@ -13,6 +13,7 @@ module Reek
           @report_formatter = report_formatter
         end
 
+        # :reek:UtilityFunction
         def show_header?(_examiner)
           raise NotImplementedError
         end
@@ -39,6 +40,7 @@ module Reek
       # Lists only smelly examiners
       #
       class Quiet < Base
+        # :reek:UtilityFunction
         def show_header?(examiner)
           examiner.smelly?
         end

--- a/lib/reek/report/report.rb
+++ b/lib/reek/report/report.rb
@@ -13,11 +13,15 @@ module Reek
     # @abstract Subclass and override {#show} to create a concrete report class.
     #
     # @public
+    #
+    # :reek:TooManyInstanceVariables: { max_instance_variables: 6 }
     class Base
       NO_WARNINGS_COLOR = :green
       WARNINGS_COLOR = :red
 
       # @public
+      #
+      # :reek:BooleanParameter
       def initialize(heading_formatter: HeadingFormatter::Quiet,
                      report_formatter: Formatter, sort_by_issue_count: false,
                      warning_formatter: SimpleWarningFormatter.new)
@@ -183,6 +187,8 @@ module Reek
         end
       end
 
+      # :reek:FeatureEnvy
+      # :reek:NestedIterators: { max_allowed_nesting: 2 }
       def file(name, smells)
         REXML::Element.new('file').tap do |file|
           file.add_attribute 'name', File.realpath(name)
@@ -194,6 +200,7 @@ module Reek
         end
       end
 
+      # :reek:UtilityFunction
       def error(smell, line)
         REXML::Element.new('error').tap do |error|
           error.add_attributes 'column'   => 0,

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -41,6 +41,7 @@ module Reek
 
       private
 
+      # :reek:UtilityFunction
       def attributes_in(module_ctx)
         if module_ctx.visibility == :public
           call_node = module_ctx.exp

--- a/lib/reek/smells/boolean_parameter.rb
+++ b/lib/reek/smells/boolean_parameter.rb
@@ -22,6 +22,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
+      # :reek:FeatureEnvy
       def examine_context(ctx)
         ctx.default_assignments.select do |_param, value|
           [:true, :false].include?(value[0])

--- a/lib/reek/smells/class_variable.rb
+++ b/lib/reek/smells/class_variable.rb
@@ -37,6 +37,8 @@ module Reek
       # Collects the names of the class variables declared and/or used
       # in the given module.
       #
+      # :reek:TooManyStatements: { max_statements: 7 }
+      # :reek:FeatureEnvy
       def class_variables_in(ast)
         result = Hash.new { |hash, key| hash[key] = [] }
         collector = proc do |cvar_node|

--- a/lib/reek/smells/control_parameter.rb
+++ b/lib/reek/smells/control_parameter.rb
@@ -52,13 +52,15 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
+      # :reek:FeatureEnvy
       def examine_context(ctx)
         ControlParameterCollector.new(ctx).control_parameters.map do |control_parameter|
+          name = control_parameter.name.to_s
           smell_warning(
             context: ctx,
             lines: control_parameter.lines,
-            message: "is controlled by argument #{control_parameter.name}",
-            parameters: { name: control_parameter.name.to_s })
+            message: "is controlled by argument #{name}",
+            parameters: { name: name })
         end
       end
 

--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -50,19 +50,20 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
+      # :reek:FeatureEnvy
       def examine_context(ctx)
         max_copies = value(MAX_COPIES_KEY, ctx, DEFAULT_MAX_COPIES)
         min_clump_size = value(MIN_CLUMP_SIZE_KEY, ctx, DEFAULT_MIN_CLUMP_SIZE)
         MethodGroup.new(ctx, min_clump_size, max_copies).clumps.map do |clump, methods|
-          print_clump = DataClump.print_clump(clump)
+          methods_length = methods.length
           smell_warning(
             context: ctx,
             lines: methods.map(&:line),
-            message: "takes parameters #{print_clump} " \
-                     "to #{methods.length} methods",
+            message: "takes parameters #{DataClump.print_clump(clump)} " \
+                     "to #{methods_length} methods",
             parameters: {
               parameters: clump.map(&:to_s),
-              count: methods.length,
+              count: methods_length,
               methods: methods.map(&:name)
             })
         end
@@ -94,6 +95,7 @@ module Reek
       end.uniq
     end
 
+    # :reek:UtilityFunction
     def common_argument_names_for(methods)
       methods.map(&:arg_names).inject(:&)
     end

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -45,6 +45,8 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
+      # :reek:FeatureEnvy
+      # :reek:DuplicateMethodCall: { max_calls: 2 }
       def examine_context(ctx)
         max_allowed_calls = value(MAX_ALLOWED_CALLS_KEY, ctx, DEFAULT_MAX_CALLS)
         allow_calls = value(ALLOW_CALLS_KEY, ctx, DEFAULT_ALLOW_CALLS)
@@ -111,6 +113,8 @@ module Reek
 
         private_attr_reader :allow_calls, :max_allowed_calls
 
+        # :reek:TooManyStatements: { max_statements: 6 }
+        # :reek:DuplicateMethodCall: { max_calls: 2 }
         def collect_calls(result)
           context.each_node(:send, [:mlhs]) do |call_node|
             next if call_node.object_creation_call?
@@ -126,6 +130,7 @@ module Reek
           found_call.occurs > max_allowed_calls && !allow_calls?(found_call.call)
         end
 
+        # :reek:UtilityFunction
         def simple_method_call?(call_node)
           !call_node.receiver && call_node.args.empty?
         end

--- a/lib/reek/smells/feature_envy.rb
+++ b/lib/reek/smells/feature_envy.rb
@@ -58,6 +58,7 @@ module Reek
 
       private
 
+      # :reek:UtilityFunction
       def envious_receivers(ctx)
         refs = ctx.refs
         return {} if refs.self_is_max?

--- a/lib/reek/smells/irresponsible_module.rb
+++ b/lib/reek/smells/irresponsible_module.rb
@@ -34,6 +34,7 @@ module Reek
         @descriptive ||= {}
       end
 
+      # :reek:FeatureEnvy
       def descriptive?(ctx)
         descriptive[ctx.full_name] ||= ctx.descriptively_commented?
       end

--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -35,11 +35,12 @@ module Reek
       #
       def examine_context(ctx)
         max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, ctx, DEFAULT_MAX_ALLOWED_PARAMS)
-        count = ctx.exp.arg_names.length
+        exp = ctx.exp
+        count = exp.arg_names.length
         return [] if count <= max_allowed_params
         [smell_warning(
           context: ctx,
-          lines: [ctx.exp.line],
+          lines: [exp.line],
           message: "has #{count} parameters",
           parameters: { count: count })]
       end

--- a/lib/reek/smells/long_yield_list.rb
+++ b/lib/reek/smells/long_yield_list.rb
@@ -27,6 +27,8 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
+      # :reek:FeatureEnvy
+      # :reek:DuplicateMethodCall: { max_calls: 2 }
       def examine_context(ctx)
         max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY,
                                    ctx,

--- a/lib/reek/smells/module_initialize.rb
+++ b/lib/reek/smells/module_initialize.rb
@@ -19,6 +19,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
+      # :reek:FeatureEnvy
       def examine_context(ctx)
         ctx.local_nodes(:def) do |node| # FIXME: also search for :defs?
           if node.name.to_s == 'initialize'

--- a/lib/reek/smells/prima_donna_method.rb
+++ b/lib/reek/smells/prima_donna_method.rb
@@ -36,6 +36,7 @@ module Reek
 
       private
 
+      # :reek:FeatureEnvy
       def check_for_smells(method_sexp, ctx)
         return unless method_sexp.ends_with_bang?
 

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -49,6 +49,8 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
+      # :reek:TooManyStatements: { max_statements: 6 }
+      # :reek:DuplicateMethodCall: { max_calls: 2 }
       def examine_context(ctx)
         max_identical_ifs = value(MAX_IDENTICAL_IFS_KEY, ctx, DEFAULT_MAX_IFS)
         conditional_counts(ctx).select do |_key, lines|
@@ -69,6 +71,8 @@ module Reek
       # the given syntax tree together with the number of times each
       # occurs. Ignores nested classes and modules.
       #
+      # :reek:TooManyStatements: { max_statements: 9 }
+      # :reek:FeatureEnvy
       def conditional_counts(sexp)
         result = Hash.new { |hash, key| hash[key] = [] }
         collector = proc do |node|

--- a/lib/reek/smells/smell_configuration.rb
+++ b/lib/reek/smells/smell_configuration.rb
@@ -18,7 +18,7 @@ module Reek
         @options = hash
       end
 
-      def merge!(new_options)
+      def merge(new_options)
         options.merge!(new_options)
       end
 

--- a/lib/reek/smells/smell_detector.rb
+++ b/lib/reek/smells/smell_detector.rb
@@ -12,6 +12,8 @@ module Reek
     #   - {file:README.md}
     # for details.
     #
+    # :reek:TooManyMethods: { max_methods: 19 }
+    # :reek:TooManyInstanceVariables: { max_instance_variables: 5 }
     class SmellDetector
       # The name of the config field that lists the names of code contexts
       # that should not be checked. Add this field to the config for each
@@ -27,6 +29,7 @@ module Reek
           [:def, :defs]
         end
 
+        # :reek:UtilityFunction
         def default_config
           {
             SmellConfiguration::ENABLED_KEY => true,
@@ -117,6 +120,7 @@ module Reek
         ctx.config_for(self.class)
       end
 
+      # :reek:FeatureEnvy
       def smell_warning(options = {})
         context = options.fetch(:context)
         exp = context.exp

--- a/lib/reek/smells/smell_repository.rb
+++ b/lib/reek/smells/smell_repository.rb
@@ -12,6 +12,13 @@ module Reek
         Reek::Smells::SmellDetector.descendants.sort_by(&:name)
       end
 
+      def self.eligible_smell_types(filter_by_smells = [])
+        return smell_types if filter_by_smells.empty?
+        smell_types.select do |klass|
+          filter_by_smells.include? klass.smell_type
+        end
+      end
+
       def initialize(smell_types: self.class.smell_types,
                      configuration: {})
         @configuration = configuration

--- a/lib/reek/smells/smell_warning.rb
+++ b/lib/reek/smells/smell_warning.rb
@@ -7,6 +7,8 @@ module Reek
     # Reports a warning that a smell has been found.
     #
     # @public
+    #
+    # :reek:TooManyInstanceVariables: { max_instance_variables: 6 }
     class SmellWarning
       include Comparable
       extend Forwardable
@@ -20,6 +22,8 @@ module Reek
       #   public API.
       #
       # FIXME: switch to required kwargs when dropping Ruby 2.0 compatibility
+      #
+      # :reek:LongParameterList: { max_params: 6 }
       def initialize(smell_detector, context: '', lines: raise, message: raise,
                                      source: raise, parameters: {})
         @smell_detector = smell_detector
@@ -77,7 +81,10 @@ module Reek
       end
 
       def common_parameters_equal?(other_parameters)
-        other_parameters.keys.each do |key|
+        other_keys   = other_parameters.keys
+        other_values = other_parameters.values
+
+        other_keys.each do |key|
           unless parameters.key?(key)
             raise ArgumentError, "The parameter #{key} you want to check for doesn't exist"
           end
@@ -91,7 +98,7 @@ module Reek
         # So in this spec we are just specifying the "name" parameter but not the "count".
         # In order to allow for this kind of leniency we just test for common parameter equality,
         # not for a strict one.
-        parameters.values_at(*other_parameters.keys) == other_parameters.values
+        parameters.values_at(*other_keys) == other_values
       end
 
       def core_yaml_hash

--- a/lib/reek/smells/uncommunicative_method_name.rb
+++ b/lib/reek/smells/uncommunicative_method_name.rb
@@ -45,6 +45,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
+      # :reek:TooManyStatements: { max_statements: 9 }
       def examine_context(ctx)
         reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
         accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -68,6 +68,7 @@ module Reek
       private
 
       # FIXME: switch to required kwargs when dropping Ruby 2.0 compatibility
+      # :reek:ControlParameter
       def acceptable_name?(context: raise, module_name: raise, fully_qualified_name: raise)
         accept_names(context).any? { |accept_name| fully_qualified_name == accept_name } ||
           reject_patterns(context).none? { |pattern| module_name.match pattern }

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -21,13 +21,13 @@ module Reek
       # The name of the config field that lists the regexps of
       # smelly names to be reported.
       REJECT_KEY = 'reject'
-      DEFAULT_REJECT_SET = [/^.$/, /[0-9]$/, /[A-Z]/, /^_/]
+      DEFAULT_REJECT_PATTERNS = [/^.$/, /[0-9]$/, /[A-Z]/, /^_/]
 
       # The name of the config field that lists the specific names that are
       # to be treated as exceptions; these names will not be reported as
       # uncommunicative.
       ACCEPT_KEY = 'accept'
-      DEFAULT_ACCEPT_SET = []
+      DEFAULT_ACCEPT_NAMES = []
 
       def self.smell_category
         'UncommunicativeName'
@@ -35,8 +35,8 @@ module Reek
 
       def self.default_config
         super.merge(
-          REJECT_KEY => DEFAULT_REJECT_SET,
-          ACCEPT_KEY => DEFAULT_ACCEPT_SET
+          REJECT_KEY => DEFAULT_REJECT_PATTERNS,
+          ACCEPT_KEY => DEFAULT_ACCEPT_NAMES
         )
       end
 
@@ -46,11 +46,9 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def examine_context(ctx)
-        self.reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
-        self.accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
         context_expression = ctx.exp
         context_expression.parameter_names.select do |name|
-          bad_name?(name) && ctx.uses_param?(name)
+          bad_name?(ctx, name) && ctx.uses_param?(name)
         end.map do |name|
           smell_warning(
             context: ctx,
@@ -60,15 +58,26 @@ module Reek
         end
       end
 
-      def bad_name?(name)
-        var = name.to_s.gsub(/^[@\*\&]*/, '')
-        return false if var == '*' || accept_names.include?(var)
-        reject_names.find { |patt| patt =~ var }
-      end
-
       private
 
-      private_attr_accessor :accept_names, :reject_names
+      def bad_name?(ctx, name)
+        sanitized_name = sanitize name
+        return false if sanitized_name == '*' || accept_names(ctx).include?(sanitized_name)
+        reject_patterns(ctx).any? { |pattern| sanitized_name.match pattern }
+      end
+
+      def reject_patterns(context)
+        value(REJECT_KEY, context, DEFAULT_REJECT_PATTERNS)
+      end
+
+      def accept_names(context)
+        value(ACCEPT_KEY, context, DEFAULT_ACCEPT_NAMES)
+      end
+
+      # :reek:UtilityFunction
+      def sanitize(name)
+        name.to_s.gsub(/^[@\*\&]*/, '')
+      end
     end
   end
 end

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -17,6 +17,8 @@ module Reek
     # * names ending with a number
     #
     # See {file:docs/Uncommunicative-Variable-Name.md} for details.
+    #
+    # :reek:DataClump: { max_copies: 4 }
     class UncommunicativeVariableName < SmellDetector
       # The name of the config field that lists the regexps of
       # smelly names to be reported.
@@ -40,7 +42,7 @@ module Reek
         )
       end
 
-      def self.contexts # :nodoc:
+      def self.contexts
         [:module, :class, :def, :defs]
       end
 
@@ -69,6 +71,7 @@ module Reek
         reject_names.find { |patt| patt =~ var }
       end
 
+      # :reek:TooManyStatements: { max_statements: 6 }
       def variable_names(exp)
         result = Hash.new { |hash, key| hash[key] = [] }
         find_assignment_variable_names(exp, result)
@@ -76,6 +79,7 @@ module Reek
         result.to_a.sort_by { |name, _| name.to_s }
       end
 
+      # :reek:UtilityFunction
       def find_assignment_variable_names(exp, accumulator)
         assignment_nodes = exp.each_node(:lvasgn, [:class, :module, :defs, :def])
 
@@ -87,6 +91,8 @@ module Reek
         assignment_nodes.each { |asgn| accumulator[asgn[1]].push(asgn.line) }
       end
 
+      # :reek:FeatureEnvy
+      # :reek:TooManyStatements: { max_statements: 6 }
       def find_block_argument_variable_names(exp, accumulator)
         arg_search_exp = case exp.first
                          when :class, :module
@@ -114,6 +120,7 @@ module Reek
         end
       end
 
+      # :reek:UtilityFunction
       def record_variable_name(exp, symbol, accumulator)
         varname = symbol.to_s.sub(/^\*/, '')
         return if varname == ''

--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -17,14 +17,16 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
+      # :reek:FeatureEnvy
       def examine_context(ctx)
         return [] if ctx.uses_super_with_implicit_arguments?
         ctx.unused_params.map do |param|
+          name = param.name.to_s
           smell_warning(
             context: ctx,
             lines: [ctx.exp.line],
-            message: "has unused parameter '#{param.name}'",
-            parameters: { name: param.name.to_s })
+            message: "has unused parameter '#{name}'",
+            parameters: { name: name })
         end
       end
     end

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -52,6 +52,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
+      # :reek:FeatureEnvy
       def examine_context(ctx)
         return [] if ctx.singleton_method?
         return [] if ctx.num_statements == 0
@@ -67,6 +68,7 @@ module Reek
 
       private
 
+      # :reek:UtilityFunction
       def num_helper_methods(method_ctx)
         method_ctx.local_nodes(:send).length
       end

--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -31,6 +31,8 @@ module Reek
 
       private_attr_reader :configuration, :paths
 
+      # :reek:TooManyStatements: { max_statements: 6 }
+      # :reek:NestedIterators: { max_allowed_nesting: 2 }
       def source_paths
         paths.each_with_object([]) do |given_path, relevant_paths|
           print_no_such_file_error(given_path) && next unless given_path.exist?
@@ -48,10 +50,12 @@ module Reek
         configuration.path_excluded?(path)
       end
 
+      # :reek:UtilityFunction
       def print_no_such_file_error(path)
         $stderr.puts "Error: No such file - #{path}"
       end
 
+      # :reek:UtilityFunction
       def hidden_directory?(path)
         path.basename.to_s.start_with? '.'
       end
@@ -60,10 +64,12 @@ module Reek
         path_excluded?(path) || hidden_directory?(path)
       end
 
+      # :reek:UtilityFunction
       def ruby_file?(path)
         path.extname == '.rb'
       end
 
+      # :reek:UtilityFunction
       def current_directory?(path)
         [Pathname.new('.'), Pathname.new('./')].include?(path)
       end

--- a/lib/reek/spec.rb
+++ b/lib/reek/spec.rb
@@ -87,6 +87,8 @@ module Reek
     #   expect(src).to reek_of(Reek::Smells::DuplicateMethodCall, name: '@other.thing')
     #
     # @public
+    #
+    # :reek:UtilityFunction
     def reek_of(smell_category,
                 smell_details = {},
                 configuration = Configuration::AppConfiguration.default)
@@ -102,6 +104,8 @@ module Reek
     #   2.) "reek_only_of" doesn't support the additional smell_details hash.
     #
     # @public
+    #
+    # :reek:UtilityFunction
     def reek_only_of(smell_category, configuration = Configuration::AppConfiguration.default)
       ShouldReekOnlyOf.new(smell_category, configuration)
     end
@@ -110,6 +114,8 @@ module Reek
     # Returns +true+ if and only if the target source code contains smells.
     #
     # @public
+    #
+    # :reek:UtilityFunction
     def reek(configuration = Configuration::AppConfiguration.default)
       ShouldReek.new(configuration: configuration)
     end

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -34,6 +34,7 @@ module Reek
       private_attr_reader :configuration, :smell_category, :smell_details
       private_attr_accessor :all_smells, :examiner
 
+      # :reek:UtilityFunction
       def normalize(smell_category_or_type)
         # In theory, users can give us many different types of input (see the documentation for
         # reek_of below), however we're basically ignoring all of those subleties and just

--- a/lib/reek/tree_dresser.rb
+++ b/lib/reek/tree_dresser.rb
@@ -34,6 +34,9 @@ module Reek
     # @param parent [Parser::AST::Node] - the parent sexp
     #
     # @return an instance of Reek::AST::Node with type-dependent sexp extensions mixed in.
+    #
+    # :reek:FeatureEnvy
+    # :reek:TooManyStatements: { max_statements: 6 }
     def dress(sexp, comment_map, parent: nil)
       return sexp unless sexp.is_a? ::Parser::AST::Node
       type = sexp.type

--- a/lib/reek/tree_walker.rb
+++ b/lib/reek/tree_walker.rb
@@ -15,6 +15,7 @@ module Reek
   # TODO: Make TreeWalker responsible only for creating Context objects, and
   # loop over the created set of contexts elsewhere.
   #
+  # :reek:TooManyMethods: { max_methods: 29 }
   class TreeWalker
     def initialize(smell_repository, exp)
       @smell_repository = smell_repository
@@ -85,10 +86,8 @@ module Reek
 
     def process_args(_) end
 
-    #
-    # Recording of calls to methods and self
-    #
-
+    # :reek:TooManyStatements: { max_statements: 6 }
+    # :reek:FeatureEnvy
     def process_send(exp)
       if exp.visibility_modifier?
         element.track_visibility(exp.method_name, exp.arg_names)
@@ -187,6 +186,7 @@ module Reek
       self.class.private_method_defined?(name)
     end
 
+    # :reek:ControlParameter
     def count_clause(sexp)
       element.count_statements(1) if sexp
     end

--- a/spec/quality/reek_source_spec.rb
+++ b/spec/quality/reek_source_spec.rb
@@ -2,6 +2,8 @@ require_relative '../spec_helper'
 
 RSpec.describe 'Reek source code' do
   it 'has no smells' do
-    expect(Dir['lib/**/*.rb']).to_not reek
+    Pathname.glob('lib/**/*.rb').each do |pathname|
+      expect(pathname).to_not reek
+    end
   end
 end

--- a/spec/reek/configuration/directory_directives_spec.rb
+++ b/spec/reek/configuration/directory_directives_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
       let(:bogus_path) { Pathname('does/not/exist') }
 
       it 'raises an error' do
-        Reek::CLI::Silencer.silently(stderr: true) do
+        Reek::CLI::Silencer.silently do
           expect { subject.add(bogus_path, {}) }.to raise_error(SystemExit)
         end
       end
@@ -46,7 +46,7 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
       let(:file_as_path) { SAMPLES_PATH.join('inline.rb') }
 
       it 'raises an error' do
-        Reek::CLI::Silencer.silently(stderr: true) do
+        Reek::CLI::Silencer.silently do
           expect { subject.add(file_as_path, {}) }.to raise_error(SystemExit)
         end
       end

--- a/spec/reek/configuration/excluded_paths_spec.rb
+++ b/spec/reek/configuration/excluded_paths_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Reek::Configuration::ExcludedPaths do
       let(:paths) { [SAMPLES_PATH, bogus_path] }
 
       it 'raises an error' do
-        Reek::CLI::Silencer.silently(stderr: true) do
+        Reek::CLI::Silencer.silently do
           expect { subject.add(paths) }.to raise_error(SystemExit)
         end
       end
@@ -21,7 +21,7 @@ RSpec.describe Reek::Configuration::ExcludedPaths do
       let(:paths) { [SAMPLES_PATH, file_as_path] }
 
       it 'raises an error if one of the given paths is a file' do
-        Reek::CLI::Silencer.silently(stderr: true) do
+        Reek::CLI::Silencer.silently do
           expect { subject.add(paths) }.to raise_error(SystemExit)
         end
       end

--- a/spec/reek/smells/smell_configuration_spec.rb
+++ b/spec/reek/smells/smell_configuration_spec.rb
@@ -19,21 +19,21 @@ RSpec.describe Reek::Smells::SmellConfiguration do
 
     let(:smell_config) { described_class.new(base_config) }
 
-    it { expect(smell_config.merge!({})).to eq(base_config) }
-    it { expect(smell_config.merge!('enabled' => true)).to eq(base_config) }
-    it { expect(smell_config.merge!('exclude' => [])).to eq(base_config) }
-    it { expect(smell_config.merge!('accept' => ['_'])).to eq(base_config) }
+    it { expect(smell_config.merge({})).to eq(base_config) }
+    it { expect(smell_config.merge('enabled' => true)).to eq(base_config) }
+    it { expect(smell_config.merge('exclude' => [])).to eq(base_config) }
+    it { expect(smell_config.merge('accept' => ['_'])).to eq(base_config) }
     it do
-      updated = smell_config.merge!('reject' => [/^.$/, /[0-9]$/, /[A-Z]/])
+      updated = smell_config.merge('reject' => [/^.$/, /[0-9]$/, /[A-Z]/])
       expect(updated).to eq(base_config)
     end
     it do
-      updated = smell_config.merge!('accept' => ['_'], 'enabled' => true)
+      updated = smell_config.merge('accept' => ['_'], 'enabled' => true)
       expect(updated).to eq(base_config)
     end
 
     it 'should override single values' do
-      updated = smell_config.merge!('enabled' => false)
+      updated = smell_config.merge('enabled' => false)
       expect(updated).to eq('accept'  => ['_'],
                             'enabled' => false,
                             'exclude' => [],
@@ -41,7 +41,7 @@ RSpec.describe Reek::Smells::SmellConfiguration do
     end
 
     it 'should override arrays of values' do
-      updated = smell_config.merge!('reject' => [/^.$/, /[3-9]$/])
+      updated = smell_config.merge('reject' => [/^.$/, /[3-9]$/])
       expect(updated).to eq('accept'  => ['_'],
                             'enabled' => true,
                             'exclude' => [],
@@ -49,7 +49,7 @@ RSpec.describe Reek::Smells::SmellConfiguration do
     end
 
     it 'should override multiple values' do
-      updated = smell_config.merge!('accept' => [/[A-Z]$/], 'enabled' => false)
+      updated = smell_config.merge('accept' => [/[A-Z]$/], 'enabled' => false)
       expect(updated).to eq('accept'  => [/[A-Z]$/],
                             'enabled' => false,
                             'exclude' => [],


### PR DESCRIPTION
Ladies and gentleman, this pull request does 3 things:

1.) Fixes all low-hanging fruits when it comes to smells in our codebase (e.g. DuplicateMethodCall, UncommunicativeParameterName, etc)
2.) Suppresses all remaining smell warnings via comments (not via configuration file. That's how I started but @chastell convinced me that it's better to use comments) so we can finally get to ....
3.) CI integration with `reek` for `reeks` own codebase!

And then we can address our own smell warnings step by step. At the very least the UtilityFunction and FeatureEnvy smells will definitely require some design changes.

What's left?

* [3] is not working yet, I'll fix this in this very PR, but I'll add it as a second commit so you can review already.
* #693 needs to merged first to make reek completely happy in this PR as well