### PR TITLE
Fix options hell in CLI namespace.

### DIFF
--- a/lib/reek/cli/option_interpreter.rb
+++ b/lib/reek/cli/option_interpreter.rb
@@ -9,10 +9,9 @@ module Reek
     #
     class OptionInterpreter
       include Input
-
       extend Forwardable
-
       def_delegators :options, :smells_to_detect
+      private_attr_reader :argv, :options
 
       def initialize(options)
         @options = options
@@ -51,10 +50,6 @@ module Reek
       def sort_by_issue_count
         options.sorting == :smelliness
       end
-
-      private
-
-      private_attr_reader :argv, :options
     end
   end
 end

--- a/spec/reek/cli/option_interpreter_spec.rb
+++ b/spec/reek/cli/option_interpreter_spec.rb
@@ -1,19 +1,19 @@
 require_relative '../../spec_helper'
 
 require_relative '../../../lib/reek/cli/options'
+require_relative '../../../lib/reek/cli/option_interpreter'
 require_relative '../../../lib/reek/report/report'
 
 RSpec.describe Reek::CLI::OptionInterpreter do
   describe '#reporter' do
-    let(:instance) { Reek::CLI::OptionInterpreter.new(options) }
-
     context 'with a valid set of options' do
       let(:options) do
-        OpenStruct.new(report_format: :text,
-                       location_format: :plain)
+        Reek::CLI::Options.new.parse
       end
+      subject { described_class.new(options) }
+
       it 'returns an object of the correct subclass of Report::Base' do
-        expect(instance.reporter).to be_instance_of Reek::Report::TextReport
+        expect(subject.reporter).to be_instance_of Reek::Report::TextReport
       end
     end
   end

--- a/spec/reek/cli/options_spec.rb
+++ b/spec/reek/cli/options_spec.rb
@@ -1,28 +1,36 @@
 require_relative '../../spec_helper'
-
 require_relative '../../../lib/reek/cli/options'
 
 RSpec.describe Reek::CLI::Options do
-  describe '#parse' do
-    context 'with no arguments passed' do
-      let(:options) { Reek::CLI::Options.new.parse }
-      it 'enables colors when stdout is a TTY' do
-        allow($stdout).to receive_messages(tty?: false)
-        expect(options.colored).to be false
-      end
+  describe '#initialize' do
+    it 'sets a valid default value for report_format' do
+      expect(subject.report_format).to eq :text
+    end
 
-      it 'does not enable colors when stdout is not a TTY' do
-        allow($stdout).to receive_messages(tty?: true)
-        expect(options.colored).to be true
-      end
+    it 'sets a valid default value for location_format' do
+      expect(subject.location_format).to eq :numbers
+    end
 
-      it 'sets a valid default value for report_format' do
-        expect(options.report_format).to eq :text
-      end
+    it 'enables colors when stdout is a TTY' do
+      allow($stdout).to receive_messages(tty?: false)
+      expect(subject.colored).to be false
+    end
 
-      it 'sets a valid default value for location_format' do
-        expect(options.location_format).to eq :numbers
-      end
+    it 'does not enable colors when stdout is not a TTY' do
+      allow($stdout).to receive_messages(tty?: true)
+      expect(subject.colored).to be true
+    end
+  end
+
+  describe 'parse' do
+    it 'raises on invalid argument in ARGV' do
+      options = described_class.new
+      options.argv = ['-z']
+      expect { options.parse }.to raise_error(OptionParser::InvalidOption)
+    end
+
+    it 'returns self' do
+      expect(subject.parse).to be_a(described_class)
     end
   end
 end


### PR DESCRIPTION
Fixes #605

Basically this removes the bad "Options#options" abstraction completely.
Now we're down to just using "Options" and "OptionInterpreter" which looks appropriate to me.
I also refactored application.rb and beefed up our specs a tad ;)