### PR TITLE
Bump deps and fix Aruba 0.9 deprecations

### DIFF
--- a/features/step_definitions/reek_steps.rb
+++ b/features/step_definitions/reek_steps.rb
@@ -11,69 +11,72 @@ When /^I run rake (\w*) with:$/ do |name, task_def|
 end
 
 Then /^it reports nothing$/ do
-  assert_exact_output '', all_stdout
+  expect(last_command_started).to have_output_on_stdout('')
 end
 
 Then /^there is no output on stdout$/ do
-  assert_exact_output '', all_stdout
+  expect(last_command_started).to have_output_on_stdout('')
 end
 
 Then /^stdout includes "(.*)"$/ do |text|
-  assert_partial_output(text, all_stdout)
+  expect(last_command_started).to have_output_on_stdout(/#{Regexp.escape(text)}/)
 end
 
 Then /^it succeeds$/ do
-  assert_exit_status Reek::CLI::Application::STATUS_SUCCESS
+  success = Reek::CLI::Application::STATUS_SUCCESS
+  expect(last_command_started).to have_exit_status(success)
 end
 
 Then /^the exit status indicates an error$/ do
-  assert_exit_status Reek::CLI::Application::STATUS_ERROR
+  error = Reek::CLI::Application::STATUS_ERROR
+  expect(last_command_started).to have_exit_status(error)
 end
 
 Then /^the exit status indicates smells$/ do
-  assert_exit_status Reek::CLI::Application::STATUS_SMELLS
+  smells = Reek::CLI::Application::STATUS_SMELLS
+  expect(last_command_started).to have_exit_status(smells)
 end
 
 Then /^it reports:$/ do |report|
-  assert_exact_output "#{report}\n", all_stdout
+  expect(last_command_started).to have_output_on_stdout(report.gsub('\n', "\n"))
 end
 
 Then /^it reports this yaml:$/ do |expected_yaml|
   expected_warnings = YAML.load(expected_yaml.chomp)
-  actual_warnings = YAML.load(all_stdout)
+  actual_warnings = YAML.load(last_command_started.stdout)
   expect(actual_warnings).to eq expected_warnings
 end
 
 Then /^it reports this JSON:$/ do |expected_json|
   expected_warnings = JSON.parse(expected_json.chomp)
-  actual_warnings = JSON.parse(all_stdout)
+  actual_warnings = JSON.parse(last_command_started.stdout)
   expect(actual_warnings).to eq expected_warnings
 end
 
 Then /^stderr reports:$/ do |report|
-  assert_exact_output report, all_stderr
+  expect(last_command_started).to have_output_on_stderr(report.chomp)
 end
 
 Then /^it reports no errors$/ do
-  assert_exact_output '', all_stderr
+  expect(last_command_started).to have_output_on_stderr('')
 end
 
 Then /^it reports an error$/ do
-  expect(all_stderr).to_not be_empty
+  expect(last_command_started.stderr).to_not be_empty
 end
 
 Then /^it reports the error ['"](.*)['"]$/ do |string|
-  assert_partial_output string, all_stderr
+  expect(last_command_started).to have_output_on_stderr(/#{Regexp.escape(string)}/)
 end
 
 Then /^it reports a parsing error$/ do
-  assert_partial_output 'Parser::SyntaxError', all_stderr
+  expect(last_command_started).to have_output_on_stderr(/Parser::SyntaxError/)
 end
 
 Then /^it should indicate the line numbers of those smells$/ do
-  assert_matching_output /\[.*\]:/, all_stdout
+  expect(last_command_started).to have_output(/\[.*\]:/)
 end
 
 Then /^it reports the current version$/ do
-  assert_exact_output "reek #{Reek::Version::STRING}\n", all_stdout
+  expect(last_command_started).to have_output("reek #{Reek::Version::STRING}")
 end

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl',  '~> 4.0'
   s.add_development_dependency 'rake',          '~> 10.0'
   s.add_development_dependency 'rspec',         '~> 3.0'
-  s.add_development_dependency 'rubocop',       '~> 0.33.0'
+  s.add_development_dependency 'rubocop',       '~> 0.34.0'
 end

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'unparser',     '~> 0.2.2'
 
   s.add_development_dependency 'activesupport', '~> 4.2'
-  s.add_development_dependency 'aruba',         '~> 0.8.0'
+  s.add_development_dependency 'aruba',         '~> 0.9.0'
   s.add_development_dependency 'ataru',         '~> 0.2.0'
   s.add_development_dependency 'bundler',       '~> 1.1'
   s.add_development_dependency 'cucumber',      '~> 2.0'


### PR DESCRIPTION
(That thing where you want to get back to hacking on reek, think ‘I’ll just bring deps to the current upstreams’ and spend an hour fixing Aruba deprecations.)