### PR TITLE
Add AST::SexpExtensions::LvarNode#simple_name

### DIFF
--- a/lib/reek/ast/sexp_extensions.rb
+++ b/lib/reek/ast/sexp_extensions.rb
@@ -231,8 +231,9 @@ module Reek
       # Utility methods for :lvar nodes.
       module LvarNode
         include VariableBase
-        # TODO: Replace with name().
-        def var_name() self[1] end
+
+        alias_method :simple_name, :name
+        alias_method :var_name,    :name
       end
 
       LvasgnNode = LvarNode

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -231,6 +231,22 @@ RSpec.describe Reek::AST::SexpExtensions::DefsNode do
   end
 end
 
+RSpec.describe Reek::AST::SexpExtensions::LvarNode do
+  let(:node) { sexp(:lvar, :foo) }
+
+  describe '#simple_name' do
+    it 'returns the lvar’s name' do
+      expect(node.simple_name).to eq(:foo)
+    end
+  end
+
+  describe '#var_name' do
+    it 'returns the lvar’s name' do
+      expect(node.var_name).to eq(:foo)
+    end
+  end
+end
+
 RSpec.describe Reek::AST::SexpExtensions::SendNode do
   context 'with no parameters' do
     let(:node) { sexp(:send, nil, :hello) }


### PR DESCRIPTION
Trying to parse Ruby’s `test/test_delegate.rb` reek blows up on the [`DC = dc.new(new)`](https://github.com/ruby/ruby/blob/v2_2_3/test/test_delegate.rb#L212) line:

```
/home/chastell/coding/reek/lib/reek/ast/sexp_extensions.rb:434:in `defines_module?': undefined method `simple_name' for (lvar :dc):#<Class:0x007fe7a2fcdb40> (NoMethodError)
```

This adds `AST::SexpExtensions::LvarNode#simple_name` to fix this.