### PR TITLE
LocationFormatters: sort lines in reports

### DIFF
--- a/lib/reek/report/location_formatter.rb
+++ b/lib/reek/report/location_formatter.rb
@@ -4,7 +4,9 @@ module Reek
     # Formats the location of a warning as an empty string.
     #
     module BlankLocationFormatter
-      def self.format(_warning)
+      module_function
+
+      def format(_warning)
         ''
       end
     end
@@ -13,8 +15,10 @@ module Reek
     # Formats the location of a warning as an array of line numbers.
     #
     module DefaultLocationFormatter
-      def self.format(warning)
-        "#{warning.lines.inspect}:"
+      module_function
+
+      def format(warning)
+        "#{warning.lines.sort.inspect}:"
       end
     end
 
@@ -24,8 +28,10 @@ module Reek
     # one line number, so the first number is displayed.
     #
     module SingleLineLocationFormatter
-      def self.format(warning)
-        "#{warning.source}:#{warning.lines.first}: "
+      module_function
+
+      def format(warning)
+        "#{warning.source}:#{warning.lines.sort.first}: "
       end
     end
   end

--- a/spec/reek/report/location_formatter_spec.rb
+++ b/spec/reek/report/location_formatter_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../../spec_helper'
+require_relative '../../../lib/reek/report/formatter'
+
+RSpec.describe 'location formatters' do
+  let(:warning) { build(:smell_warning, lines: [11, 9, 250, 100]) }
+
+  describe Reek::Report::BlankLocationFormatter do
+    describe '.format' do
+      it 'returns a blank String regardless of the warning' do
+        expect(described_class.format(warning)).to eq('')
+      end
+    end
+  end
+
+  describe Reek::Report::DefaultLocationFormatter do
+    describe '.format' do
+      it 'returns a prefix with sorted line numbers' do
+        expect(described_class.format(warning)).to eq('[9, 11, 100, 250]:')
+      end
+    end
+  end
+
+  describe Reek::Report::SingleLineLocationFormatter do
+    describe '.format' do
+      it 'returns the first line where the smell was found' do
+        expect(described_class.format(warning)).to eq('dummy_file:9: ')
+      end
+    end
+  end
+end


### PR DESCRIPTION
I recently noticed that our formatters don’t sort line numbers on output.

This makes the `DefaultLocationFormatter` sort lines on output, `SingleLineLocationFormatter` output the first line and turns all `.format` methods into `module_functions`.