### PR TITLE
require_lib_reek

### DIFF
--- a/spec/reek/ast/node_spec.rb
+++ b/spec/reek/ast/node_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/ast/node'
+require_lib 'reek/ast/node'
 
 RSpec.describe Reek::AST::Node do
   context 'format' do

--- a/spec/reek/ast/object_refs_spec.rb
+++ b/spec/reek/ast/object_refs_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/ast/object_refs'
+require_lib 'reek/ast/object_refs'
 
 RSpec.describe Reek::AST::ObjectRefs do
   let(:refs) { Reek::AST::ObjectRefs.new }

--- a/spec/reek/ast/reference_collector_spec.rb
+++ b/spec/reek/ast/reference_collector_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/ast/reference_collector'
+require_lib 'reek/ast/reference_collector'
 
 RSpec.describe Reek::AST::ReferenceCollector do
   context 'counting refs to self' do

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/ast/sexp_extensions'
+require_lib 'reek/ast/sexp_extensions'
 
 RSpec.describe Reek::AST::SexpExtensions::DefNode do
   context 'with no parameters' do

--- a/spec/reek/ast/sexp_formatter_spec.rb
+++ b/spec/reek/ast/sexp_formatter_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/ast/sexp_formatter'
+require_lib 'reek/ast/sexp_formatter'
 
 RSpec.describe Reek::AST::SexpFormatter do
   describe '::format' do

--- a/spec/reek/cli/option_interpreter_spec.rb
+++ b/spec/reek/cli/option_interpreter_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../../spec_helper'
 
-require_relative '../../../lib/reek/cli/options'
-require_relative '../../../lib/reek/cli/option_interpreter'
-require_relative '../../../lib/reek/report/report'
+require_lib 'reek/cli/options'
+require_lib 'reek/cli/option_interpreter'
+require_lib 'reek/report/report'
 
 RSpec.describe Reek::CLI::OptionInterpreter do
   describe '#reporter' do

--- a/spec/reek/cli/options_spec.rb
+++ b/spec/reek/cli/options_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/cli/options'
+require_lib 'reek/cli/options'
 
 RSpec.describe Reek::CLI::Options do
   describe '#initialize' do

--- a/spec/reek/cli/warning_collector_spec.rb
+++ b/spec/reek/cli/warning_collector_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/cli/warning_collector'
-require_relative '../../../lib/reek/smells/smell_warning'
+require_lib 'reek/cli/warning_collector'
+require_lib 'reek/smells/smell_warning'
 
 RSpec.describe Reek::CLI::WarningCollector do
   let(:collector) { described_class.new }

--- a/spec/reek/code_comment_spec.rb
+++ b/spec/reek/code_comment_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../spec_helper'
-require_relative '../../lib/reek/code_comment'
+require_lib 'reek/code_comment'
 
 RSpec.describe Reek::CodeComment do
   context 'with an empty comment' do

--- a/spec/reek/configuration/app_configuration_spec.rb
+++ b/spec/reek/configuration/app_configuration_spec.rb
@@ -1,9 +1,9 @@
 require 'pathname'
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/configuration/app_configuration'
-require_relative '../../../lib/reek/configuration/directory_directives'
-require_relative '../../../lib/reek/configuration/default_directive'
-require_relative '../../../lib/reek/configuration/excluded_paths'
+require_lib 'reek/configuration/app_configuration'
+require_lib 'reek/configuration/directory_directives'
+require_lib 'reek/configuration/default_directive'
+require_lib 'reek/configuration/excluded_paths'
 
 RSpec.describe Reek::Configuration::AppConfiguration do
   describe '#new' do

--- a/spec/reek/configuration/default_directive_spec.rb
+++ b/spec/reek/configuration/default_directive_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/configuration/default_directive'
+require_lib 'reek/configuration/default_directive'
 
 RSpec.describe Reek::Configuration::DefaultDirective do
   describe '#add' do

--- a/spec/reek/configuration/directory_directives_spec.rb
+++ b/spec/reek/configuration/directory_directives_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/configuration/directory_directives'
+require_lib 'reek/configuration/directory_directives'
 
 RSpec.describe Reek::Configuration::DirectoryDirectives do
   describe '#directive_for' do

--- a/spec/reek/configuration/excluded_paths_spec.rb
+++ b/spec/reek/configuration/excluded_paths_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/configuration/excluded_paths'
+require_lib 'reek/configuration/excluded_paths'
 
 RSpec.describe Reek::Configuration::ExcludedPaths do
   describe '#add' do

--- a/spec/reek/context/code_context_spec.rb
+++ b/spec/reek/context/code_context_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/context/method_context'
-require_relative '../../../lib/reek/context/module_context'
+require_lib 'reek/context/method_context'
+require_lib 'reek/context/module_context'
 
 RSpec.describe Reek::Context::CodeContext do
   context 'name recognition' do

--- a/spec/reek/context/method_context_spec.rb
+++ b/spec/reek/context/method_context_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/context/method_context'
+require_lib 'reek/context/method_context'
 
 RSpec.describe Reek::Context::MethodContext do
   let(:method_context) { Reek::Context::MethodContext.new(nil, exp) }

--- a/spec/reek/context/module_context_spec.rb
+++ b/spec/reek/context/module_context_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/context/module_context'
-require_relative '../../../lib/reek/context/root_context'
+require_lib 'reek/context/module_context'
+require_lib 'reek/context/root_context'
 
 RSpec.describe Reek::Context::ModuleContext do
   it 'should report module name for smell in method' do

--- a/spec/reek/context/root_context_spec.rb
+++ b/spec/reek/context/root_context_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/context/root_context'
+require_lib 'reek/context/root_context'
 
 RSpec.describe Reek::Context::RootContext do
   context 'full_name' do

--- a/spec/reek/context/singleton_method_context_spec.rb
+++ b/spec/reek/context/singleton_method_context_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/context/singleton_method_context'
+require_lib 'reek/context/singleton_method_context'
 
 RSpec.describe Reek::Context::SingletonMethodContext do
   let(:smc) do

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../spec_helper'
-require_relative '../../lib/reek/examiner'
+require_lib 'reek/examiner'
 
 RSpec.shared_examples_for 'no smells found' do
   it 'is not smelly' do

--- a/spec/reek/report/html_report_spec.rb
+++ b/spec/reek/report/html_report_spec.rb
@@ -1,7 +1,7 @@
 require 'tempfile'
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/examiner'
-require_relative '../../../lib/reek/report/report'
+require_lib 'reek/examiner'
+require_lib 'reek/report/report'
 
 RSpec.describe Reek::Report::HTMLReport do
   let(:instance) { Reek::Report::HTMLReport.new }

--- a/spec/reek/report/json_report_spec.rb
+++ b/spec/reek/report/json_report_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/examiner'
-require_relative '../../../lib/reek/report/report'
-require_relative '../../../lib/reek/report/formatter'
+require_lib 'reek/examiner'
+require_lib 'reek/report/report'
+require_lib 'reek/report/formatter'
 
 require 'json'
 require 'stringio'

--- a/spec/reek/report/location_formatter_spec.rb
+++ b/spec/reek/report/location_formatter_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/report/formatter'
+require_lib 'reek/report/formatter'
 
 RSpec.describe 'location formatters' do
   let(:warning) { build(:smell_warning, lines: [11, 9, 250, 100]) }

--- a/spec/reek/report/text_report_spec.rb
+++ b/spec/reek/report/text_report_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/examiner'
-require_relative '../../../lib/reek/report/report'
-require_relative '../../../lib/reek/report/formatter'
-require_relative '../../../lib/reek/report/heading_formatter'
+require_lib 'reek/examiner'
+require_lib 'reek/report/report'
+require_lib 'reek/report/formatter'
+require_lib 'reek/report/heading_formatter'
 require 'rainbow'
 
 RSpec.describe Reek::Report::TextReport do

--- a/spec/reek/report/xml_report_spec.rb
+++ b/spec/reek/report/xml_report_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/examiner'
-require_relative '../../../lib/reek/report/report'
+require_lib 'reek/examiner'
+require_lib 'reek/report/report'
 
 RSpec.describe Reek::Report::XMLReport do
   let(:xml_report) { Reek::Report::XMLReport.new }

--- a/spec/reek/report/yaml_report_spec.rb
+++ b/spec/reek/report/yaml_report_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/examiner'
-require_relative '../../../lib/reek/report/report'
-require_relative '../../../lib/reek/report/formatter'
+require_lib 'reek/examiner'
+require_lib 'reek/report/report'
+require_lib 'reek/report/formatter'
 
 require 'yaml'
 require 'stringio'

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/attribute'
+require_lib 'reek/smells/attribute'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::Attribute do

--- a/spec/reek/smells/boolean_parameter_spec.rb
+++ b/spec/reek/smells/boolean_parameter_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/boolean_parameter'
+require_lib 'reek/smells/boolean_parameter'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::BooleanParameter do

--- a/spec/reek/smells/class_variable_spec.rb
+++ b/spec/reek/smells/class_variable_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/class_variable'
-require_relative '../../../lib/reek/context/module_context'
+require_lib 'reek/smells/class_variable'
+require_lib 'reek/context/module_context'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::ClassVariable do

--- a/spec/reek/smells/control_parameter_spec.rb
+++ b/spec/reek/smells/control_parameter_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/control_parameter'
+require_lib 'reek/smells/control_parameter'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::ControlParameter do

--- a/spec/reek/smells/data_clump_spec.rb
+++ b/spec/reek/smells/data_clump_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/data_clump'
+require_lib 'reek/smells/data_clump'
 require_relative 'smell_detector_shared'
 
 RSpec.shared_examples_for 'a data clump detector' do

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/duplicate_method_call'
-require_relative '../../../lib/reek/context/code_context'
-require_relative '../../../lib/reek/tree_walker'
+require_lib 'reek/smells/duplicate_method_call'
+require_lib 'reek/context/code_context'
+require_lib 'reek/tree_walker'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::DuplicateMethodCall do

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/feature_envy'
-require_relative '../../../lib/reek/examiner'
+require_lib 'reek/smells/feature_envy'
+require_lib 'reek/examiner'
 require_relative 'smell_detector_shared'
 
 # TODO: Bring specs in line with specs for other detectors

--- a/spec/reek/smells/irresponsible_module_spec.rb
+++ b/spec/reek/smells/irresponsible_module_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/context/code_context'
-require_relative '../../../lib/reek/smells/irresponsible_module'
+require_lib 'reek/context/code_context'
+require_lib 'reek/smells/irresponsible_module'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::IrresponsibleModule do

--- a/spec/reek/smells/long_parameter_list_spec.rb
+++ b/spec/reek/smells/long_parameter_list_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/context/code_context'
-require_relative '../../../lib/reek/smells/long_parameter_list'
+require_lib 'reek/context/code_context'
+require_lib 'reek/smells/long_parameter_list'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::LongParameterList do

--- a/spec/reek/smells/long_yield_list_spec.rb
+++ b/spec/reek/smells/long_yield_list_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/context/code_context'
-require_relative '../../../lib/reek/smells/long_yield_list'
+require_lib 'reek/context/code_context'
+require_lib 'reek/smells/long_yield_list'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::LongYieldList do

--- a/spec/reek/smells/module_initialize_spec.rb
+++ b/spec/reek/smells/module_initialize_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/module_initialize'
+require_lib 'reek/smells/module_initialize'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::ModuleInitialize do

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/nested_iterators'
+require_lib 'reek/smells/nested_iterators'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::NestedIterators do

--- a/spec/reek/smells/nil_check_spec.rb
+++ b/spec/reek/smells/nil_check_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/context/code_context'
-require_relative '../../../lib/reek/smells/nil_check'
+require_lib 'reek/context/code_context'
+require_lib 'reek/smells/nil_check'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::NilCheck do

--- a/spec/reek/smells/prima_donna_method_spec.rb
+++ b/spec/reek/smells/prima_donna_method_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/context/module_context'
+require_lib 'reek/context/module_context'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::PrimaDonnaMethod do

--- a/spec/reek/smells/repeated_conditional_spec.rb
+++ b/spec/reek/smells/repeated_conditional_spec.rb
@@ -1,8 +1,8 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/repeated_conditional'
-require_relative '../../../lib/reek/context/code_context'
+require_lib 'reek/smells/repeated_conditional'
+require_lib 'reek/context/code_context'
 require_relative 'smell_detector_shared'
-require_relative '../../../lib/reek/source/source_code'
+require_lib 'reek/source/source_code'
 
 RSpec.describe Reek::Smells::RepeatedConditional do
   let(:detector) { build(:smell_detector, smell_type: :RepeatedConditional, source: source_name) }

--- a/spec/reek/smells/smell_configuration_spec.rb
+++ b/spec/reek/smells/smell_configuration_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/smell_configuration'
+require_lib 'reek/smells/smell_configuration'
 
 RSpec.describe Reek::Smells::SmellConfiguration do
   it 'returns the default value when key not found' do

--- a/spec/reek/smells/smell_repository_spec.rb
+++ b/spec/reek/smells/smell_repository_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/smell_detector'
-require_relative '../../../lib/reek/smells/smell_repository'
+require_lib 'reek/smells/smell_detector'
+require_lib 'reek/smells/smell_repository'
 
 RSpec.describe Reek::Smells::SmellRepository do
   describe '.smell_types' do

--- a/spec/reek/smells/smell_warning_spec.rb
+++ b/spec/reek/smells/smell_warning_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/smell_warning'
+require_lib 'reek/smells/smell_warning'
 
 RSpec.describe Reek::Smells::SmellWarning do
   let(:duplication_detector)  { build(:smell_detector, smell_type: 'DuplicateMethodCall') }

--- a/spec/reek/smells/too_many_instance_variables_spec.rb
+++ b/spec/reek/smells/too_many_instance_variables_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/too_many_instance_variables'
+require_lib 'reek/smells/too_many_instance_variables'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::TooManyInstanceVariables do

--- a/spec/reek/smells/too_many_methods_spec.rb
+++ b/spec/reek/smells/too_many_methods_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/too_many_methods'
+require_lib 'reek/smells/too_many_methods'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::TooManyMethods do

--- a/spec/reek/smells/too_many_statements_spec.rb
+++ b/spec/reek/smells/too_many_statements_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/too_many_statements'
+require_lib 'reek/smells/too_many_statements'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::TooManyStatements do

--- a/spec/reek/smells/uncommunicative_method_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_method_name_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/uncommunicative_method_name'
+require_lib 'reek/smells/uncommunicative_method_name'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::UncommunicativeMethodName do

--- a/spec/reek/smells/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_module_name_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/uncommunicative_module_name'
+require_lib 'reek/smells/uncommunicative_module_name'
 require_relative 'smell_detector_shared'
-require_relative '../../../lib/reek/context/code_context'
+require_lib 'reek/context/code_context'
 
 RSpec.describe Reek::Smells::UncommunicativeModuleName do
   let(:source_name) { 'string' }

--- a/spec/reek/smells/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_parameter_name_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/uncommunicative_parameter_name'
+require_lib 'reek/smells/uncommunicative_parameter_name'
 require_relative 'smell_detector_shared'
-require_relative '../../../lib/reek/context/method_context'
+require_lib 'reek/context/method_context'
 
 RSpec.describe Reek::Smells::UncommunicativeParameterName do
   let(:detector) do

--- a/spec/reek/smells/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_variable_name_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/uncommunicative_variable_name'
+require_lib 'reek/smells/uncommunicative_variable_name'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::UncommunicativeVariableName do

--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/unused_parameters'
+require_lib 'reek/smells/unused_parameters'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::UnusedParameters do

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/smells/utility_function'
-require_relative '../../../lib/reek/examiner'
+require_lib 'reek/smells/utility_function'
+require_lib 'reek/examiner'
 require_relative 'smell_detector_shared'
 
 # TODO: Bring specs in line with specs for other detectors

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 require 'stringio'
-require_relative '../../../lib/reek/source/source_code'
+require_lib 'reek/source/source_code'
 
 RSpec.describe Reek::Source::SourceCode do
   describe '#syntax_tree' do

--- a/spec/reek/source/source_locator_spec.rb
+++ b/spec/reek/source/source_locator_spec.rb
@@ -1,7 +1,7 @@
 require 'pathname'
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/configuration/app_configuration'
-require_relative '../../../lib/reek/source/source_locator'
+require_lib 'reek/configuration/app_configuration'
+require_lib 'reek/source/source_locator'
 
 RSpec.describe Reek::Source::SourceLocator do
   describe '#sources' do

--- a/spec/reek/spec/should_reek_of_spec.rb
+++ b/spec/reek/spec/should_reek_of_spec.rb
@@ -1,6 +1,6 @@
 require 'pathname'
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/spec'
+require_lib 'reek/spec'
 
 RSpec.describe Reek::Spec::ShouldReekOf do
   context 'rdoc demo example' do

--- a/spec/reek/spec/should_reek_only_of_spec.rb
+++ b/spec/reek/spec/should_reek_only_of_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/spec'
+require_lib 'reek/spec'
 
 RSpec.describe Reek::Spec::ShouldReekOnlyOf do
   let(:examiner) { double('examiner').as_null_object }

--- a/spec/reek/spec/should_reek_spec.rb
+++ b/spec/reek/spec/should_reek_spec.rb
@@ -1,5 +1,5 @@
 require_relative '../../spec_helper'
-require_relative '../../../lib/reek/spec'
+require_lib 'reek/spec'
 
 RSpec.describe Reek::Spec::ShouldReek do
   describe 'checking code in a string' do

--- a/spec/reek/tree_dresser_spec.rb
+++ b/spec/reek/tree_dresser_spec.rb
@@ -1,10 +1,10 @@
-require_relative '../../lib/reek/cli/silencer'
+require_lib 'reek/cli/silencer'
 Reek::CLI::Silencer.silently do
   require 'parser/ruby22'
 end
 
 require_relative '../spec_helper'
-require_relative '../../lib/reek/tree_dresser'
+require_lib 'reek/tree_dresser'
 
 RSpec.describe Reek::TreeDresser do
   let(:dresser) { described_class.new }

--- a/spec/reek/tree_walker_spec.rb
+++ b/spec/reek/tree_walker_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../spec_helper'
-require_relative '../../lib/reek/tree_walker'
-require_relative '../../lib/reek/source/source_code'
+require_lib 'reek/tree_walker'
+require_lib 'reek/source/source_code'
 
 # Dummy repository to inject into TreeWalker in order to count statements in
 # all contexts.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,3 +52,9 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 end
+
+private
+
+def require_lib(path)
+  require_relative "../lib/#{path}"
+end


### PR DESCRIPTION
As per [the recent discussion](https://github.com/troessner/reek/pull/711#discussion_r39927347) this introduces a private, top-level `require_lib_reek` for use in specs to shorten the `require_relative '../../..`… trainwrecks.