### PR TITLE
SendNode: don’t blow up on arg-less attr calls

### DIFF
--- a/lib/reek/ast/sexp_extensions.rb
+++ b/lib/reek/ast/sexp_extensions.rb
@@ -196,7 +196,7 @@ module Reek
         # Handles the case where we create an attribute writer via:
         # attr :foo, true
         def attr_with_writable_flag?
-          method_name == :attr && args.last.type == :true
+          method_name == :attr && args.any? && args.last.type == :true
         end
 
         VISIBILITY_MODIFIERS = [:private, :public, :protected, :module_function]

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -254,6 +254,10 @@ RSpec.describe Reek::AST::SexpExtensions::SendNode do
     it 'has no argument names' do
       expect(node.arg_names).to eq []
     end
+
+    it 'is not considered to be a writable attr' do
+      expect(sexp(:send, nil, :attr).attr_with_writable_flag?).to be_falsey
+    end
   end
 
   context 'with 1 literal parameter' do


### PR DESCRIPTION
Fixes #708.