### PR TITLE
adds tests for existing functionality of SmellWarning#matches? 

### DIFF
--- a/spec/reek/smells/smell_warning_spec.rb
+++ b/spec/reek/smells/smell_warning_spec.rb
@@ -86,6 +86,34 @@ RSpec.describe Reek::Smells::SmellWarning do
     end
   end
 
+  context '#matches?' do
+    let(:uncommunicative) do
+      uncommunicative_name_detector = build(:smell_detector,
+                                            smell_type: 'UncommunicativeVariableName')
+      build(:smell_warning, smell_detector: uncommunicative_name_detector,
+                            message: "has the variable name '@s'",
+                            parameters: { test: 'something' })
+    end
+
+    it 'matches on class symbol' do
+      expect(uncommunicative.matches?(:UncommunicativeVariableName)).to be_truthy
+    end
+
+    it 'matches on class symbol and params' do
+      expect(uncommunicative.matches?(:UncommunicativeVariableName,
+                                      test: 'something')).to be_truthy
+    end
+
+    it 'does not match on different class symbol' do
+      expect(uncommunicative.matches?(:FeatureEnvy)).to be_falsy
+    end
+
+    it 'does not match on different params' do
+      expect(uncommunicative.matches?(:UncommunicativeVariableName,
+                                      test: 'something else')).to be_falsy
+    end
+  end
+
   context '#yaml_hash' do
     let(:class) { 'FeatureEnvy' }
     let(:context_name) { 'Module::Class#method/block' }


### PR DESCRIPTION
This is prep for more sophisticated version that will check more than just class name and params; but assuming it's best to start with a small pull request so we can check that I'm fitting in with the way the project is currently doing things, before I go on and code lots more.

Existing discussion on this feature and the approach here: https://github.com/troessner/reek/issues/589