### PR TITLE
‘Foo = new’ syntax support

### DIFF
--- a/lib/reek/ast/sexp_extensions.rb
+++ b/lib/reek/ast/sexp_extensions.rb
@@ -180,6 +180,14 @@ module Reek
           args.map { |arg| arg[1] }
         end
 
+        def module_creation_call?
+          object_creation_call? && module_creation_receiver?
+        end
+
+        def module_creation_receiver?
+          receiver && [:Class, :Struct].include?(receiver.simple_name)
+        end
+
         def object_creation_call?
           method_name == :new
         end
@@ -420,8 +428,6 @@ module Reek
       module CasgnNode
         include ModuleNodeBase
 
-        MODULE_DEFINERS = [:Class, :Struct]
-
         def defines_module?
           return false unless value
           call = case value.type
@@ -430,9 +436,7 @@ module Reek
                  when :send
                    value
                  end
-          call &&
-            call.object_creation_call? &&
-            MODULE_DEFINERS.include?(call.receiver.simple_name)
+          call && call.module_creation_call?
         end
 
         def name

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -260,6 +260,22 @@ RSpec.describe Reek::AST::SexpExtensions::SendNode do
     end
   end
 
+  context 'when it’s ‘new’ with no parameters and no receiver' do
+    let(:bare_new) { sexp(:send, nil, :new) }
+
+    it 'is not considered to be a module creation call' do
+      expect(bare_new.module_creation_call?).to be_falsey
+    end
+
+    it 'is not considered to have a module creation receiver' do
+      expect(bare_new.module_creation_receiver?).to be_falsey
+    end
+
+    it 'is considered to be an object creation call' do
+      expect(bare_new.object_creation_call?).to be_truthy
+    end
+  end
+
   context 'with 1 literal parameter' do
     let(:node) { sexp(:send, nil, :hello, sexp(:lit, :param)) }
 
@@ -357,7 +373,14 @@ RSpec.describe Reek::AST::SexpExtensions::CasgnNode do
     end
 
     it 'does not define a module' do
-      expect(subject.defines_module?).to eq(false)
+      expect(subject.defines_module?).to be_falsey
+    end
+  end
+
+  context 'with implicit receiver to new' do
+    it 'does not define a module' do
+      exp = sexp(:casgn, nil, :Foo, sexp(:send, nil, :new))
+      expect(exp.defines_module?).to be_falsey
     end
   end
 end


### PR DESCRIPTION
I don’t think it’s feasible (or even possible) to statically infer whether `Foo = new` creates a `Module`, a `Class` or some other object, so this assumes this is not a module-creation call.

Fixes #715.