### PR TITLE
Get rid of all deprecated methods in AST::Node.

### DIFF
--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -31,18 +31,8 @@ module Reek
         comment_lines.map(&:text).join("\n")
       end
 
-      # @deprecated
-      def [](index)
-        elements[index]
-      end
-
       def line
         loc && loc.line
-      end
-
-      # @deprecated
-      def first
-        type
       end
 
       #
@@ -128,10 +118,6 @@ module Reek
 
       def each_sexp
         children.each { |elem| yield elem if elem.is_a? ::Parser::AST::Node }
-      end
-
-      def elements
-        [type, *children]
       end
     end
   end

--- a/lib/reek/ast/sexp_extensions.rb
+++ b/lib/reek/ast/sexp_extensions.rb
@@ -120,10 +120,10 @@ module Reek
 
       # Base module for utility methods for :and and :or nodes.
       module LogicOperatorBase
-        def condition() self[1] end
+        def condition() children.first end
 
         def body_nodes(type, ignoring = [])
-          self[2].find_nodes type, ignoring
+          children[1].find_nodes type, ignoring
         end
       end
 
@@ -139,12 +139,12 @@ module Reek
 
       # Utility methods for :attrasgn nodes.
       module AttrasgnNode
-        def args() self[3] end
+        def args() children[2] end
       end
 
       # Utility methods for :case nodes.
       module CaseNode
-        def condition() self[1] end
+        def condition() children.first end
 
         def body_nodes(type, ignoring = [])
           children[1..-1].compact.flat_map { |child| child.find_nodes(type, ignoring) }
@@ -177,7 +177,7 @@ module Reek
         end
 
         def arg_names
-          args.map { |arg| arg[1] }
+          args.map { |arg| arg.children.first }
         end
 
         def module_creation_call?
@@ -215,7 +215,7 @@ module Reek
 
       # Base module for utility methods for nodes representing variables.
       module VariableBase
-        def name() self[1] end
+        def name() children.first end
       end
 
       # Utility methods for :cvar nodes.
@@ -301,11 +301,11 @@ module Reek
 
       # Utility methods for :def nodes.
       module DefNode
-        def name() self[1] end
-        def argslist() self[2] end
+        def name() children.first end
+        def argslist() children[1] end
 
         def body
-          self[3]
+          children[2]
         end
 
         def full_name(outer)
@@ -323,12 +323,12 @@ module Reek
 
       # Utility methods for :defs nodes.
       module DefsNode
-        def receiver() self[1] end
-        def name() self[2] end
-        def argslist() self[3] end
+        def receiver() children.first end
+        def name() children[1] end
+        def argslist() children[2] end
 
         def body
-          self[4]
+          children[3]
         end
 
         include MethodNodeBase
@@ -345,7 +345,7 @@ module Reek
 
       # Utility methods for :if nodes.
       module IfNode
-        def condition() self[1] end
+        def condition() children.first end
 
         def body_nodes(type, ignoring = [])
           children[1..-1].compact.flat_map { |child| child.find_nodes(type, ignoring) }
@@ -354,13 +354,13 @@ module Reek
 
       # Utility methods for :block nodes.
       module BlockNode
-        def call() self[1] end
-        def args() self[2] end
-        def block() self[3] end
-        def parameters() self[2] || [] end
+        def call() children.first end
+        def args() children[1] end
+        def block() children[2] end
+        def parameters() children[1] || [] end
 
         def parameter_names
-          parameters[1..-1].to_a
+          parameters.children
         end
 
         def simple_name
@@ -370,7 +370,7 @@ module Reek
 
       # Utility methods for :lit nodes.
       module LitNode
-        def value() self[1] end
+        def value() children.first end
       end
 
       # Utility methods for :const nodes.
@@ -425,7 +425,7 @@ module Reek
       # Utility methods for :class nodes.
       module ClassNode
         include ModuleNode
-        def superclass() self[2] end
+        def superclass() children[1] end
       end
 
       # Utility methods for :casgn nodes.
@@ -464,7 +464,7 @@ module Reek
 
       # Utility methods for :yield nodes.
       module YieldNode
-        def args() self[1..-1] end
+        def args() children end
 
         def arg_names
           args.map { |arg| arg[1] }

--- a/lib/reek/smells/boolean_parameter.rb
+++ b/lib/reek/smells/boolean_parameter.rb
@@ -25,7 +25,7 @@ module Reek
       # :reek:FeatureEnvy
       def examine_context(ctx)
         ctx.default_assignments.select do |_param, value|
-          [:true, :false].include?(value[0])
+          [:true, :false].include?(value.type)
         end.map do |parameter, _value|
           smell_warning(
             context: ctx,

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -39,7 +39,7 @@ module Reek
       #
       def examine_context(ctx)
         max_allowed_ivars = value(MAX_ALLOWED_IVARS_KEY, ctx, DEFAULT_MAX_IVARS)
-        count = ctx.local_nodes(:ivasgn).map { |ivasgn| ivasgn[1] }.uniq.length
+        count = ctx.local_nodes(:ivasgn).map { |ivasgn| ivasgn.children.first }.uniq.length
         return [] if count <= max_allowed_ivars
         [smell_warning(
           context: ctx,

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -83,18 +83,18 @@ module Reek
       def find_assignment_variable_names(exp, accumulator)
         assignment_nodes = exp.each_node(:lvasgn, [:class, :module, :defs, :def])
 
-        case exp.first
+        case exp.type
         when :class, :module
           assignment_nodes += exp.each_node(:ivasgn, [:class, :module])
         end
 
-        assignment_nodes.each { |asgn| accumulator[asgn[1]].push(asgn.line) }
+        assignment_nodes.each { |asgn| accumulator[asgn.children.first].push(asgn.line) }
       end
 
       # :reek:FeatureEnvy
       # :reek:TooManyStatements: { max_statements: 6 }
       def find_block_argument_variable_names(exp, accumulator)
-        arg_search_exp = case exp.first
+        arg_search_exp = case exp.type
                          when :class, :module
                            exp
                          when :defs, :def

--- a/lib/reek/tree_walker.rb
+++ b/lib/reek/tree_walker.rb
@@ -140,14 +140,15 @@ module Reek
     alias_method :process_kwbegin, :process_begin
 
     def process_if(exp)
-      count_clause(exp[2])
-      count_clause(exp[3])
+      children = exp.children
+      count_clause(children[1])
+      count_clause(children[2])
       element.count_statements(-1)
       process_default(exp)
     end
 
     def process_while(exp)
-      count_clause(exp[2])
+      count_clause(exp.children[1])
       element.count_statements(-1)
       process_default(exp)
     end
@@ -155,19 +156,19 @@ module Reek
     alias_method :process_until, :process_while
 
     def process_for(exp)
-      count_clause(exp[3])
+      count_clause(exp.children[2])
       element.count_statements(-1)
       process_default(exp)
     end
 
     def process_rescue(exp)
-      count_clause(exp[1])
+      count_clause(exp.children.first)
       element.count_statements(-1)
       process_default(exp)
     end
 
     def process_resbody(exp)
-      count_statement_list(exp[2..-1].compact)
+      count_statement_list(exp.children[1..-1].compact)
       process_default(exp)
     end
 

--- a/spec/reek/context/code_context_spec.rb
+++ b/spec/reek/context/code_context_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Reek::Context::CodeContext do
       end
 
       it "yields the method's full AST" do
-        ctx.each_node(:def, []) { |exp| expect(exp[1]).to eq(:calloo) }
+        ctx.each_node(:def, []) { |exp| expect(exp.children.first).to eq(:calloo) }
       end
 
       context 'pruning the traversal' do


### PR DESCRIPTION
Fixes #546

I believe "first" and "[]" were misleading, artificial and confusing abstractions that added complexity but no value.

Oh, and they **always** tripped me up.;)