### PR TITLE
Use non-deprecated method for configuring Aruba

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -37,5 +37,7 @@ World do
 end
 
 Before do
-  @aruba_timeout_seconds = 30
+  Aruba.configure do |config|
+    config.exit_timeout = 30
+  end
 end


### PR DESCRIPTION
Just a tiny fix ...