### PR TITLE
Refactor NestedIterators.

### DIFF
--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -10,6 +10,16 @@ module Reek
     #
     # See {file:docs/Nested-Iterators.md} for details.
     class NestedIterators < SmellDetector
+      # Struct for conveniently associating iterators with their depth (that is, their nesting).
+      Iterator = Struct.new :exp, :depth do
+        include Comparable
+        def <=>(other)
+          depth <=> other.depth
+        end
+      end
+
+      private_attr_accessor :ignore_iterators
+
       # The name of the config field that sets the maximum depth
       # of nested iterators to be permitted within any single method.
       MAX_ALLOWED_NESTING_KEY = 'max_allowed_nesting'
@@ -28,47 +38,84 @@ module Reek
       end
 
       #
-      # Checks whether the given +block+ is inside another.
+      # Attempts to find the deepest nested iterator and warns if it's depth
+      # is bigger than our allowed maximum.
       #
       # @return [Array<SmellWarning>]
       #
+      # :reek:TooManyStatements: { max_statements: 6 }
       def examine_context(ctx)
-        exp, depth = *find_deepest_iterator(ctx)
+        configure_ignore_iterators(ctx)
+        deepest_iterator = find_deepest_iterator ctx
+        return [] unless deepest_iterator
+        depth = deepest_iterator.depth
+        return [] unless depth > max_nesting(ctx)
 
-        if depth && depth > value(MAX_ALLOWED_NESTING_KEY, ctx, DEFAULT_MAX_ALLOWED_NESTING)
-          [smell_warning(
-            context: ctx,
-            lines: [exp.line],
-            message: "contains iterators nested #{depth} deep",
-            parameters: { name: ctx.full_name, count: depth })]
-        else
-          []
-        end
+        [smell_warning(
+          context: ctx,
+          lines: [deepest_iterator.exp.line],
+          message: "contains iterators nested #{depth} deep",
+          parameters: { name: ctx.full_name, count: depth })]
       end
 
       private
 
-      private_attr_accessor :ignore_iterators
-
+      #
+      # @return [Iterator|nil]
+      #
       def find_deepest_iterator(ctx)
-        self.ignore_iterators = value(IGNORE_ITERATORS_KEY, ctx, DEFAULT_IGNORE_ITERATORS)
-
-        find_iters(ctx.exp, 1).sort_by { |item| item[1] }.last
+        exp = ctx.exp
+        return nil unless exp.find_nodes([:block])
+        scout(parent: exp, exp: exp, depth: 0).
+          flatten.
+          sort.
+          last
       end
 
-      def find_iters(exp, depth)
-        return [] unless exp
-        exp.find_nodes([:block]).flat_map do |elem|
-          find_iters_for_iter_node(elem, depth)
+      # A little digression into parser's sexp is necessary here:
+      #
+      # Given
+      #   foo.each() do ... end
+      # this will end up as:
+      #
+      # "foo.each() do ... end" -> the iterator below
+      # "each()"                -> the "call" below
+      # "do ... end"            -> the "block" below
+      #
+      # @param parent [AST::Node] The parent iterator
+      #
+      # @param exp [AST::Node]
+      #   The given expression to analyze.
+      #   Will be nil on empty blocks so we'll return just the parent iterator
+      #
+      # @param depth [Integer]
+      #
+      # @return [Array<Iterator>]
+      #
+      def scout(parent: raise, exp: raise, depth: raise)
+        return [Iterator.new(parent, depth)] unless exp
+        iterators = exp.find_nodes([:block])
+        return [Iterator.new(parent, depth)] if iterators.empty?
+        iterators.map do |iterator|
+          # 1st case: we recurse down the given block of the iterator. In this case
+          # we need to check if we should increment the depth.
+          # 2nd case: we recurse down the associated call of the iterator. In this case
+          # the depth stays the same.
+          scout(parent: iterator, exp: iterator.block, depth: increment_depth(iterator, depth)) +
+            scout(parent: iterator, exp: iterator.call, depth: depth)
         end
       end
 
-      def find_iters_for_iter_node(exp, depth)
-        ignored = ignored_iterator? exp
-        result = find_iters(exp.call, depth) +
-          find_iters(exp.block, depth + (ignored ? 0 : 1))
-        result << [exp, depth] unless ignored
-        result
+      def configure_ignore_iterators(ctx)
+        self.ignore_iterators = value(IGNORE_ITERATORS_KEY, ctx, DEFAULT_IGNORE_ITERATORS)
+      end
+
+      def increment_depth(iterator, depth)
+        ignored_iterator?(iterator) ? depth : depth + 1
+      end
+
+      def max_nesting(ctx)
+        value(MAX_ALLOWED_NESTING_KEY, ctx, DEFAULT_MAX_ALLOWED_NESTING)
       end
 
       # :reek:FeatureEnvy


### PR DESCRIPTION
While working on #729 I figured that we have to refactor NestedIterators.

Why, you ask?

1.) It's spaghetti code at it's best. "find_iters" calls "find_iters_for_iter_node". Which then calls "find_iters". Which then calls "find_iters_for_iter_node". You see where I'm going with this, don't you? ;)
2.) It's not a real recursion (see [1]) which it should be, given that we are traversing trees
3.) It's very hard to read and understand. I'd call that "unmaintainable"
4.) It's not documented at all.

So, let's fix all the things!

Please find below my humble attempt to improve this.
I believe the refactoring below addresses all of the issues mentioned above and will allow us to extend NestedIterators in the future if necessary.