### PR TITLE
Bump Parser

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
   s.summary = 'Code smell detector for Ruby'
 
-  s.add_runtime_dependency 'parser',       '~> 2.2.2.5'
+  s.add_runtime_dependency 'parser',       '~> 2.2', '>= 2.2.2.5'
   s.add_runtime_dependency 'private_attr', '~> 1.1'
   s.add_runtime_dependency 'rainbow',      '~> 2.0'
   s.add_runtime_dependency 'unparser',     '~> 0.2.2'


### PR DESCRIPTION
Parser 2.2.3.0 got released and it seems Reek can use it just fine.

I’m unhappy with this PR, though: some time ago we agreed that Parser’s versioning is at odds with SemVer and – since it’s crucial to Reek’s operations – we should be strict about this dependency. That said, making us depend on `parser ~> 2.2.3.0` means that Reek can’t be used alongside tools with a Parser 2.2.2.x dependency; one could argue that this is actually a breaking change.

We know that Reek works with Parser 2.2.2.5+ and assume it’ll work with any 2.2.3.x. Maybe we should do the dependency like this?

```Ruby
 s.add_runtime_dependency 'parser', '>= 2.2.2.5', '< 2.2.4'
```