### PR TITLE
Unified smell warning interface

### DIFF
--- a/lib/reek/smells/smell_warning.rb
+++ b/lib/reek/smells/smell_warning.rb
@@ -9,7 +9,6 @@ module Reek
     # @public
     #
     # :reek:TooManyInstanceVariables: { max_instance_variables: 6 }
-    # :reek:TooManyStatements: { max_statements: 6 }
     class SmellWarning
       include Comparable
       extend Forwardable
@@ -17,8 +16,6 @@ module Reek
       # @public
       attr_reader :context, :lines, :message, :parameters, :smell_detector, :source
       def_delegators :smell_detector, :smell_category, :smell_type
-
-      COMPARABLE_ATTRIBUTES = %i(message lines context source)
 
       # @note When using reek's public API, you should not create SmellWarning
       #   objects yourself. This is why the initializer is not part of the
@@ -52,24 +49,6 @@ module Reek
         (self <=> other) == 0
       end
 
-      def matches_smell_type?(klass)
-        smell_classes.include?(klass.to_s)
-      end
-
-      def matches_attributes?(attributes = {})
-        check_attributes_comparability(attributes)
-        main_attributes = attributes.slice(*COMPARABLE_ATTRIBUTES)
-        paramater_attributes = attributes.except(*COMPARABLE_ATTRIBUTES)
-        return false unless common_parameters_equal?(paramater_attributes)
-        main_attributes.all? do |other_key, other_value|
-          send(other_key) == other_value
-        end
-      end
-
-      def matches?(klass, attributes = {})
-        matches_smell_type?(klass) && matches_attributes?(attributes)
-      end
-
       def report_on(listener)
         listener.found_smell(self)
       end
@@ -92,21 +71,6 @@ module Reek
       end
 
       private
-
-      def smell_classes
-        [smell_detector.smell_category, smell_detector.smell_type]
-      end
-
-      def check_attributes_comparability(other_attributes)
-        parameter_keys = other_attributes.keys - COMPARABLE_ATTRIBUTES
-        extra_keys = parameter_keys - parameters.keys
-        return if extra_keys.empty?
-        raise ArgumentError, "The attribute '#{extra_keys.first}' is not available for comparison"
-      end
-
-      def common_parameters_equal?(other_parameters)
-        parameters.slice(*other_parameters.keys) == other_parameters
-      end
 
       def core_yaml_hash
         {

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -1,4 +1,5 @@
 require_relative '../examiner'
+require_relative 'smell_matcher'
 
 module Reek
   module Spec
@@ -39,8 +40,12 @@ module Reek
       end
 
       def matching_smell_types
-        @matching_smell_types ||= examiner.smells.
-          select { |warning| warning.matches_smell_type?(smell_category) }
+        @matching_smell_types ||= smell_matchers.
+          select { |it| it.matches_smell_type?(smell_category) }
+      end
+
+      def smell_matchers
+        examiner.smells.map { |it| SmellMatcher.new(it) }
       end
 
       def matching_smell_types?

--- a/lib/reek/spec/should_reek_only_of.rb
+++ b/lib/reek/spec/should_reek_only_of.rb
@@ -1,6 +1,7 @@
 require_relative '../examiner'
 require_relative '../report/formatter'
 require_relative 'should_reek_of'
+require_relative 'smell_matcher'
 
 module Reek
   module Spec
@@ -17,7 +18,7 @@ module Reek
         self.examiner = examiner
         self.warnings = examiner.smells
         return false if warnings.empty?
-        warnings.all? { |warning| warning.matches?(smell_category) }
+        warnings.all? { |warning| SmellMatcher.new(warning).matches?(smell_category) }
       end
 
       def failure_message

--- a/lib/reek/spec/smell_matcher.rb
+++ b/lib/reek/spec/smell_matcher.rb
@@ -1,0 +1,59 @@
+module Reek
+  module Spec
+    #
+    # Matches a +SmellWarning+ object agains a smell type and hash of attributes.
+    #
+    class SmellMatcher
+      attr_reader :smell_warning
+
+      COMPARABLE_ATTRIBUTES = %i(message lines context source)
+
+      def initialize(smell_warning)
+        @smell_warning = smell_warning
+      end
+
+      def matches?(klass, attributes = {})
+        matches_smell_type?(klass) && matches_attributes?(attributes)
+      end
+
+      def matches_smell_type?(klass)
+        smell_classes.include?(klass.to_s)
+      end
+
+      def matches_attributes?(attributes)
+        check_attributes_comparability(attributes)
+
+        # FIXME: Use Array#to_h when dropping Ruby 2.0 compatibility.
+        fields, params = attributes.
+          partition { |key, _| COMPARABLE_ATTRIBUTES.include? key }.
+          map { |arr| Hash[arr] }
+
+        common_parameters_equal?(params) &&
+          common_attributes_equal?(fields)
+      end
+
+      private
+
+      def smell_classes
+        [smell_warning.smell_category, smell_warning.smell_type]
+      end
+
+      def check_attributes_comparability(other_attributes)
+        parameter_keys = other_attributes.keys - COMPARABLE_ATTRIBUTES
+        extra_keys = parameter_keys - smell_warning.parameters.keys
+        return if extra_keys.empty?
+        raise ArgumentError, "The attribute '#{extra_keys.first}' is not available for comparison"
+      end
+
+      def common_parameters_equal?(other_parameters)
+        smell_warning.parameters.slice(*other_parameters.keys) == other_parameters
+      end
+
+      def common_attributes_equal?(attributes)
+        attributes.all? do |other_key, other_value|
+          smell_warning.send(other_key) == other_value
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -26,7 +26,6 @@ FactoryGirl.define do
     skip_create
     transient do
       smell_type 'FeatureEnvy'
-      source 'foo'
     end
 
     initialize_with do

--- a/spec/reek/context/module_context_spec.rb
+++ b/spec/reek/context/module_context_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Reek::Context::ModuleContext do
       module Fred
         def simple(x) x + 1; end
       end
-    ').to reek_of(:UncommunicativeParameterName, parameters: { name: 'x' })
+    ').to reek_of(:UncommunicativeParameterName, name: 'x')
   end
 
   it 'should not report module with empty class' do

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr_writer :my_attr
         end
       EOS
-      expect(src).to reek_of(:Attribute, parameters: { name: 'my_attr' })
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
     end
 
     it 'records attr_writer attribute in a module' do
@@ -43,7 +43,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr_writer :my_attr
         end
       EOS
-      expect(src).to reek_of(:Attribute, parameters: { name: 'my_attr' })
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
     end
 
     it 'records accessor attribute' do
@@ -52,7 +52,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr_accessor :my_attr
         end
       EOS
-      expect(src).to reek_of(:Attribute, parameters: { name: 'my_attr' })
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
     end
 
     it 'records attr defining a writer' do
@@ -61,7 +61,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr :my_attr, true
         end
       EOS
-      expect(src).to reek_of(:Attribute, parameters: { name: 'my_attr' })
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
     end
 
     it "doesn't record protected attributes" do
@@ -100,7 +100,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr_writer :my_attr
         end
       EOS
-      expect(src).to reek_of(:Attribute, parameters: { name: 'my_attr' })
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
     end
 
     it 'records attr_writer after switching visbility to public' do
@@ -111,7 +111,7 @@ RSpec.describe Reek::Smells::Attribute do
           public :my_attr
         end
       EOS
-      expect(src).to reek_of(:Attribute, parameters: { name: 'my_attr' })
+      expect(src).to reek_of(:Attribute, name: 'my_attr')
     end
 
     it 'resets visibility in new contexts' do

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -3,8 +3,7 @@ require_lib 'reek/smells/attribute'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::Attribute do
-  let(:detector) { build(:smell_detector, smell_type: :Attribute, source: source_name) }
-  let(:source_name) { 'source' }
+  let(:detector) { build(:smell_detector, smell_type: :Attribute) }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/boolean_parameter_spec.rb
+++ b/spec/reek/smells/boolean_parameter_spec.rb
@@ -7,24 +7,24 @@ RSpec.describe Reek::Smells::BooleanParameter do
     context 'in a method' do
       it 'reports a parameter defaulted to true' do
         src = 'def cc(arga = true); arga; end'
-        expect(src).to reek_of(:BooleanParameter, parameters: { name: 'arga' })
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
       end
 
       it 'reports a parameter defaulted to false' do
         src = 'def cc(arga = false) end'
-        expect(src).to reek_of(:BooleanParameter, parameters: { name: 'arga' })
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
       end
 
       it 'reports two parameters defaulted to booleans' do
         src = 'def cc(nowt, arga = true, argb = false, &blk) end'
-        expect(src).to reek_of(:BooleanParameter, parameters: { name: 'arga' })
-        expect(src).to reek_of(:BooleanParameter, parameters: { name: 'argb' })
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, name: 'argb')
       end
 
       it 'reports keyword parameters defaulted to booleans' do
         src = 'def cc(arga: true, argb: false) end'
-        expect(src).to reek_of(:BooleanParameter, parameters: { name: 'arga' })
-        expect(src).to reek_of(:BooleanParameter, parameters: { name: 'argb' })
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, name: 'argb')
       end
 
       it 'does not report regular parameters' do
@@ -51,16 +51,16 @@ RSpec.describe Reek::Smells::BooleanParameter do
     context 'in a singleton method' do
       it 'reports a parameter defaulted to true' do
         src = 'def self.cc(arga = true) end'
-        expect(src).to reek_of(:BooleanParameter, parameters: { name: 'arga' })
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
       end
       it 'reports a parameter defaulted to false' do
         src = 'def fred.cc(arga = false) end'
-        expect(src).to reek_of(:BooleanParameter, parameters: { name: 'arga' })
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
       end
       it 'reports two parameters defaulted to booleans' do
         src = 'def Module.cc(nowt, arga = true, argb = false, &blk) end'
-        expect(src).to reek_of(:BooleanParameter, parameters: { name: 'arga' })
-        expect(src).to reek_of(:BooleanParameter, parameters: { name: 'argb' })
+        expect(src).to reek_of(:BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, name: 'argb')
       end
     end
   end

--- a/spec/reek/smells/boolean_parameter_spec.rb
+++ b/spec/reek/smells/boolean_parameter_spec.rb
@@ -66,21 +66,23 @@ RSpec.describe Reek::Smells::BooleanParameter do
   end
 
   context 'when a smell is reported' do
-    let(:detector) { build(:smell_detector, smell_type: :BooleanParameter, source: source_name) }
-    let(:source_name) { 'string' }
+    let(:detector) { build(:smell_detector, smell_type: :BooleanParameter) }
 
     it_should_behave_like 'SmellDetector'
 
-    it 'reports the fields correctly' do
-      src = 'def cc(arga = true) end'
-      ctx = Reek::Context::MethodContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      smells = detector.examine_context(ctx)
-      expect(smells.length).to eq(1)
-      expect(smells[0].smell_category).to eq(described_class.smell_category)
-      expect(smells[0].parameters[:name]).to eq('arga')
-      expect(smells[0].source).to eq(source_name)
-      expect(smells[0].smell_type).to eq(described_class.smell_type)
-      expect(smells[0].lines).to eq([1])
+    context 'when a smell is reported' do
+      let(:warning) do
+        src = 'def cc(arga = true) end'
+        ctx = Reek::Context::MethodContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
+        detector.examine_context(ctx).first
+      end
+
+      it_should_behave_like 'common fields set correctly'
+
+      it 'reports the correct values' do
+        expect(warning.parameters[:name]).to eq('arga')
+        expect(warning.lines).to eq([1])
+      end
     end
   end
 end

--- a/spec/reek/smells/class_variable_spec.rb
+++ b/spec/reek/smells/class_variable_spec.rb
@@ -5,8 +5,7 @@ require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::ClassVariable do
   let(:class_variable) { '@@things' }
-  let(:detector) { build(:smell_detector, smell_type: :ClassVariable, source: source_name) }
-  let(:source_name) { 'string' }
+  let(:detector) { build(:smell_detector, smell_type: :ClassVariable) }
 
   it_should_behave_like 'SmellDetector'
 
@@ -78,18 +77,22 @@ RSpec.describe Reek::Smells::ClassVariable do
     end
   end
 
-  it 'reports the correct fields' do
-    src = <<-EOS
-      module Fred
-        #{class_variable} = {}
-      end
-    EOS
-    ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-    warning = detector.examine_context(ctx)[0]
-    expect(warning.source).to eq(source_name)
-    expect(warning.smell_category).to eq(described_class.smell_category)
-    expect(warning.smell_type).to eq(described_class.smell_type)
-    expect(warning.parameters[:name]).to eq(class_variable)
-    expect(warning.lines).to eq([2])
+  context 'when a smell is reported' do
+    let(:warning) do
+      src = <<-EOS
+        module Fred
+          #{class_variable} = {}
+        end
+      EOS
+      ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
+      detector.examine_context(ctx).first
+    end
+
+    it_should_behave_like 'common fields set correctly'
+
+    it 'reports the correct values' do
+      expect(warning.parameters[:name]).to eq(class_variable)
+      expect(warning.lines).to eq([2])
+    end
   end
 end

--- a/spec/reek/smells/control_parameter_spec.rb
+++ b/spec/reek/smells/control_parameter_spec.rb
@@ -32,72 +32,72 @@ RSpec.describe Reek::Smells::ControlParameter do
   context 'parameter only used to determine code path' do
     it 'reports a ternary check on a parameter' do
       src = 'def simple(arga) arga ? @ivar : 3 end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arga' })
+      expect(src).to reek_of(:ControlParameter, name: 'arga')
     end
 
     it 'reports a couple inside a block' do
       src = 'def blocks(arg) @text.map { |blk| arg ? blk : "#{blk}" } end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on an if statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => \'A\') if arg end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on an unless statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => \'A\') unless arg end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression' do
       src = 'def simple(arg) args = {}; if arg then args.merge(\'a\' => \'A\') end end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with &&' do
       src = 'def simple(arg) if arg && true then puts "arg" end end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with preceding &&' do
       src = 'def simple(arg) if true && arg then puts "arg" end end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with two && conditions' do
       src = 'def simple(a) ag = {}; if a && true && true then puts "2" end end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'a' })
+      expect(src).to reek_of(:ControlParameter, name: 'a')
     end
 
     it 'reports on if control expression with ||' do
       src = 'def simple(arg) args = {}; if arg || true then puts "arg" end end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with or' do
       src = 'def simple(arg) args = {}; if arg or true then puts "arg" end end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on if control expression with if' do
       src = 'def simple(arg) args = {}; if (arg if true) then puts "arg" end end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on && notation' do
       src = 'def simple(arg) args = {}; arg && args.merge(\'a\' => \'A\') end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on || notation' do
       src = 'def simple(arg) args = {}; arg || args.merge(\'a\' => \'A\') end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on case statement' do
       src = 'def simple(arg) case arg when nil; nil when false; nil else nil end end'
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on nested if statements that are both control parameters' do
@@ -109,7 +109,7 @@ RSpec.describe Reek::Smells::ControlParameter do
           end
         end
       EOS
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on nested if statements where the inner if is a control parameter' do
@@ -121,7 +121,7 @@ RSpec.describe Reek::Smells::ControlParameter do
           end
         end
       EOS
-      expect(src).to reek_of(:ControlParameter, parameters: { name: 'arg' })
+      expect(src).to reek_of(:ControlParameter, name: 'arg')
     end
 
     it 'reports on explicit comparison in the condition' do

--- a/spec/reek/smells/control_parameter_spec.rb
+++ b/spec/reek/smells/control_parameter_spec.rb
@@ -3,8 +3,7 @@ require_lib 'reek/smells/control_parameter'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::ControlParameter do
-  let(:detector) { build(:smell_detector, smell_type: :ControlParameter, source: source_name) }
-  let(:source_name) { 'string' }
+  let(:detector) { build(:smell_detector, smell_type: :ControlParameter) }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/data_clump_spec.rb
+++ b/spec/reek/smells/data_clump_spec.rb
@@ -67,8 +67,8 @@ RSpec.shared_examples_for 'a data clump detector' do
       end
     EOS
     expect(src).to reek_of(:DataClump,
-                           parameters: { count: 3,
-                                         parameters: ['pa', 'pb'] })
+                           count: 3,
+                           parameters: ['pa', 'pb'])
   end
 
   it 'reports 3 identical parameter sets' do
@@ -80,8 +80,8 @@ RSpec.shared_examples_for 'a data clump detector' do
       end
     EOS
     expect(src).to reek_of(:DataClump,
-                           parameters: { count: 3,
-                                         parameters: ['pa', 'pb', 'pc'] })
+                           count: 3,
+                           parameters: ['pa', 'pb', 'pc'])
   end
 
   it 'reports re-ordered identical parameter sets' do
@@ -93,8 +93,8 @@ RSpec.shared_examples_for 'a data clump detector' do
       end
     EOS
     expect(src).to reek_of(:DataClump,
-                           parameters: { count: 3,
-                                         parameters: ['pa', 'pb', 'pc'] })
+                           count: 3,
+                           parameters: ['pa', 'pb', 'pc'])
   end
 
   it 'counts only identical parameter sets' do
@@ -118,7 +118,7 @@ RSpec.shared_examples_for 'a data clump detector' do
         def c_raw_singleton (src, options) end
       end
     EOS
-    expect(src).to reek_of(:DataClump, parameters: { count: 5 })
+    expect(src).to reek_of(:DataClump, count: 5)
   end
 
   it 'correctly checks number of occurences' do
@@ -143,7 +143,7 @@ RSpec.shared_examples_for 'a data clump detector' do
       end
     EOS
     expect(src).to reek_of(:DataClump,
-                           parameters: { parameters: %w(p1 p2) })
+                           parameters: %w(p1 p2))
   end
 
   it 'ignores anonymous parameters' do
@@ -155,7 +155,7 @@ RSpec.shared_examples_for 'a data clump detector' do
       end
     EOS
     expect(src).to reek_of(:DataClump,
-                           parameters: { parameters: %w(p1 p2) })
+                           parameters: %w(p1 p2))
   end
 end
 

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -6,8 +6,7 @@ require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::DuplicateMethodCall do
   context 'when a smell is reported' do
-    let(:detector) { build(:smell_detector, smell_type: :DuplicateMethodCall, source: source_name) }
-    let(:source_name) { 'string' }
+    let(:detector) { build(:smell_detector, smell_type: :DuplicateMethodCall) }
 
     let(:warning) do
       src = <<-EOS

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -37,23 +37,23 @@ RSpec.describe Reek::Smells::DuplicateMethodCall do
   context 'with repeated method calls' do
     it 'reports repeated call' do
       src = 'def double_thing() @other.thing + @other.thing end'
-      expect(src).to reek_of(:DuplicateMethodCall, parameters: { name: '@other.thing' })
+      expect(src).to reek_of(:DuplicateMethodCall, name: '@other.thing')
     end
 
     it 'reports repeated call to lvar' do
       src = 'def double_thing(other) other[@thing] + other[@thing] end'
-      expect(src).to reek_of(:DuplicateMethodCall, parameters: { name: 'other[@thing]' })
+      expect(src).to reek_of(:DuplicateMethodCall, name: 'other[@thing]')
     end
 
     it 'reports call parameters' do
       src = 'def double_thing() @other.thing(2,3) + @other.thing(2,3) end'
-      expect(src).to reek_of(:DuplicateMethodCall, parameters: { name: '@other.thing(2, 3)' })
+      expect(src).to reek_of(:DuplicateMethodCall, name: '@other.thing(2, 3)')
     end
 
     it 'should report nested calls' do
       src = 'def double_thing() @other.thing.foo + @other.thing.foo end'
-      expect(src).to reek_of(:DuplicateMethodCall, parameters: { name: '@other.thing' })
-      expect(src).to reek_of(:DuplicateMethodCall, parameters: { name: '@other.thing.foo' })
+      expect(src).to reek_of(:DuplicateMethodCall, name: '@other.thing')
+      expect(src).to reek_of(:DuplicateMethodCall, name: '@other.thing.foo')
     end
 
     it 'should ignore calls to new' do
@@ -125,7 +125,7 @@ RSpec.describe Reek::Smells::DuplicateMethodCall do
   context 'with repeated attribute assignment' do
     it 'reports repeated assignment' do
       src = 'def double_thing(thing) @other[thing] = true; @other[thing] = true; end'
-      expect(src).to reek_of(:DuplicateMethodCall, parameters: { name: '@other[thing] = true' })
+      expect(src).to reek_of(:DuplicateMethodCall, name: '@other[thing] = true')
     end
     it 'does not report multi-assignments' do
       src = <<-EOS
@@ -174,7 +174,7 @@ RSpec.describe Reek::Smells::DuplicateMethodCall do
         end
       '
       expect(src).to reek_of(:DuplicateMethodCall,
-                             { parameters: { name: '@other.thing', count: 4 } },
+                             { name: '@other.thing', count: 4 },
                              configuration)
     end
   end
@@ -196,13 +196,13 @@ RSpec.describe Reek::Smells::DuplicateMethodCall do
     it 'reports calls to other methods' do
       src = 'def double_other_thing() @other.thing + @other.thing end'
 
-      expect(src).to reek_of(:DuplicateMethodCall, { parameters: { name: '@other.thing' } }, configuration)
+      expect(src).to reek_of(:DuplicateMethodCall, { name: '@other.thing' }, configuration)
     end
 
     it 'does not report calls to methods specifed with a regular expression' do
       src = 'def double_puts() puts @other.thing; puts @other.thing end'
 
-      expect(src).to reek_of(:DuplicateMethodCall, { parameters: { name: '@other.thing' } }, configuration)
+      expect(src).to reek_of(:DuplicateMethodCall, { name: '@other.thing' }, configuration)
     end
   end
 end

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -214,15 +214,14 @@ RSpec.describe Reek::Smells::FeatureEnvy do
 end
 
 RSpec.describe Reek::Smells::FeatureEnvy do
-  let(:detector) { build(:smell_detector, smell_type: :FeatureEnvy, source: source_name) }
-  let(:source_name) { 'string' }
+  let(:detector) { build(:smell_detector, smell_type: :FeatureEnvy) }
 
   it_should_behave_like 'SmellDetector'
 
   context 'when a smell is reported' do
     let(:receiver) { 'other' }
 
-    let(:smells) do
+    let(:warning) do
       src = <<-EOS
         def envious(other)
           #{receiver}.call
@@ -231,35 +230,15 @@ RSpec.describe Reek::Smells::FeatureEnvy do
           #{receiver}.fred
         end
       EOS
-      Reek::Examiner.new(src, ['FeatureEnvy']).smells
+      Reek::Examiner.new(src, ['FeatureEnvy']).smells.first
     end
 
-    it 'reports only that smell' do
-      expect(smells.length).to eq(1)
-    end
+    it_should_behave_like 'common fields set correctly'
 
-    it 'reports the source' do
-      expect(smells[0].source).to eq(source_name)
-    end
-
-    it 'reports the smell class' do
-      expect(smells[0].smell_category).to eq(described_class.smell_category)
-    end
-
-    it 'reports the smell sub class' do
-      expect(smells[0].smell_type).to eq(described_class.smell_type)
-    end
-
-    it 'reports the envious receiver' do
-      expect(smells[0].parameters[:name]).to eq(receiver)
-    end
-
-    it 'reports the number of references' do
-      expect(smells[0].parameters[:count]).to eq(3)
-    end
-
-    it 'reports the referring lines' do
-      expect(smells[0].lines).to eq([2, 4, 5])
+    it 'reports the correct values' do
+      expect(warning.parameters[:name]).to eq(receiver)
+      expect(warning.parameters[:count]).to eq(3)
+      expect(warning.lines).to eq([2, 4, 5])
     end
   end
 end

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Reek::Smells::FeatureEnvy do
         def envy(arga)
           arga.b(arga) + arga.c(@fred)
         end
-      ').to reek_of(:FeatureEnvy, parameters: { name: 'arga' })
+      ').to reek_of(:FeatureEnvy, name: 'arga')
     end
   end
 
@@ -90,8 +90,8 @@ RSpec.describe Reek::Smells::FeatureEnvy do
         total *= 1.15
       end
       EOS
-    expect(src).to reek_of(:FeatureEnvy, parameters: { name: 'total' })
-    expect(src).not_to reek_of(:FeatureEnvy, parameters: { name: 'fred' })
+    expect(src).to reek_of(:FeatureEnvy, name: 'total')
+    expect(src).not_to reek_of(:FeatureEnvy, name: 'fred')
   end
 
   it 'should report multiple affinities' do
@@ -103,8 +103,8 @@ RSpec.describe Reek::Smells::FeatureEnvy do
         total += fred.tax
       end
       EOS
-    expect(src).to reek_of(:FeatureEnvy, parameters: { name: 'total' })
-    expect(src).to reek_of(:FeatureEnvy, parameters: { name: 'fred' })
+    expect(src).to reek_of(:FeatureEnvy, name: 'total')
+    expect(src).to reek_of(:FeatureEnvy, name: 'fred')
   end
 
   it 'should not be fooled by duplication' do

--- a/spec/reek/smells/irresponsible_module_spec.rb
+++ b/spec/reek/smells/irresponsible_module_spec.rb
@@ -6,12 +6,12 @@ require_relative 'smell_detector_shared'
 RSpec.describe Reek::Smells::IrresponsibleModule do
   it 'reports a class without a comment' do
     src = 'class BadClass; end'
-    expect(src).to reek_of :IrresponsibleModule, parameters: { name: 'BadClass' }
+    expect(src).to reek_of :IrresponsibleModule, name: 'BadClass'
   end
 
   it 'reports a module without a comment' do
     src = 'module BadClass; end'
-    expect(src).to reek_of :IrresponsibleModule, parameters: { name: 'BadClass' }
+    expect(src).to reek_of :IrresponsibleModule, name: 'BadClass'
   end
 
   it 'does not report re-opened modules' do
@@ -63,7 +63,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
 
   it 'reports a fully qualified class name correctly' do
     src = 'class Foo::Bar; end'
-    expect(src).to reek_of :IrresponsibleModule, parameters: { name: 'Foo::Bar' }
+    expect(src).to reek_of :IrresponsibleModule, name: 'Foo::Bar'
   end
 
   it 'does not report modules used only as namespaces' do
@@ -159,7 +159,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
         Foo = Class.new Bar
       end
     EOS
-    expect(src).to reek_of(:IrresponsibleModule, parameters: { name: 'Foo' })
+    expect(src).to reek_of(:IrresponsibleModule, name: 'Foo')
   end
 
   it 'reports structs defined through assignment' do
@@ -169,7 +169,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
         Foo = Struct.new(:x, :y)
       end
     EOS
-    expect(src).to reek_of(:IrresponsibleModule, parameters: { name: 'Foo' })
+    expect(src).to reek_of(:IrresponsibleModule, name: 'Foo')
   end
 
   it 'does not report constants that are not classes' do

--- a/spec/reek/smells/irresponsible_module_spec.rb
+++ b/spec/reek/smells/irresponsible_module_spec.rb
@@ -184,8 +184,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
   end
 
   context 'when a smell is reported' do
-    let(:detector) { build(:smell_detector, smell_type: :IrresponsibleModule, source: source_name) }
-    let(:source_name) { 'string' }
+    let(:detector) { build(:smell_detector, smell_type: :IrresponsibleModule) }
 
     it_should_behave_like 'SmellDetector'
   end

--- a/spec/reek/smells/long_parameter_list_spec.rb
+++ b/spec/reek/smells/long_parameter_list_spec.rb
@@ -74,8 +74,7 @@ RSpec.describe Reek::Smells::LongParameterList do
 end
 
 RSpec.describe Reek::Smells::LongParameterList do
-  let(:detector) { build(:smell_detector, smell_type: :LongParameterList, source: source_name) }
-  let(:source_name) { 'string' }
+  let(:detector) { build(:smell_detector, smell_type: :LongParameterList) }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/long_parameter_list_spec.rb
+++ b/spec/reek/smells/long_parameter_list_spec.rb
@@ -51,23 +51,23 @@ RSpec.describe Reek::Smells::LongParameterList do
   describe 'for methods with too many parameters' do
     it 'should report 4 parameters' do
       src = 'def simple(arga, argb, argc, argd) f(3);true end'
-      expect(src).to reek_of(:LongParameterList, parameters: { count: 4 })
+      expect(src).to reek_of(:LongParameterList, count: 4)
     end
 
     it 'should report 8 parameters' do
       src = 'def simple(arga, argb, argc, argd,arge, argf, argg, argh) f(3);true end'
-      expect(src).to reek_of(:LongParameterList, parameters: { count: 8 })
+      expect(src).to reek_of(:LongParameterList, count: 8)
     end
 
     describe 'and default values' do
       it 'should report 3 with 1 defaulted' do
         src = 'def simple(polly, queue, yep, zero=nil) f(3);false end'
-        expect(src).to reek_of(:LongParameterList, parameters: { count: 4 })
+        expect(src).to reek_of(:LongParameterList, count: 4)
       end
 
       it 'should report with 3 defaulted' do
         src = 'def simple(aarg, polly=2, yep=:truth, zero=nil) f(3);false end'
-        expect(src).to reek_of(:LongParameterList, parameters: { count: 4 })
+        expect(src).to reek_of(:LongParameterList, count: 4)
       end
     end
   end

--- a/spec/reek/smells/long_yield_list_spec.rb
+++ b/spec/reek/smells/long_yield_list_spec.rb
@@ -4,8 +4,7 @@ require_lib 'reek/smells/long_yield_list'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::LongYieldList do
-  let(:detector) { build(:smell_detector, smell_type: :LongYieldList, source: source_name) }
-  let(:source_name) { 'string' }
+  let(:detector) { build(:smell_detector, smell_type: :LongYieldList) }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/long_yield_list_spec.rb
+++ b/spec/reek/smells/long_yield_list_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Reek::Smells::LongYieldList do
     end
     it 'should report yield with many parameters' do
       src = 'def simple(arga, argb, &blk) f(3);yield arga,argb,arga,argb; end'
-      expect(src).to reek_of(:LongYieldList, parameters: { count: 4 })
+      expect(src).to reek_of(:LongYieldList, count: 4)
     end
     it 'should not report yield of a long expression' do
       src = 'def simple(arga, argb, &blk) f(3);yield(if @dec then argb else 5+3 end); end'

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -259,8 +259,7 @@ RSpec.describe Reek::Smells::NestedIterators do
 end
 
 RSpec.describe Reek::Smells::NestedIterators do
-  let(:detector) { build(:smell_detector, smell_type: :NestedIterators, source: source_name) }
-  let(:source_name) { 'string' }
+  let(:detector) { build(:smell_detector, smell_type: :NestedIterators) }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Reek::Smells::NestedIterators do
         ) { |qux| qux.quuz }
       end
     EOS
-    expect(src).to reek_of(:NestedIterators, parameters: { count: 2 })
+    expect(src).to reek_of(:NestedIterators, count: 2)
   end
 
   it 'reports the deepest level of nesting only' do
@@ -82,7 +82,7 @@ RSpec.describe Reek::Smells::NestedIterators do
         }
       end
     EOS
-    expect(src).to reek_of(:NestedIterators, parameters: { count: 3 })
+    expect(src).to reek_of(:NestedIterators, count: 3)
   end
 
   it 'handles the case where super receives a block' do
@@ -235,7 +235,7 @@ RSpec.describe Reek::Smells::NestedIterators do
           @fred.ignore_me {|item| item.each {|ting| ting.each {|other| other.other} } }
         end
       '
-      expect(src).to reek_of(:NestedIterators, { parameters: { count: 2 } }, configuration)
+      expect(src).to reek_of(:NestedIterators, { count: 2 }, configuration)
     end
 
     it 'should report nested iterators outside the ignored iterator' do
@@ -244,7 +244,7 @@ RSpec.describe Reek::Smells::NestedIterators do
           @fred.each {|item| item.each {|ting| ting.ignore_me {|other| other.other} } }
         end
       '
-      expect(src).to reek_of(:NestedIterators, { parameters: { count: 2 } }, configuration)
+      expect(src).to reek_of(:NestedIterators, { count: 2 }, configuration)
     end
 
     it 'should report nested iterators with the ignored iterator between them' do
@@ -253,7 +253,7 @@ RSpec.describe Reek::Smells::NestedIterators do
           @fred.each {|item| item.ignore_me {|ting| ting.ting {|other| other.other} } }
         end
       '
-      expect(src).to reek_of(:NestedIterators, { parameters: { count: 2 } }, configuration)
+      expect(src).to reek_of(:NestedIterators, { count: 2 }, configuration)
     end
   end
 end

--- a/spec/reek/smells/nil_check_spec.rb
+++ b/spec/reek/smells/nil_check_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Reek::Smells::NilCheck do
       end
       EOS
       ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      detector = build(:smell_detector, smell_type: :NilCheck, source: 'source_name')
+      detector = build(:smell_detector, smell_type: :NilCheck)
       smells = detector.examine_context(ctx)
       expect(smells[0].lines).to eq [2]
     end

--- a/spec/reek/smells/prima_donna_method_spec.rb
+++ b/spec/reek/smells/prima_donna_method_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Reek::Smells::PrimaDonnaMethod do
   end
 
   describe 'the right smell' do
-    let(:detector) { build(:smell_detector, smell_type: :PrimaDonnaMethod, source: 'source_name') }
+    let(:detector) { build(:smell_detector, smell_type: :PrimaDonnaMethod) }
     let(:src)      { 'class C; def m!; end; end' }
     let(:ctx)      do
       Reek::Context::ModuleContext.new(nil,

--- a/spec/reek/smells/repeated_conditional_spec.rb
+++ b/spec/reek/smells/repeated_conditional_spec.rb
@@ -5,8 +5,7 @@ require_relative 'smell_detector_shared'
 require_lib 'reek/source/source_code'
 
 RSpec.describe Reek::Smells::RepeatedConditional do
-  let(:detector) { build(:smell_detector, smell_type: :RepeatedConditional, source: source_name) }
-  let(:source_name) { 'string' }
+  let(:detector) { build(:smell_detector, smell_type: :RepeatedConditional) }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/smell_detector_shared.rb
+++ b/spec/reek/smells/smell_detector_shared.rb
@@ -20,7 +20,7 @@ end
 
 RSpec.shared_examples_for 'common fields set correctly' do
   it 'reports the source' do
-    expect(warning.source).to eq(source_name)
+    expect(warning.source).to eq('string')
   end
   it 'reports the smell class' do
     expect(warning.smell_category).to eq(detector.smell_category)

--- a/spec/reek/smells/smell_warning_spec.rb
+++ b/spec/reek/smells/smell_warning_spec.rb
@@ -84,55 +84,6 @@ RSpec.describe Reek::Smells::SmellWarning do
     end
   end
 
-  context '#matches?' do
-    let(:uncommunicative) do
-      uncommunicative_name_detector = build(:smell_detector,
-                                            smell_type: 'UncommunicativeVariableName')
-      build(:smell_warning, smell_detector: uncommunicative_name_detector,
-                            message: "has the variable name '@s'",
-                            parameters: { test: 'something' })
-    end
-
-    it 'matches on class symbol' do
-      expect(uncommunicative.matches?(:UncommunicativeVariableName)).to\
-        be_truthy
-    end
-
-    it 'matches on class symbol and params' do
-      expect(uncommunicative.matches?(:UncommunicativeVariableName,
-                                      test: 'something')).to be_truthy
-    end
-
-    it 'matches on class symbol, params and attributes' do
-      expect(uncommunicative.matches?(:UncommunicativeVariableName,
-                                      test: 'something',
-                                      message: "has the variable name '@s'")).to be_truthy
-    end
-
-    it 'does not match on different class symbol' do
-      expect(uncommunicative.matches?(:FeatureEnvy)).to be_falsy
-    end
-
-    it 'does not match on different params' do
-      expect(uncommunicative.matches?(:UncommunicativeVariableName,
-                                      test: 'something else')).to be_falsy
-    end
-
-    it 'does not match on different attributes' do
-      expect(uncommunicative.matches?(:UncommunicativeVariableName,
-                                      test: 'something',
-                                      message: 'nothing')).to be_falsy
-    end
-
-    it 'raises error on uncomparable attribute' do
-      expect do
-        uncommunicative.matches?(:UncommunicativeVariableName,
-                                 test: 'something',
-                                 random: 'nothing')
-      end.to raise_error("The attribute 'random' is not available for comparison")
-    end
-  end
-
   context '#yaml_hash' do
     let(:class) { 'FeatureEnvy' }
     let(:context_name) { 'Module::Class#method/block' }

--- a/spec/reek/smells/smell_warning_spec.rb
+++ b/spec/reek/smells/smell_warning_spec.rb
@@ -100,16 +100,13 @@ RSpec.describe Reek::Smells::SmellWarning do
 
     it 'matches on class symbol and params' do
       expect(uncommunicative.matches?(:UncommunicativeVariableName,
-                                      parameters: {
-                                        test: 'something'
-                                      })).to be_truthy
+                                      test: 'something')).to be_truthy
     end
 
     it 'matches on class symbol, params and attributes' do
       expect(uncommunicative.matches?(:UncommunicativeVariableName,
-                                      parameters: { test: 'something' },
-                                      message: "has the variable name '@s'"
-                                     )).to be_truthy
+                                      test: 'something',
+                                      message: "has the variable name '@s'")).to be_truthy
     end
 
     it 'does not match on different class symbol' do
@@ -118,21 +115,19 @@ RSpec.describe Reek::Smells::SmellWarning do
 
     it 'does not match on different params' do
       expect(uncommunicative.matches?(:UncommunicativeVariableName,
-                                      parameters: {
-                                        test: 'something else'
-                                      })).to be_falsy
+                                      test: 'something else')).to be_falsy
     end
 
     it 'does not match on different attributes' do
       expect(uncommunicative.matches?(:UncommunicativeVariableName,
-                                      parameters: { test: 'something' },
+                                      test: 'something',
                                       message: 'nothing')).to be_falsy
     end
 
     it 'raises error on uncomparable attribute' do
       expect do
         uncommunicative.matches?(:UncommunicativeVariableName,
-                                 parameters: { test: 'something' },
+                                 test: 'something',
                                  random: 'nothing')
       end.to raise_error("The attribute 'random' is not available for comparison")
     end

--- a/spec/reek/smells/smell_warning_spec.rb
+++ b/spec/reek/smells/smell_warning_spec.rb
@@ -66,8 +66,7 @@ RSpec.describe Reek::Smells::SmellWarning do
     context 'smells differing everywhere' do
       let(:first) do
         uncommunicative_name_detector = build(:smell_detector,
-                                              smell_type: 'UncommunicativeVariableName',
-                                              source: true)
+                                              smell_type: 'UncommunicativeVariableName')
         build(:smell_warning, smell_detector: uncommunicative_name_detector,
                               context: 'Dirty',
                               message: "has the variable name '@s'")
@@ -75,8 +74,7 @@ RSpec.describe Reek::Smells::SmellWarning do
 
       let(:second) do
         duplication_detector = build(:smell_detector,
-                                     smell_type: 'DuplicateMethodCall',
-                                     source: false)
+                                     smell_type: 'DuplicateMethodCall')
         build(:smell_warning, smell_detector: duplication_detector,
                               context: 'Dirty#a',
                               message: 'calls @s.title twice')

--- a/spec/reek/smells/too_many_instance_variables_spec.rb
+++ b/spec/reek/smells/too_many_instance_variables_spec.rb
@@ -3,10 +3,7 @@ require_lib 'reek/smells/too_many_instance_variables'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::TooManyInstanceVariables do
-  let(:source_name) { 'string' }
-  let(:detector) do
-    build(:smell_detector, smell_type: :TooManyInstanceVariables, source: source_name)
-  end
+  let(:detector) { build(:smell_detector, smell_type: :TooManyInstanceVariables) }
 
   it_should_behave_like 'SmellDetector'
 
@@ -77,21 +74,25 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
     end
   end
 
-  it 'reports correctly for excessive instance variables' do
-    src = <<-EOS
-      # Comment
-      class Empty
-        def ivars
-          #{ivar_sequence(count: too_many_ivars)}
+  context 'when a smell is reported' do
+    let(:warning) do
+      src = <<-EOS
+        # Comment
+        class Empty
+          def ivars
+            #{ivar_sequence(count: too_many_ivars)}
+          end
         end
-      end
-    EOS
-    ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-    warning = detector.examine_context(ctx)[0]
-    expect(warning.source).to eq(source_name)
-    expect(warning.smell_category).to eq(Reek::Smells::TooManyInstanceVariables.smell_category)
-    expect(warning.smell_type).to eq(Reek::Smells::TooManyInstanceVariables.smell_type)
-    expect(warning.parameters[:count]).to eq(too_many_ivars)
-    expect(warning.lines).to eq([2])
+      EOS
+      ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
+      detector.examine_context(ctx).first
+    end
+
+    it_should_behave_like 'common fields set correctly'
+
+    it 'reports the correct values' do
+      expect(warning.parameters[:count]).to eq(too_many_ivars)
+      expect(warning.lines).to eq([2])
+    end
   end
 end

--- a/spec/reek/smells/too_many_statements_spec.rb
+++ b/spec/reek/smells/too_many_statements_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Reek::Smells::TooManyStatements do
 end
 
 RSpec.describe Reek::Smells::TooManyStatements do
-  let(:detector) { build(:smell_detector, smell_type: :TooManyStatements, source: 'source_name') }
+  let(:detector) { build(:smell_detector, smell_type: :TooManyStatements) }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/uncommunicative_method_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_method_name_spec.rb
@@ -3,10 +3,7 @@ require_lib 'reek/smells/uncommunicative_method_name'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::UncommunicativeMethodName do
-  let(:source_name) { 'string' }
-  let(:detector) do
-    build(:smell_detector, smell_type: :UncommunicativeMethodName, source: source_name)
-  end
+  let(:detector) { build(:smell_detector, smell_type: :UncommunicativeMethodName) }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_module_name_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe Reek::Smells::UncommunicativeModuleName do
     end
 
     it 'reports one-letter name' do
-      expect("#{type} X; end").to reek_of(:UncommunicativeModuleName, parameters: { name: 'X' })
+      expect("#{type} X; end").to reek_of(:UncommunicativeModuleName, name: 'X')
     end
 
     it 'reports name of the form "x2"' do
-      expect("#{type} X2; end").to reek_of(:UncommunicativeModuleName, parameters: { name: 'X2' })
+      expect("#{type} X2; end").to reek_of(:UncommunicativeModuleName, name: 'X2')
     end
 
     it 'reports long name ending in a number' do
-      expect("#{type} Printer2; end").to reek_of(:UncommunicativeModuleName, parameters: { name: 'Printer2' })
+      expect("#{type} Printer2; end").to reek_of(:UncommunicativeModuleName, name: 'Printer2')
     end
 
     it 'reports a bad scoped name' do

--- a/spec/reek/smells/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_module_name_spec.rb
@@ -4,10 +4,7 @@ require_relative 'smell_detector_shared'
 require_lib 'reek/context/code_context'
 
 RSpec.describe Reek::Smells::UncommunicativeModuleName do
-  let(:source_name) { 'string' }
-  let(:detector) do
-    build(:smell_detector, smell_type: :UncommunicativeModuleName, source: source_name)
-  end
+  let(:detector) { build(:smell_detector, smell_type: :UncommunicativeModuleName) }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_parameter_name_spec.rb
@@ -4,10 +4,7 @@ require_relative 'smell_detector_shared'
 require_lib 'reek/context/method_context'
 
 RSpec.describe Reek::Smells::UncommunicativeParameterName do
-  let(:detector) do
-    build(:smell_detector, smell_type: :UncommunicativeParameterName, source: source_name)
-  end
-  let(:source_name) { 'string' }
+  let(:detector) { build(:smell_detector, smell_type: :UncommunicativeParameterName) }
 
   it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_parameter_name_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Reek::Smells::UncommunicativeParameterName do
       it "reports parameter's name" do
         src = "def #{host}help(x) basics(x) end"
         expect(src).to reek_of(:UncommunicativeParameterName,
-                               parameters: { name: 'x' })
+                               name: 'x')
       end
 
       it 'does not report unused parameters' do
@@ -35,13 +35,13 @@ RSpec.describe Reek::Smells::UncommunicativeParameterName do
       it 'reports names of the form "x2"' do
         src = "def #{host}help(x2) basics(x2) end"
         expect(src).to reek_of(:UncommunicativeParameterName,
-                               parameters: { name: 'x2' })
+                               name: 'x2')
       end
 
       it 'reports long name ending in a number' do
         src = "def #{host}help(param2) basics(param2) end"
         expect(src).to reek_of(:UncommunicativeParameterName,
-                               parameters: { name: 'param2' })
+                               name: 'param2')
       end
 
       it 'does not report unused anonymous parameter' do
@@ -62,13 +62,13 @@ RSpec.describe Reek::Smells::UncommunicativeParameterName do
       it 'reports names inside array decomposition' do
         src = "def #{host}help((b, nice)) basics(b, nice) end"
         expect(src).to reek_of(:UncommunicativeParameterName,
-                               parameters: { name: 'b' })
+                               name: 'b')
       end
 
       it 'reports names inside nested array decomposition' do
         src = "def #{host}help((foo, (bar, c))) basics(foo, c) end"
         expect(src).to reek_of(:UncommunicativeParameterName,
-                               parameters: { name: 'c' })
+                               name: 'c')
       end
     end
   end

--- a/spec/reek/smells/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_variable_name_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
     end
     it 'reports one-letter fieldname in assignment' do
       src = 'class Thing; def simple(fred) @x = fred end end'
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: '@x' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: '@x')
     end
   end
 
@@ -32,19 +32,19 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
 
     it 'reports one-letter variable name' do
       src = 'def simple(fred) x = jim(45) end'
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'x' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
     end
 
     it 'reports name of the form "x2"' do
       src = 'def simple(fred) x2 = jim(45) end'
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'x2' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x2')
     end
 
     it 'reports long name ending in a number' do
       bad_var = 'var123'
       src = "def simple(fred) #{bad_var} = jim(45) end"
       expect(src).to reek_of(:UncommunicativeVariableName,
-                             parameters: { name: bad_var })
+                             name: bad_var)
     end
 
     it 'reports variable name only once' do
@@ -60,12 +60,12 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
 
     it 'reports a bad name inside a block' do
       src = 'def clean(text) text.each { q2 = 3 } end'
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'q2' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'q2')
     end
 
     it 'reports variable name outside any method' do
       expect('class Simple; x = jim(45); end').to reek_of(:UncommunicativeVariableName,
-                                                          parameters: { name: 'x' })
+                                                          name: 'x')
     end
   end
 
@@ -78,7 +78,7 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
           end
         end
       EOS
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'x' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
     end
 
     it 'reports all relevant block parameters' do
@@ -87,8 +87,8 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
           @foo.map { |x, y| x + y }
         end
       EOS
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'x' })
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'y' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
     end
 
     it 'reports block parameters used outside of methods' do
@@ -97,7 +97,7 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
         @foo.map { |x| x * 2 }
       end
       EOS
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'x' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
     end
 
     it 'reports splatted block parameters correctly' do
@@ -106,7 +106,7 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
           @foo.map { |*y| y << 1 }
         end
       EOS
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'y' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
     end
 
     it 'reports nested block parameters' do
@@ -115,8 +115,8 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
           @foo.map { |(x, y)| x + y }
         end
       EOS
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'x' })
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'y' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
     end
 
     it 'reports splatted nested block parameters' do
@@ -125,8 +125,8 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
           @foo.map { |(x, *y)| x + y }
         end
       EOS
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'x' })
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'y' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
     end
 
     it 'reports deeply nested block parameters' do
@@ -135,9 +135,9 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
           @foo.map { |(x, (y, z))| x + y + z }
         end
       EOS
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'x' })
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'y' })
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'z' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'z')
     end
 
     it 'reports shadowed block parameters' do
@@ -146,8 +146,8 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
           @foo.map { |x; y| y = x * 2 }
         end
       EOS
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'x' })
-      expect(src).to reek_of(:UncommunicativeVariableName, parameters: { name: 'y' })
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
     end
   end
 

--- a/spec/reek/smells/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_variable_name_spec.rb
@@ -3,9 +3,8 @@ require_lib 'reek/smells/uncommunicative_variable_name'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::UncommunicativeVariableName do
-  let(:source_name) { 'string' }
   let(:detector) do
-    build(:smell_detector, smell_type: :UncommunicativeVariableName, source: source_name)
+    build(:smell_detector, smell_type: :UncommunicativeVariableName)
   end
 
   it_should_behave_like 'SmellDetector'

--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe Reek::Smells::UnusedParameters do
 
     it 'reports for 1 used and 2 unused parameter' do
       src = 'def simple(num,sum,denum); sum end'
-      expect(src).to reek_of(:UnusedParameters, parameters: { name: 'num' })
-      expect(src).to reek_of(:UnusedParameters, parameters: { name: 'denum' })
+      expect(src).to reek_of(:UnusedParameters, name: 'num')
+      expect(src).to reek_of(:UnusedParameters, name: 'denum')
     end
 
     it 'reports for 3 used and 1 unused parameter' do
       src = 'def simple(num,sum,denum,quotient); num + denum + sum end'
       expect(src).to reek_of(:UnusedParameters,
-                             parameters: { name: 'quotient' })
+                             name: 'quotient')
     end
 
     it 'reports nothing for used splatted parameter' do

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -6,8 +6,7 @@ require_relative 'smell_detector_shared'
 # TODO: Bring specs in line with specs for other detectors
 RSpec.describe Reek::Smells::UtilityFunction do
   describe 'a detector' do
-    let(:detector) { build(:smell_detector, smell_type: :UtilityFunction, source: source_name) }
-    let(:source_name) { 'string' }
+    let(:detector) { build(:smell_detector, smell_type: :UtilityFunction) }
 
     it_should_behave_like 'SmellDetector'
 

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -3,7 +3,6 @@ require_lib 'reek/smells/utility_function'
 require_lib 'reek/examiner'
 require_relative 'smell_detector_shared'
 
-# TODO: Bring specs in line with specs for other detectors
 RSpec.describe Reek::Smells::UtilityFunction do
   describe 'a detector' do
     let(:detector) { build(:smell_detector, smell_type: :UtilityFunction) }
@@ -154,7 +153,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
 
   context 'with only one call' do
     it 'reports a call to a parameter' do
-      expect('def simple(arga) arga.to_s end').to reek_of(:UtilityFunction, parameters: { name: 'simple' })
+      expect('def simple(arga) arga.to_s end').to reek_of(:UtilityFunction, name: 'simple')
     end
 
     it 'reports a call to a constant' do
@@ -165,7 +164,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
   context 'with two or more calls' do
     it 'reports two calls' do
       src = 'def simple(arga) arga.to_s + arga.to_i end'
-      expect(src).to reek_of(:UtilityFunction, parameters: { name: 'simple' })
+      expect(src).to reek_of(:UtilityFunction, name: 'simple')
       expect(src).not_to reek_of(:FeatureEnvy)
     end
 
@@ -190,7 +189,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
 
     it 'should report message chain' do
       src = 'def simple(arga) arga.b.c end'
-      expect(src).to reek_of(:UtilityFunction, parameters: { name: 'simple' })
+      expect(src).to reek_of(:UtilityFunction, name: 'simple')
       expect(src).not_to reek_of(:FeatureEnvy)
     end
 
@@ -233,7 +232,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
             def m1(a) a.to_s; end
           end
         EOS
-        expect(src).to reek_of(:UtilityFunction, { parameters: { name: 'C#m1' } }, configuration)
+        expect(src).to reek_of(:UtilityFunction, { name: 'C#m1' }, configuration)
       end
     end
 

--- a/spec/reek/spec/should_reek_of_spec.rb
+++ b/spec/reek/spec/should_reek_of_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
   describe 'different sources of input' do
     context 'checking code in a string' do
       let(:clean_code) { 'def good() true; end' }
-      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, parameters: { name: 'y' }) }
+      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, name: 'y') }
       let(:smelly_code) { 'def x() y = 4; end' }
 
       it 'matches a smelly String' do
@@ -32,7 +32,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
 
     context 'checking code in a File' do
       let(:clean_file) { Pathname.glob("#{SAMPLES_PATH}/three_clean_files/*.rb").first }
-      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, parameters: { name: '@s' }) }
+      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, name: '@s') }
       let(:smelly_file) { Pathname.glob("#{SAMPLES_PATH}/two_smelly_files/*.rb").first }
 
       it 'matches a smelly file' do
@@ -47,7 +47,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
 
   describe 'smell types and smell details' do
     context 'passing in smell_details with unknown parameter name' do
-      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, parameters: { foo: 'y' }) }
+      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, foo: 'y') }
       let(:smelly_code) { 'def x() y = 4; end' }
 
       it 'raises ArgumentError' do
@@ -57,7 +57,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
 
     context 'both are matching' do
       let(:smelly_code) { 'def x() y = 4; end' }
-      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, parameters: { name: 'y' }) }
+      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, name: 'y') }
 
       it 'is truthy' do
         expect(matcher.matches?(smelly_code)).to be_truthy
@@ -67,8 +67,8 @@ RSpec.describe Reek::Spec::ShouldReekOf do
     context 'no smell_type is matching' do
       let(:smelly_code) { 'def dummy() y = 4; end' }
 
-      let(:falsey_matcher) { Reek::Spec::ShouldReekOf.new(:FeatureEnvy, parameters: { name: 'y' }) }
-      let(:truthy_matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, parameters: { name: 'y' }) }
+      let(:falsey_matcher) { Reek::Spec::ShouldReekOf.new(:FeatureEnvy, name: 'y') }
+      let(:truthy_matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, name: 'y') }
 
       it 'is falsey' do
         expect(falsey_matcher.matches?(smelly_code)).to be_falsey
@@ -91,7 +91,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
 
     context 'smell type is matching but smell details are not' do
       let(:smelly_code) { 'def dummy() y = 4; end' }
-      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, parameters: { name: 'x' }) }
+      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, name: 'x') }
 
       it 'is falsey' do
         expect(matcher.matches?(smelly_code)).to be_falsey
@@ -101,7 +101,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
         matcher.matches?(smelly_code)
         expect(matcher.failure_message).to\
           match('Expected string to reek of UncommunicativeVariableName (which it did) with '\
-                  'smell details {:parameters=>{:name=>"x"}}, which it didn\'t')
+                  'smell details {:name=>"x"}, which it didn\'t')
       end
 
       it 'sets the proper error message when negated' do
@@ -109,7 +109,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
 
         expect(matcher.failure_message_when_negated).to\
           match('Expected string not to reek of UncommunicativeVariableName with smell '\
-                  'details {:parameters=>{:name=>"x"}}, but it did')
+                  'details {:name=>"x"}, but it did')
       end
     end
   end

--- a/spec/reek/spec/smell_matcher_spec.rb
+++ b/spec/reek/spec/smell_matcher_spec.rb
@@ -1,0 +1,92 @@
+require_relative '../../spec_helper'
+require_lib 'reek/spec/smell_matcher'
+
+RSpec.describe Reek::Spec::SmellMatcher do
+  let(:detector) { build(:smell_detector, smell_type: 'UncommunicativeVariableName') }
+  let(:smell_warning) do
+    build(:smell_warning, smell_detector: detector,
+                          message: "has the variable name '@s'",
+                          parameters: { test: 'something' })
+  end
+  let(:matcher) { described_class.new(smell_warning) }
+
+  context '#matches?' do
+    it 'matches on class symbol' do
+      expect(matcher.matches?(:UncommunicativeVariableName)).to be_truthy
+    end
+
+    it 'matches on class symbol and params' do
+      expect(matcher.matches?(:UncommunicativeVariableName,
+                              test: 'something')).to be_truthy
+    end
+
+    it 'matches on class symbol, params and attributes' do
+      expect(matcher.matches?(:UncommunicativeVariableName,
+                              test: 'something',
+                              message: "has the variable name '@s'")).to be_truthy
+    end
+
+    it 'does not match on different class symbol' do
+      expect(matcher.matches?(:FeatureEnvy)).to be_falsy
+    end
+
+    it 'does not match on different params' do
+      expect(matcher.matches?(:UncommunicativeVariableName,
+                              test: 'something else')).to be_falsy
+    end
+
+    it 'does not match on different attributes' do
+      expect(matcher.matches?(:UncommunicativeVariableName,
+                              test: 'something',
+                              message: 'nothing')).to be_falsy
+    end
+
+    it 'raises error on uncomparable attribute' do
+      expect do
+        matcher.matches?(:UncommunicativeVariableName,
+                         test: 'something',
+                         random: 'nothing')
+      end.to raise_error("The attribute 'random' is not available for comparison")
+    end
+  end
+
+  context '#matches_smell_type?' do
+    it 'matches on class symbol' do
+      expect(matcher.matches_smell_type?(:UncommunicativeVariableName)).to be_truthy
+    end
+
+    it 'matches on category symbol' do
+      expect(matcher.matches_smell_type?(:UncommunicativeName)).to be_truthy
+    end
+
+    it 'does not match on different class symbol' do
+      expect(matcher.matches_smell_type?(:FeatureEnvy)).to be_falsy
+    end
+  end
+
+  context '#matches_attributes?' do
+    it 'matches on params' do
+      expect(matcher.matches_attributes?(test: 'something')).to be_truthy
+    end
+
+    it 'matches on class symbol, params and attributes' do
+      expect(matcher.matches_attributes?(test: 'something',
+                                         message: "has the variable name '@s'")).to be_truthy
+    end
+
+    it 'does not match on different params' do
+      expect(matcher.matches_attributes?(test: 'something else')).to be_falsy
+    end
+
+    it 'does not match on different attributes' do
+      expect(matcher.matches_attributes?(test: 'something',
+                                         message: 'nothing')).to be_falsy
+    end
+
+    it 'raises error on uncomparable attribute' do
+      expect do
+        matcher.matches_attributes? test: 'something', random: 'nothing'
+      end.to raise_error("The attribute 'random' is not available for comparison")
+    end
+  end
+end


### PR DESCRIPTION
See #738.

The ultimate goal is for all of SmellWarning's attributes to be on equal footing. This was already the case for the json/yaml hash output.

This restores the `.reek_of` interface.