### PR TITLE
Unify config loading

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -73,44 +73,25 @@ IrresponsibleModule:
   enabled: false
 ```
 
+Reek will load this file automatically by default. If you want to load the
+configuration explicitely, you can use one of the methods below.
+
 You can now use either
 
 ```Ruby
 Reek::Configuration::AppConfiguration.from_path Pathname.new('config.reek')
 ```
 
-but you can also pass a hash via `Reek::Configuration::AppConfiguration.from_map`.
+but you can also pass a hash with the contents of the `config.reek` YAML file
+to `Reek::Configuration::AppConfiguration.from_hash`.
 
-This hash can have the following 3 keys:
-
-1.) directory_directives [Hash] for instance:
-
-```Ruby
-  { Pathname("spec/samples/three_clean_files/") =>
-    { Reek::Smells::UtilityFunction => { "enabled" => false } } }
-```
-
-2.) default_directive [Hash] for instance:
-
-```Ruby
-  { Reek::Smells::IrresponsibleModule => { "enabled" => false } }
-```
-
-3.) excluded_paths [Array] for instance:
-
-```Ruby
-  [ Pathname('spec/samples/two_smelly_files') ]
-```
-
-Given the example above you should load that as "default directive" which means that it will
-be the default configuration for smell types for which there is
-no "directory directive" (so a directory-specific configuration):
+Given the example above you would load that as follows:
 
 ```Ruby
 require 'reek'
 
-default_directive = { Reek::Smells::IrresponsibleModule => { 'enabled' => false } }
-configuration = Reek::Configuration::AppConfiguration.from_map default_directive: default_directive
+config_hash = { 'IrresponsibleModule' => { 'enabled' => false } }
+configuration = Reek::Configuration::AppConfiguration.from_hash config_hash
 
 source = <<-EOS
   class Dirty
@@ -126,13 +107,33 @@ reporter.add_examiner examiner; nil
 reporter.show
 ```
 
-This would now only report the `UncommunicativeParameterName` but not the `IrresponsibleModule`
-for the `Dirty` class:
+This would now only report `UncommunicativeParameterName` but not
+`IrresponsibleModule` for the `Dirty` class:
 
 ```
 string -- 2 warnings:
   Dirty#call_me has the parameter name 'a' (UncommunicativeParameterName)
   Dirty#call_me has the parameter name 'b' (UncommunicativeParameterName)
+```
+
+Instead of the smell detector names you can also use the full detector class in
+your configuration hash, for example:
+
+```ruby
+config_hash = { Reek::Smells::IrresponsibleModule => { 'enabled' => false } }
+```
+
+Of course, directory specific configuration and excluded paths are supported as
+well:
+
+```
+config_hash = {
+  'IrresponsibleModule' => { 'enabled' => false }
+  'spec/samples/three_clean_files/' =>
+    { 'UtilityFunction' => { "enabled" => false } }
+  'exclude_paths' =>
+    [ 'spec/samples/two_smelly_files' ]
+}
 ```
 
 ## Accessing the smell warnings directly

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -9,8 +9,9 @@ require_relative './excluded_paths'
 module Reek
   module Configuration
     #
-    # Reek's singleton configuration instance.
+    # Reek's application configuration.
     #
+    # @public
     class AppConfiguration
       include ConfigurationValidator
       EXCLUDE_PATHS_KEY = 'exclude_paths'
@@ -21,6 +22,8 @@ module Reek
       # @param path [Pathname] the path to the config file
       #
       # @return [AppConfiguration]
+      #
+      # @public
       def self.from_path(path = nil)
         allocate.tap do |instance|
           instance.instance_eval { find_and_load(path: path) }
@@ -29,22 +32,47 @@ module Reek
 
       # Instantiate a configuration by passing everything in.
       #
-      # @param map [Hash] can have the following 3 keys:
-      # 1.) directory_directives [Hash] for instance:
-      #   { Pathname("spec/samples/three_clean_files/") =>
-      #     { Reek::Smells::UtilityFunction => { "enabled" => false } } }
-      # 2.) default_directive [Hash] for instance:
-      #   { Reek::Smells::IrresponsibleModule => { "enabled" => false } }
-      # 3.) excluded_paths [Array] for instance:
-      #   [ Pathname('spec/samples/two_smelly_files') ]
+      # @deprecated This method will be removed in Reek 4.0.
+      #
+      # @param [Hash] map a hash with three possible keys representing
+      # different types of directives.
+      # @option map [Hash] :directory_directives Directory specific configuration
+      #   for instance:
+      #     { Pathname("spec/samples/three_clean_files/") =>
+      #       { Reek::Smells::UtilityFunction => { "enabled" => false } } }
+      # @option map [Hash] :default_directive Default configuration
+      #   for instance:
+      #     { Reek::Smells::IrresponsibleModule => { "enabled" => false } }
+      # @option map [Array] :excluded_paths list of paths to exclude from analysis
+      #   for instance:
+      #     [ Pathname('spec/samples/two_smelly_files') ]
       #
       # @return [AppConfiguration]
+      #
+      # @public
       def self.from_map(map = {})
         allocate.tap do |instance|
           instance.instance_eval do
             load_values map.fetch(:directory_directives, {})
             load_values map.fetch(:default_directive, {})
             load_values EXCLUDE_PATHS_KEY => map.fetch(:excluded_paths, [])
+          end
+        end
+      end
+
+      # Instantiate a configuration by passing everything in.
+      #
+      # Loads the configuration from a hash of the form that is loaded from a
+      # +.reek+ config file.
+      # @param [Hash] hash The configuration hash to load.
+      #
+      # @return [AppConfiguration]
+      #
+      # @public
+      def self.from_hash(hash = {})
+        allocate.tap do |instance|
+          instance.instance_eval do
+            load_values hash
           end
         end
       end

--- a/spec/reek/configuration/app_configuration_spec.rb
+++ b/spec/reek/configuration/app_configuration_spec.rb
@@ -25,6 +25,26 @@ RSpec.describe Reek::Configuration::AppConfiguration do
         { Reek::Smells::UtilityFunction => { 'enabled' => false } } }
     end
 
+    let(:default_directive_value) do
+      { 'IrresponsibleModule' => { 'enabled' => false } }
+    end
+
+    let(:directory_directives_value) do
+      { 'spec/samples/three_clean_files' =>
+        { 'UtilityFunction' => { 'enabled' => false } } }
+    end
+
+    let(:exclude_paths_value) do
+      ['spec/samples/two_smelly_files',
+       'spec/samples/source_with_non_ruby_files']
+    end
+
+    let(:combined_value) do
+      directory_directives_value.
+        merge(default_directive_value).
+        merge('exclude_paths' => exclude_paths_value)
+    end
+
     describe '#from_path' do
       let(:full_configuration_path) { SAMPLES_PATH.join('configuration/full_configuration.reek') }
 
@@ -38,20 +58,6 @@ RSpec.describe Reek::Configuration::AppConfiguration do
     end
 
     describe '#from_map' do
-      let(:default_directive_value) do
-        { 'IrresponsibleModule' => { 'enabled' => false } }
-      end
-
-      let(:directory_directives_value) do
-        { 'spec/samples/three_clean_files' =>
-          { 'UtilityFunction' => { 'enabled' => false } } }
-      end
-
-      let(:exclude_paths_value) do
-        ['spec/samples/two_smelly_files',
-         'spec/samples/source_with_non_ruby_files']
-      end
-
       it 'properly sets the configuration from simple data structures' do
         config = described_class.from_map(directory_directives: directory_directives_value,
                                           default_directive: default_directive_value,
@@ -66,6 +72,16 @@ RSpec.describe Reek::Configuration::AppConfiguration do
         config = described_class.from_map(directory_directives: expected_directory_directives,
                                           default_directive: expected_default_directive,
                                           excluded_paths: expected_excluded_paths)
+
+        expect(config.send(:excluded_paths)).to eq(expected_excluded_paths)
+        expect(config.send(:default_directive)).to eq(expected_default_directive)
+        expect(config.send(:directory_directives)).to eq(expected_directory_directives)
+      end
+    end
+
+    describe '#from_hash' do
+      it 'sets the configuration a unified simple data structure' do
+        config = described_class.from_hash(combined_value)
 
         expect(config.send(:excluded_paths)).to eq(expected_excluded_paths)
         expect(config.send(:default_directive)).to eq(expected_default_directive)


### PR DESCRIPTION
#662.

I decided to create a new method `.from_hash` in the end because I think this is a nicer name and we can more simply deprecate the entire `.from_map` method. We can remove `.from_map` in Reek 4.

Internally, `.from_map` is still used at the moment.