### PR TITLE
Bump Aruba dependency

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'unparser',     '~> 0.2.2'
 
   s.add_development_dependency 'activesupport', '~> 4.2'
-  s.add_development_dependency 'aruba',         '~> 0.9.0'
+  s.add_development_dependency 'aruba',         '~> 0.10.0'
   s.add_development_dependency 'ataru',         '~> 0.2.0'
   s.add_development_dependency 'bundler',       '~> 1.1'
   s.add_development_dependency 'cucumber',      '~> 2.0'


### PR DESCRIPTION
I was running into the following error running Reek's Cucumber suite:

```
% bundle exec cucumber
cannot load such file -- rspec/support/object_formatter (LoadError)
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/aruba-0.9.0/lib/aruba/matchers/base/base_matcher.rb:1:in `require'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/aruba-0.9.0/lib/aruba/matchers/base/base_matcher.rb:1:in `<top (required)>'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/aruba-0.9.0/lib/aruba/platforms/unix_platform.rb:86:in `require_relative'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/aruba-0.9.0/lib/aruba/platforms/unix_platform.rb:86:in `block in require_matching_files'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/aruba-0.9.0/lib/aruba/platforms/unix_platform.rb:86:in `each'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/aruba-0.9.0/lib/aruba/platforms/unix_platform.rb:86:in `require_matching_files'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/aruba-0.9.0/lib/aruba/api.rb:19:in `<top (required)>'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/aruba-0.9.0/lib/aruba/cucumber.rb:3:in `require'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/aruba-0.9.0/lib/aruba/cucumber.rb:3:in `<top (required)>'
/Users/andy/code/forked/troessner/reek/features/support/env.rb:3:in `require'
/Users/andy/code/forked/troessner/reek/features/support/env.rb:3:in `<top (required)>'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/cucumber-2.0.0/lib/cucumber/rb_support/rb_language.rb:94:in `load'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/cucumber-2.0.0/lib/cucumber/rb_support/rb_language.rb:94:in `load_code_file'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/cucumber-2.0.0/lib/cucumber/runtime/support_code.rb:237:in `load_file'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/cucumber-2.0.0/lib/cucumber/runtime/support_code.rb:97:in `block in load_files!'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/cucumber-2.0.0/lib/cucumber/runtime/support_code.rb:96:in `each'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/cucumber-2.0.0/lib/cucumber/runtime/support_code.rb:96:in `load_files!'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/cucumber-2.0.0/lib/cucumber/runtime.rb:242:in `load_step_definitions'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/cucumber-2.0.0/lib/cucumber/runtime.rb:65:in `run!'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/cucumber-2.0.0/lib/cucumber/cli/main.rb:38:in `execute!'
/Users/andy/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/cucumber-2.0.0/bin/cucumber:9:in `<top (required)>'
/Users/andy/.rbenv/versions/2.2.2/bin/cucumber:23:in `load'
/Users/andy/.rbenv/versions/2.2.2/bin/cucumber:23:in `<main>'
```

This was because Aruba 0.9 was relying on `RSpec::Support::ObjectFormatter`,
but that was only available since RSpec 3.3, and Reek specifies '~> 3.0'

https://github.com/rspec/rspec-support/commit/a5a6a75e6cacb0c1cd840228a247e909529eaf71

This was fixed in Aruba 0.10.0:

https://github.com/cucumber/aruba/commit/6326885d01963f2edc9f78396665496eecd9f354