### PR TITLE
Add Code Climate JSON report format

### DIFF
--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -40,6 +40,7 @@ Feature: Reek can be controlled using command-line options
                                              yaml
                                              json
                                              xml
+                                             code_climate
 
       Text format options:
               --[no-]color                 Use colors for the output (default: true)

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -72,9 +72,9 @@ module Reek
       def set_alternative_formatter_options
         parser.separator "\nReport format:"
         parser.on(
-          '-f', '--format FORMAT', [:html, :text, :yaml, :json, :xml],
+          '-f', '--format FORMAT', [:html, :text, :yaml, :json, :xml, :code_climate],
           'Report smells in the given format:',
-          '  html', '  text (default)', '  yaml', '  json', '  xml'
+          '  html', '  text (default)', '  yaml', '  json', '  xml', '  code_climate'
         ) do |opt|
           self.report_format = opt
         end

--- a/lib/reek/report.rb
+++ b/lib/reek/report.rb
@@ -12,7 +12,8 @@ module Reek
       json: JSONReport,
       html: HTMLReport,
       xml: XMLReport,
-      text: TextReport
+      text: TextReport,
+      code_climate: CodeClimateReport
     }
 
     LOCATION_FORMATTERS = {

--- a/lib/reek/report/code_climate_formatter.rb
+++ b/lib/reek/report/code_climate_formatter.rb
@@ -1,0 +1,46 @@
+require 'codeclimate_engine'
+require 'private_attr'
+
+module Reek
+  module Report
+    # Generates a hash in the structure specified by the Code Climate engine spec
+    class CodeClimateFormatter
+      private_attr_reader :warning
+
+      def initialize(warning)
+        @warning = warning
+      end
+
+      def to_hash
+        CCEngine::Issue.new(check_name: check_name,
+                            description: description,
+                            categories: categories,
+                            location: location
+                           ).to_hash
+      end
+
+      private
+
+      def description
+        [warning.context, warning.message].join(' ')
+      end
+
+      def check_name
+        [warning.smell_category, warning.smell_type].join('/')
+      end
+
+      def categories
+        # TODO: provide mappings for Reek's smell categories
+        ['Complexity']
+      end
+
+      def location
+        warning_lines = warning.lines
+        CCEngine::Location::LineRange.new(
+          path: warning.source,
+          line_range: warning_lines.first..warning_lines.last
+        )
+      end
+    end
+  end
+end

--- a/lib/reek/report/formatter.rb
+++ b/lib/reek/report/formatter.rb
@@ -1,5 +1,6 @@
 require 'private_attr/everywhere'
 require_relative 'location_formatter'
+require_relative '../report/code_climate_formatter'
 
 module Reek
   module Report
@@ -40,6 +41,11 @@ module Reek
       # :reek:UtilityFunction
       def format_hash(warning)
         warning.yaml_hash
+      end
+
+      # :reek:UtilityFunction
+      def format_code_climate_hash(warning)
+        CodeClimateFormatter.new(warning).to_hash
       end
 
       private_attr_reader :location_formatter

--- a/lib/reek/report/report.rb
+++ b/lib/reek/report/report.rb
@@ -144,6 +144,18 @@ module Reek
     end
 
     #
+    # Displays a list of smells in Code Climate engine format
+    # (https://github.com/codeclimate/spec/blob/master/SPEC.md)
+    # JSON with empty array for 0 smells
+    #
+    class CodeClimateReport < Base
+      # @public
+      def show(out = $stdout)
+        out.print ::JSON.generate smells.map { |smell| warning_formatter.format_code_climate_hash(smell) }
+      end
+    end
+
+    #
     # Saves the report as a HTML file
     #
     # @public

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -22,10 +22,11 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
   s.summary = 'Code smell detector for Ruby'
 
-  s.add_runtime_dependency 'parser',       '~> 2.2', '>= 2.2.2.5'
-  s.add_runtime_dependency 'private_attr', '~> 1.1'
-  s.add_runtime_dependency 'rainbow',      '~> 2.0'
-  s.add_runtime_dependency 'unparser',     '~> 0.2.2'
+  s.add_runtime_dependency 'codeclimate-engine-rb', '~> 0.1.0'
+  s.add_runtime_dependency 'parser',                '~> 2.2', '>= 2.2.2.5'
+  s.add_runtime_dependency 'private_attr',          '~> 1.1'
+  s.add_runtime_dependency 'rainbow',               '~> 2.0'
+  s.add_runtime_dependency 'unparser',              '~> 0.2.2'
 
   s.add_development_dependency 'activesupport', '~> 4.2'
   s.add_development_dependency 'aruba',         '~> 0.10.0'

--- a/spec/reek/report/code_climate_formatter_spec.rb
+++ b/spec/reek/report/code_climate_formatter_spec.rb
@@ -1,0 +1,63 @@
+require_relative '../../spec_helper'
+require_lib 'reek/report/code_climate_formatter'
+
+RSpec.describe Reek::Report::CodeClimateFormatter, '#to_hash' do
+  it "sets the type as 'issue'" do
+    warning = FactoryGirl.build(:smell_warning)
+    issue = Reek::Report::CodeClimateFormatter.new(warning)
+
+    result = issue.to_hash
+
+    expect(result).to include(type: 'issue')
+  end
+
+  it 'sets the category' do
+    warning = FactoryGirl.build(:smell_warning)
+    issue = Reek::Report::CodeClimateFormatter.new(warning)
+
+    result = issue.to_hash
+
+    expect(result).to include(categories: ['Complexity'])
+  end
+
+  it 'constructs a description based on the context and message' do
+    warning = FactoryGirl.build(:smell_warning,
+                                context: 'context foo',
+                                message: 'message bar')
+    issue = Reek::Report::CodeClimateFormatter.new(warning)
+
+    result = issue.to_hash
+
+    expect(result).to include(
+      description: 'context foo message bar')
+  end
+
+  it 'sets a check name based on the smell detector' do
+    warning = FactoryGirl.build(:smell_warning,
+                                smell_detector: Reek::Smells::UtilityFunction.new)
+    issue = Reek::Report::CodeClimateFormatter.new(warning)
+
+    result = issue.to_hash
+
+    expect(result).to include(check_name: 'LowCohesion/UtilityFunction')
+  end
+
+  it 'sets the location' do
+    warning = FactoryGirl.build(:smell_warning,
+                                lines: [1, 2],
+                                source: 'a/ruby/source/file.rb')
+    issue = Reek::Report::CodeClimateFormatter.new(warning)
+
+    result = issue.to_hash
+
+    expect(result).to include(
+      location: {
+        path: 'a/ruby/source/file.rb',
+        lines: {
+          begin: 1,
+          end: 2
+        }
+      }
+    )
+  end
+end

--- a/spec/reek/report/code_climate_report_spec.rb
+++ b/spec/reek/report/code_climate_report_spec.rb
@@ -1,0 +1,68 @@
+require_relative '../../spec_helper'
+require_lib 'reek/examiner'
+require_lib 'reek/report/report'
+require_lib 'reek/report/formatter'
+
+require 'json'
+require 'stringio'
+
+RSpec.describe Reek::Report::CodeClimateReport do
+  let(:options) { {} }
+  let(:instance) { Reek::Report::CodeClimateReport.new(options) }
+  let(:examiner) { Reek::Examiner.new(source) }
+
+  before do
+    instance.add_examiner examiner
+  end
+
+  context 'with empty source' do
+    let(:source) { '' }
+
+    it 'prints empty json' do
+      expect { instance.show }.to output(/^\[\]$/).to_stdout
+    end
+  end
+
+  context 'with smelly source' do
+    let(:source) { 'def simple(a) a[3] end' }
+
+    it 'prints smells as json' do
+      out = StringIO.new
+      instance.show(out)
+      out.rewind
+      result = JSON.parse(out.read)
+      expected = JSON.parse <<-EOS
+        [
+          {
+            "type": "issue",
+            "check_name": "LowCohesion/UtilityFunction",
+            "description": "simple doesn't depend on instance state (maybe move it to another class?)",
+            "categories": ["Complexity"],
+            "location": {
+              "path": "string",
+              "lines": {
+                "begin": 1,
+                "end": 1
+              }
+            }
+          },
+          {
+            "type": "issue",
+            "check_name": "UncommunicativeName/UncommunicativeParameterName",
+            "description": "simple has the parameter name 'a'",
+            "categories": ["Complexity"],
+            "location": {
+              "path": "string",
+              "lines": {
+                "begin": 1,
+                "end": 1
+              }
+            }
+          }
+        ]
+      EOS
+
+      expect(result).to eq expected
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces a new formatter intended for use with Code
Climate's engine platform.

https://github.com/codeclimate/spec

Further integration work will be required, but the aim is that the Reek
repository will act as the home for Code Climate's Reek engine, rather
than having a separate repository for the engine.

The core team have discussed and agreed to this approach.