### PR TITLE
Remove FIXME comment.

### DIFF
--- a/lib/reek/smells/module_initialize.rb
+++ b/lib/reek/smells/module_initialize.rb
@@ -21,7 +21,7 @@ module Reek
       #
       # :reek:FeatureEnvy
       def inspect(ctx)
-        ctx.local_nodes(:def) do |node| # FIXME: also search for :defs?
+        ctx.local_nodes(:def) do |node|
           if node.name.to_s == 'initialize'
             return [
               smell_warning(


### PR DESCRIPTION
Let's face it, this comment would stick there for the next 10 years and decrease readability and confuse readers.
Let's remove it. IF we want to do this (and I don't see the point of it), we should rather discuss this in github issues, not as FIXME comments.