### PR TITLE
Spec TreeWalker properly.

### DIFF
--- a/lib/reek/tree_walker.rb
+++ b/lib/reek/tree_walker.rb
@@ -22,6 +22,7 @@ module Reek
       @smell_repository = smell_repository
       @exp = exp
       @element = Context::RootContext.new(exp)
+      @context_tree = process(exp)
     end
 
     def walk
@@ -33,7 +34,7 @@ module Reek
     private
 
     private_attr_accessor :element
-    private_attr_reader :exp, :smell_repository
+    private_attr_reader :exp, :smell_repository, :context_tree
 
     # Processes the given AST, memoizes it and returns a tree of nested
     # contexts.
@@ -53,10 +54,6 @@ module Reek
     # RootContext -> children: 1 ModuleContext -> children: 1 MethodContext
     #
     # @return [Reek::Context::RootContext] tree of nested contexts
-    def context_tree
-      @context_tree ||= process(exp)
-    end
-
     def process(exp)
       context_processor = "process_#{exp.type}"
       if context_processor_exists?(context_processor)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,13 @@ module Helpers
     configuration
   end
 
+  # @param code [String] The given code.
+  #
+  # @return syntax_tree [Reek::AST::Node]
+  def syntax_tree(code)
+    Reek::Source::SourceCode.from(code).syntax_tree
+  end
+
   # :reek:UncommunicativeMethodName
   def sexp(type, *children)
     @klass_map ||= Reek::AST::ASTNodeClassMap.new


### PR DESCRIPTION
Ready for review!

This is a prerequisite for me in order to start refactoring TreeWalker and CodeContexts to address #775 and quite a few other issues we're having there (obscurity being the biggest one).
The diff is messy by nature unfortunately, probably makes more sense to look at the file without a diff.

What I did:

1.) Introduced specs for #initialize (un-speced before)
2.) Restructured, simplified and cleaned up our existing "statement counting" specs
3.) Introduced specs for #walk (un-speced before)

I'd appreciate a quick review @chastell && @mvz since this is kind of blocking me from further refactoring tasks.