### PR TITLE
Refactor context building.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,3 +63,6 @@ Style/Documentation:
 Style/AccessorMethodName:
   Exclude:
     - 'lib/reek/context/visibility_tracker.rb'
+
+Style/ParallelAssignment:
+  Enabled: false

--- a/lib/reek/context/visibility_tracker.rb
+++ b/lib/reek/context/visibility_tracker.rb
@@ -39,7 +39,7 @@ module Reek
         child.visibility = tracked_visibility
       end
 
-      # return [Boolean] If the visibility is public or not.
+      # @return [Boolean] If the visibility is public or not.
       def non_public_visibility?
         visibility != :public
       end


### PR DESCRIPTION
Our context building was pretty confusing.
So basically we were using the chain

inside_new_context -> new_context -> push

but we were also using `new_context` standalone (e.g. for AttributeContext). In this case however not for a new context itself, but for the sideeffect of appending a child context.
Additonally we were passing down a block 2 methods deep, something that always smells for me.

This PR cleans this up and separates concerns better which results in better readability.