### PR TITLE
Parser 2.3 support

### DIFF
--- a/features/command_line_interface/stdin.feature
+++ b/features/command_line_interface/stdin.feature
@@ -33,7 +33,7 @@ Feature: Reek reads from $stdin when no files are given
       """
 
   Scenario: syntax error causes the source to be ignored
-    When I pass "def incomplete" to reek
+    When I pass "= invalid syntax =" to reek
     Then it reports a parsing error
     Then it succeeds
     And it reports nothing

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.summary = 'Code smell detector for Ruby'
 
   s.add_runtime_dependency 'codeclimate-engine-rb', '~> 0.1.0'
-  s.add_runtime_dependency 'parser',                '~> 2.2.2', '>= 2.2.2.5'
+  s.add_runtime_dependency 'parser',                '~> 2.3'
   s.add_runtime_dependency 'private_attr',          '~> 1.1'
   s.add_runtime_dependency 'rainbow',               '~> 2.0'
 end


### PR DESCRIPTION
I want to get my pet projects that would benefit from the squiggly heredoc over to Ruby 2.3 ASAP, and for this we need to make sure Reek supports it.

To the best of my quick checks the current blockers are:

1. (the newest) parser 2.3.0.pre.6 still not supporting the new syntax,
1. (the newest) unparser 0.4.2 depending on parser `'~> 2.2.2'`.

Once the above are resolved I want to make sure Reek at least doesn’t blow up on the new syntax, but ideally addresses those parts of the new syntax it should address. ;)