### PR TITLE
Switching to keyword arguments for SourceCode initializer

### DIFF
--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -21,7 +21,7 @@ module Reek
       # code   - Ruby code as String
       # origin - 'STDIN', 'string' or a filepath as String
       # parser - the parser to use for generating AST's out of the given source
-      def initialize(code, origin, parser: Parser::Ruby22)
+      def initialize(code: raise, origin: raise, parser: Parser::Ruby22)
         @source = code
         @origin = origin
         @parser = parser
@@ -39,10 +39,10 @@ module Reek
       # :reek:DuplicateMethodCall: { max_calls: 2 }
       def self.from(source)
         case source
-        when File     then new(source.read, source.path)
-        when IO       then new(source.readlines.join, IO_IDENTIFIER)
-        when Pathname then new(source.read, source.to_s)
-        when String   then new(source, STRING_IDENTIFIER)
+        when File     then new(code: source.read,           origin: source.path)
+        when IO       then new(code: source.readlines.join, origin: IO_IDENTIFIER)
+        when Pathname then new(code: source.read,           origin: source.to_s)
+        when String   then new(code: source,                origin: STRING_IDENTIFIER)
         end
       end
 

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe Reek::Source::SourceCode do
   describe '#syntax_tree' do
     it 'associates comments with the AST' do
       source = "# this is\n# a comment\ndef foo; end"
-      source_code = Reek::Source::SourceCode.new(source, '(string)')
+      source_code = Reek::Source::SourceCode.new(code: source, origin: '(string)')
       result = source_code.syntax_tree
       expect(result.leading_comment).to eq "# this is\n# a comment"
     end
 
     it 'cleanly processes empty source' do
-      source_code = Reek::Source::SourceCode.new('', '(string)')
+      source_code = Reek::Source::SourceCode.new(code: '', origin: '(string)')
       result = source_code.syntax_tree
       expect(result).to be_nil
     end
 
     it 'cleanly processes empty source with comments' do
       source = "# this is\n# a comment\n"
-      source_code = Reek::Source::SourceCode.new(source, '(string)')
+      source_code = Reek::Source::SourceCode.new(code: source, origin: '(string)')
       result = source_code.syntax_tree
       expect(result).to be_nil
     end
@@ -30,7 +30,7 @@ RSpec.describe Reek::Source::SourceCode do
     let(:source_name) { 'Test source' }
     let(:error_message) { 'Error message' }
     let(:parser) { double('parser') }
-    let(:src) { Reek::Source::SourceCode.new('', source_name, parser: parser) }
+    let(:src) { Reek::Source::SourceCode.new(code: '', origin: source_name, parser: parser) }
 
     before { $stderr = catcher }
 


### PR DESCRIPTION
Improves readability