### PR TITLE
[bug fix] Skip path if path doesn't exist.

### DIFF
--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -31,11 +31,15 @@ module Reek
 
       private_attr_reader :configuration, :paths
 
-      # :reek:TooManyStatements: { max_statements: 6 }
+      # :reek:TooManyStatements: { max_statements: 7 }
       # :reek:NestedIterators: { max_allowed_nesting: 2 }
       def source_paths
         paths.each_with_object([]) do |given_path, relevant_paths|
-          print_no_such_file_error(given_path) && next unless given_path.exist?
+          unless given_path.exist?
+            print_no_such_file_error(given_path)
+            next
+          end
+
           given_path.find do |path|
             if path.directory?
               ignore_path?(path) ? Find.prune : next


### PR DESCRIPTION
Hi.

I encounter an error.
https://github.com/skyarch-networks/skyhopper/pull/180#issuecomment-169521324

I think Reek doesn't skip a path that doesn't exist.
Because, `print_no_such_file_error(given_path)` returns a `nil`. So, `&& next` is not evaluated.



I created a repository for this problem. 
https://github.com/pocke/broken-reek-repo

You can try this problem by the following procedure.

```sh
$ git clone https://github.com/pocke/broken-reek-repo
$ cd broken-reek-repo
$ reek
```

Before patch
-------

![1452133760](https://cloud.githubusercontent.com/assets/4361134/12160680/c2c54e9c-b531-11e5-8717-7474d2afd8a9.png)

After patch
-----

![1452133790](https://cloud.githubusercontent.com/assets/4361134/12160683/cea13802-b531-11e5-98a9-842c28b363a1.png)
