### PR TITLE
Accept FileList as Rake task source files

### DIFF
--- a/docs/Rake-Task.md
+++ b/docs/Rake-Task.md
@@ -41,6 +41,14 @@ Reek::Rake::Task.new do |t|
 end
 ```
 
+Alternatively, you can create your own [Rake::FileList](http://rake.rubyforge.org/classes/Rake/FileList.html) and use that for `source_files`:
+
+```Ruby
+Reek::Rake::Task.new do |t|
+  t.source_files = FileList['lib/**/*.rb'].exclude('lib/templates/**/*.rb')
+end
+```
+
 ## Configuration via environment variables
 
 You can overwrite the following attributes by environment variables:

--- a/features/rake_task/rake_task.feature
+++ b/features/rake_task/rake_task.feature
@@ -20,6 +20,24 @@ Feature: Reek can be driven through its Task
         [3]:UncommunicativeMethodName: Smelly#m has the name 'm' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
       """
 
+  Scenario: source_files using a FileList instead of a String
+    Given a smelly file called 'smelly.rb'
+    When I run rake reek with:
+      """
+      Reek::Rake::Task.new do |t|
+        t.source_files = FileList['smelly.*']
+        t.reek_opts = '--no-color'
+      end
+      """
+    Then the exit status indicates an error
+    And it reports:
+      """
+      smelly.rb -- 3 warnings:
+        [4, 5]:DuplicateMethodCall: Smelly#m calls @foo.bar 2 times [https://github.com/troessner/reek/blob/master/docs/Duplicate-Method-Call.md]
+        [4, 5]:DuplicateMethodCall: Smelly#m calls puts(@foo.bar) 2 times [https://github.com/troessner/reek/blob/master/docs/Duplicate-Method-Call.md]
+        [3]:UncommunicativeMethodName: Smelly#m has the name 'm' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      """
+
   Scenario: name changes the task name
     Given a smelly file called 'smelly.rb'
     When I run rake silky with:

--- a/lib/reek/rake/task.rb
+++ b/lib/reek/rake/task.rb
@@ -85,17 +85,16 @@ module Reek
 
       # @public
       def source_files=(files)
-        raise ArgumentError, no_string_given_for_file_list_warning unless files.is_a?(String)
+        unless files.is_a?(String) || files.is_a?(FileList)
+          raise ArgumentError, 'File list should be a FileList or a String that can contain'\
+            " a glob pattern, e.g. '{app,lib,spec}/**/*.rb'"
+        end
         @source_files = FileList[files]
       end
 
       private
 
       private_attr_reader :fail_on_error, :name, :verbose
-
-      def no_string_given_for_file_list_warning
-        "File list should be a String that can contain a glob pattern, e.g. '{app,lib,spec}/**/*.rb'"
-      end
 
       def define_task
         desc 'Check for code smells'


### PR DESCRIPTION
The Rake task currently insists on taking a single glob pattern, while Rake's FileList is perfectly capable of taking multiple patterns. By relaxing the type check and taking advantage of the fact that passing a `FileList` to `FileList.[]` returns the same `FileList`, we can allow developers to set a fully customized `FileList` without changing the original API.

The right place to test this is unclear to me. There are no unit tests for the Rake task, and only some integration tests. Any suggestions?

See #788.