### PR TITLE
Improve our bundler and gemspec handling.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 cache: bundler
 language: ruby
-bundler_args: --without local_development
+bundler_args: --without debugging
 script:
 - bundle exec rake
 - bundle exec ataru check

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,26 @@
 source 'https://rubygems.org'
 
-# The gem's dependencies are specified in the gemspec
 gemspec
 
-group :local_development do
-  gem 'pry'
-  gem 'yard', '~> 0.8.7'
+group :development do
+  gem 'aruba',         '~> 0.10.0'
+  gem 'ataru',         '~> 0.2.0'
+  gem 'cucumber',      '~> 2.0'
+  gem 'factory_girl',  '~> 4.0'
+  gem 'rake',          '~> 10.0'
+  gem 'rspec',         '~> 3.0'
+  gem 'rubocop',       '~> 0.34.0'
+  gem 'yard',          '~> 0.8.7'
 
+  platforms :mri do
+    gem 'redcarpet', '~> 3.3.1'
+  end
+end
+
+group :debugging do
+  gem 'pry'
   platforms :mri do
     gem 'pry-byebug'
     gem 'pry-stack_explorer'
-
-    gem 'redcarpet', '~> 3.3.1'
   end
 end

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -26,15 +26,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'parser',                '~> 2.2', '>= 2.2.2.5'
   s.add_runtime_dependency 'private_attr',          '~> 1.1'
   s.add_runtime_dependency 'rainbow',               '~> 2.0'
-  s.add_runtime_dependency 'unparser',              '~> 0.2.2'
-
-  s.add_development_dependency 'activesupport', '~> 4.2'
-  s.add_development_dependency 'aruba',         '~> 0.10.0'
-  s.add_development_dependency 'ataru',         '~> 0.2.0'
-  s.add_development_dependency 'bundler',       '~> 1.1'
-  s.add_development_dependency 'cucumber',      '~> 2.0'
-  s.add_development_dependency 'factory_girl',  '~> 4.0'
-  s.add_development_dependency 'rake',          '~> 10.0'
-  s.add_development_dependency 'rspec',         '~> 3.0'
-  s.add_development_dependency 'rubocop',       '~> 0.34.0'
+  s.add_runtime_dependency 'unparser',              '~> 0.2.4'
 end


### PR DESCRIPTION
Fixes #821 with some small adjustments:

* I decided to put "development_dependencies" under the group "test" because we use them for running tests local and on travis
* I renamed "local_development" to "development"
* I removed the "yard" gem and the "redcarpet" gem. Why exactly did we have them in the first place? I can't really remember :)

Additionally I bumped `unparser` from 0.2.2 to 0.2.4 since bundler was acting up on ruby 2.1 and 2.0 for whatever reasons. I didn't investigate since this upgrade fixed it and seemed non-critical since we plan to remove `unparser` as soon as possible anyway.