### PR TITLE
[TEST] triggering travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 ## Overview
 
-
 [![Build Status](https://secure.travis-ci.org/troessner/reek.svg?branch=master)](https://travis-ci.org/troessner/reek?branch=master)
 [![Gem Version](https://badge.fury.io/rb/reek.svg)](https://badge.fury.io/rb/reek)
 [![Dependency Status](https://gemnasium.com/troessner/reek.png)](https://gemnasium.com/troessner/reek)


### PR DESCRIPTION
There seems to be a Reek-related dependency conflict in Travis for rubycritic that I can't reproduce locally https://travis-ci.org/whitesmith/rubycritic/jobs/102805608

Opening a dummy PR to kick-off Reek's travis build to see if it can be reproduced