### PR TITLE
Use parser 2.3 in `SourceCode`.

### DIFF
--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -1,6 +1,6 @@
 require_relative '../cli/silencer'
 Reek::CLI::Silencer.silently do
-  require 'parser/ruby22'
+  require 'parser/ruby23'
 end
 require_relative '../tree_dresser'
 require_relative '../ast/node'
@@ -21,7 +21,7 @@ module Reek
       # code   - Ruby code as String
       # origin - 'STDIN', 'string' or a filepath as String
       # parser - the parser to use for generating AST's out of the given source
-      def initialize(code: raise, origin: raise, parser: Parser::Ruby22)
+      def initialize(code: raise, origin: raise, parser: Parser::Ruby23)
         @source = code
         @origin = origin
         @parser = parser


### PR DESCRIPTION
Kind of funny that none of us noticed ;)
Nothing broke because Parser::Ruby22 parses e.g.

>> user.&profile

just fine and the exact same way Parser::Ruby23 does.