### PR TITLE
Disable UnusedPrivateMethod detector by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ Reek currently includes checks for some aspects of
 and more. See the [Code Smells](docs/Code-Smells.md)
 for up to date details of exactly what Reek will check in your code.
 
+Note that [Unused Private Method](docs/Unused-Private-Method.md) is disabled by default
+because it is [kind of controversial](https://github.com/troessner/reek/issues/844) which means
+you have to explicitly activate in your configuration via
+
+```Yaml
+UnusedPrivateMethod:
+  enabled: true
+```
+
 ## Configuration
 
 ### Command-line interface

--- a/defaults.reek
+++ b/defaults.reek
@@ -107,7 +107,7 @@ UnusedParameters:
   enabled: true
   exclude: []
 UnusedPrivateMethod:
-  enabled: true
+  enabled: false
   exclude: []
 UtilityFunction:
   enabled: true

--- a/features/samples.feature
+++ b/features/samples.feature
@@ -177,7 +177,7 @@ Feature: Basic smell detection
       UnusedParameters: OptionParser::Completion#convert has unused parameter 'opt' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
       UnusedParameters: OptionParser::Switch::NoArgument#parse has unused parameter 'argv' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
       UnusedParameters: OptionParser::Switch::OptionalArgument#parse has unused parameter 'argv' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
-    redcloth.rb -- 121 warnings:
+    redcloth.rb -- 101 warnings:
       Attribute: RedCloth#filter_html is a writable attribute [https://github.com/troessner/reek/blob/master/docs/Attribute.md]
       Attribute: RedCloth#filter_styles is a writable attribute [https://github.com/troessner/reek/blob/master/docs/Attribute.md]
       Attribute: RedCloth#hard_breaks is a writable attribute [https://github.com/troessner/reek/blob/master/docs/Attribute.md]
@@ -269,26 +269,6 @@ Feature: Basic smell detection
       UnusedParameters: RedCloth#textile_fn_ has unused parameter 'cite' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
       UnusedParameters: RedCloth#textile_fn_ has unused parameter 'tag' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
       UnusedParameters: RedCloth#textile_p has unused parameter 'cite' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `block_markdown_atx` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `block_markdown_bq` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `block_markdown_lists` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `block_markdown_rule` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `block_markdown_setext` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `block_textile_lists` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `block_textile_prefix` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `block_textile_table` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `inline_markdown_link` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `inline_markdown_reflink` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `inline_textile_code` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `inline_textile_image` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `inline_textile_link` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `inline_textile_span` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `refs_markdown` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `refs_textile` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `textile_bq` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `textile_fn_` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `textile_p` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
-      UnusedPrivateMethod: RedCloth has the unused private instance method `textile_popup_help` [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
       UtilityFunction: RedCloth#block_markdown_rule doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/master/docs/Utility-Function.md]
       UtilityFunction: RedCloth#clean_html doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/master/docs/Utility-Function.md]
       UtilityFunction: RedCloth#flush_left doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/master/docs/Utility-Function.md]
@@ -299,5 +279,5 @@ Feature: Basic smell detection
       UtilityFunction: RedCloth#lT doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/master/docs/Utility-Function.md]
       UtilityFunction: RedCloth#no_textile doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/master/docs/Utility-Function.md]
       UtilityFunction: RedCloth#v_align doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/master/docs/Utility-Function.md]
-    285 total warnings
+    265 total warnings
     """

--- a/lib/reek/smells/unused_private_method.rb
+++ b/lib/reek/smells/unused_private_method.rb
@@ -11,6 +11,10 @@ module Reek
     # See {file:docs/Unused-Private-Method.md} for details.
     #
     class UnusedPrivateMethod < SmellDetector
+      def self.default_config
+        super.merge(SmellConfiguration::ENABLED_KEY => false)
+      end
+
       # Class for storing `hits` which are unused private methods
       # we found in the given context. `name` and `line` are then used to
       # construct SmellWarnings.

--- a/spec/reek/smells/unused_private_method_spec.rb
+++ b/spec/reek/smells/unused_private_method_spec.rb
@@ -4,6 +4,12 @@ require_lib 'reek/examiner'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::UnusedPrivateMethod do
+  let(:configuration) do
+    test_configuration_for(
+      described_class =>
+        { Reek::Smells::SmellConfiguration::ENABLED_KEY => true }
+    )
+  end
   let(:detector) { build(:smell_detector, smell_type: :UnusedPrivateMethod) }
 
   it_should_behave_like 'SmellDetector'
@@ -18,8 +24,8 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
         end
       EOF
 
-      expect(source).to reek_of(:UnusedPrivateMethod, name: :start)
-      expect(source).to reek_of(:UnusedPrivateMethod, name: :drive)
+      expect(source).to reek_of(:UnusedPrivateMethod, { name: :start }, configuration)
+      expect(source).to reek_of(:UnusedPrivateMethod, { name: :drive }, configuration)
     end
 
     it 'creates warnings correctly' do
@@ -31,7 +37,7 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
         end
       EOF
 
-      examiner = Reek::Examiner.new(source, 'UnusedPrivateMethod')
+      examiner = Reek::Examiner.new(source, 'UnusedPrivateMethod', configuration: configuration)
 
       first_warning = examiner.smells.first
       expect(first_warning.smell_category).to eq(Reek::Smells::UnusedPrivateMethod.smell_category)
@@ -58,7 +64,7 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
         end
       EOF
 
-      examiner = Reek::Examiner.new(source, 'UnusedPrivateMethod')
+      examiner = Reek::Examiner.new(source, 'UnusedPrivateMethod', configuration: configuration)
 
       expect(examiner.smells.size).to eq(1)
       warning_for_drive = examiner.smells.first


### PR DESCRIPTION
Fixes #844 

Regarding the "re-enable a by default deactivated smell detector for tests" I took some inspiration from the corresponding Attribute smell detector PR [here](https://github.com/troessner/reek/pull/613/files)