### PR TITLE
Always require frozen string literal comments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,13 @@ Style/DotPosition:
 Style/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 
+# Require comment for files in lib and bin
+Style/FrozenStringLiteralComment:
+  Include:
+    - 'bin/*'
+    - 'lib/**/*'
+  EnforcedStyle: always
+
 # Allow multiline block chains
 Style/MultilineBlockChain:
   Enabled: false

--- a/bin/code_climate_reek
+++ b/bin/code_climate_reek
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 #
 # Wrapper for the CodeClimate integration.
 

--- a/bin/reek
+++ b/bin/reek
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 #
 # Reek examines Ruby source code for smells.
 # Visit https://wiki.github.com/troessner/reek for docs etc.

--- a/lib/reek.rb
+++ b/lib/reek.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Reek's core functionality
 #

--- a/lib/reek/ast/ast_node_class_map.rb
+++ b/lib/reek/ast/ast_node_class_map.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'node'
 require_relative 'sexp_extensions'
 

--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../cli/silencer'
 
 Reek::CLI::Silencer.silently do

--- a/lib/reek/ast/object_refs.rb
+++ b/lib/reek/ast/object_refs.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   # Represents functionality related to an Abstract Syntax Tree.
   module AST

--- a/lib/reek/ast/reference_collector.rb
+++ b/lib/reek/ast/reference_collector.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     #

--- a/lib/reek/ast/sexp_extensions.rb
+++ b/lib/reek/ast/sexp_extensions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'reference_collector'
 
 require_relative 'sexp_extensions/arguments'

--- a/lib/reek/ast/sexp_extensions/arguments.rb
+++ b/lib/reek/ast/sexp_extensions/arguments.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/attribute_assignments.rb
+++ b/lib/reek/ast/sexp_extensions/attribute_assignments.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/block.rb
+++ b/lib/reek/ast/sexp_extensions/block.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/case.rb
+++ b/lib/reek/ast/sexp_extensions/case.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/constant.rb
+++ b/lib/reek/ast/sexp_extensions/constant.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/if.rb
+++ b/lib/reek/ast/sexp_extensions/if.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/literal.rb
+++ b/lib/reek/ast/sexp_extensions/literal.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/logical_operators.rb
+++ b/lib/reek/ast/sexp_extensions/logical_operators.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/methods.rb
+++ b/lib/reek/ast/sexp_extensions/methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/module.rb
+++ b/lib/reek/ast/sexp_extensions/module.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/nested_assignables.rb
+++ b/lib/reek/ast/sexp_extensions/nested_assignables.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/self.rb
+++ b/lib/reek/ast/sexp_extensions/self.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/send.rb
+++ b/lib/reek/ast/sexp_extensions/send.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/super.rb
+++ b/lib/reek/ast/sexp_extensions/super.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/symbols.rb
+++ b/lib/reek/ast/sexp_extensions/symbols.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/variables.rb
+++ b/lib/reek/ast/sexp_extensions/variables.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/when.rb
+++ b/lib/reek/ast/sexp_extensions/when.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/yield.rb
+++ b/lib/reek/ast/sexp_extensions/yield.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'options'
 require_relative 'option_interpreter'
 require_relative '../configuration/app_configuration'

--- a/lib/reek/cli/command/base_command.rb
+++ b/lib/reek/cli/command/base_command.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module CLI
     module Command

--- a/lib/reek/cli/command/report_command.rb
+++ b/lib/reek/cli/command/report_command.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'base_command'
 require_relative '../../examiner'
 

--- a/lib/reek/cli/command/todo_list_command.rb
+++ b/lib/reek/cli/command/todo_list_command.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'base_command'
 require_relative '../../examiner'
 

--- a/lib/reek/cli/input.rb
+++ b/lib/reek/cli/input.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../source/source_locator'
 
 module Reek

--- a/lib/reek/cli/option_interpreter.rb
+++ b/lib/reek/cli/option_interpreter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'forwardable'
 require_relative 'input'
 require_relative '../report'

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'optparse'
 require 'rainbow'
 require_relative '../version'

--- a/lib/reek/cli/silencer.rb
+++ b/lib/reek/cli/silencer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'stringio'
 
 module Reek

--- a/lib/reek/cli/warning_collector.rb
+++ b/lib/reek/cli/warning_collector.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'set'
 
 module Reek

--- a/lib/reek/code_comment.rb
+++ b/lib/reek/code_comment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'yaml'
 
 module Reek

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'pathname'
 require_relative './configuration_file_finder'
 require_relative './configuration_validator'

--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'pathname'
 
 module Reek

--- a/lib/reek/configuration/configuration_validator.rb
+++ b/lib/reek/configuration/configuration_validator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module Configuration
     #

--- a/lib/reek/configuration/default_directive.rb
+++ b/lib/reek/configuration/default_directive.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module Configuration
     #

--- a/lib/reek/configuration/directory_directives.rb
+++ b/lib/reek/configuration/directory_directives.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative './configuration_validator'
 
 module Reek

--- a/lib/reek/configuration/excluded_paths.rb
+++ b/lib/reek/configuration/excluded_paths.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative './configuration_validator'
 
 module Reek

--- a/lib/reek/context/attribute_context.rb
+++ b/lib/reek/context/attribute_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'code_context'
 
 module Reek

--- a/lib/reek/context/class_context.rb
+++ b/lib/reek/context/class_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'module_context'
 
 module Reek

--- a/lib/reek/context/code_context.rb
+++ b/lib/reek/context/code_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../code_comment'
 require_relative '../ast/object_refs'
 require_relative 'statement_counter'

--- a/lib/reek/context/ghost_context.rb
+++ b/lib/reek/context/ghost_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'code_context'
 require_relative 'singleton_method_context'
 

--- a/lib/reek/context/method_context.rb
+++ b/lib/reek/context/method_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'code_context'
 
 module Reek

--- a/lib/reek/context/module_context.rb
+++ b/lib/reek/context/module_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'code_context'
 require_relative 'attribute_context'
 require_relative 'method_context'

--- a/lib/reek/context/root_context.rb
+++ b/lib/reek/context/root_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'code_context'
 require_relative 'method_context'
 

--- a/lib/reek/context/send_context.rb
+++ b/lib/reek/context/send_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'code_context'
 
 module Reek

--- a/lib/reek/context/singleton_attribute_context.rb
+++ b/lib/reek/context/singleton_attribute_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'attribute_context'
 
 module Reek

--- a/lib/reek/context/singleton_method_context.rb
+++ b/lib/reek/context/singleton_method_context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'method_context'
 
 module Reek

--- a/lib/reek/context/statement_counter.rb
+++ b/lib/reek/context/statement_counter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../ast/node'
 
 module Reek

--- a/lib/reek/context/visibility_tracker.rb
+++ b/lib/reek/context/visibility_tracker.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module Context
     # Responsible for tracking visibilities in regards to CodeContexts.

--- a/lib/reek/context_builder.rb
+++ b/lib/reek/context_builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'context/attribute_context'
 require_relative 'context/class_context'
 require_relative 'context/ghost_context'

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'context_builder'
 require_relative 'source/source_code'
 require_relative 'cli/warning_collector'

--- a/lib/reek/rake/task.rb
+++ b/lib/reek/rake/task.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'rake'
 require 'rake/tasklib'

--- a/lib/reek/report.rb
+++ b/lib/reek/report.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'report/report'
 require_relative 'report/formatter'
 require_relative 'report/heading_formatter'

--- a/lib/reek/report/code_climate/code_climate_formatter.rb
+++ b/lib/reek/report/code_climate/code_climate_formatter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'codeclimate_engine'
 
 module Reek

--- a/lib/reek/report/formatter.rb
+++ b/lib/reek/report/formatter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'location_formatter'
 require_relative 'code_climate/code_climate_formatter'
 

--- a/lib/reek/report/heading_formatter.rb
+++ b/lib/reek/report/heading_formatter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module Report
     module HeadingFormatter

--- a/lib/reek/report/location_formatter.rb
+++ b/lib/reek/report/location_formatter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module Report
     #

--- a/lib/reek/report/report.rb
+++ b/lib/reek/report/report.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'json'
 require 'pathname'
 require 'rainbow'

--- a/lib/reek/smells.rb
+++ b/lib/reek/smells.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smells/attribute'
 require_relative 'smells/boolean_parameter'
 require_relative 'smells/class_variable'

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_configuration'
 require_relative 'smell_detector'
 require_relative 'smell_warning'

--- a/lib/reek/smells/boolean_parameter.rb
+++ b/lib/reek/smells/boolean_parameter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/class_variable.rb
+++ b/lib/reek/smells/class_variable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'set'
 require_relative 'smell_detector'
 require_relative 'smell_warning'

--- a/lib/reek/smells/control_parameter.rb
+++ b/lib/reek/smells/control_parameter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/feature_envy.rb
+++ b/lib/reek/smells/feature_envy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/irresponsible_module.rb
+++ b/lib/reek/smells/irresponsible_module.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_configuration'
 require_relative 'smell_detector'
 require_relative 'smell_warning'

--- a/lib/reek/smells/long_yield_list.rb
+++ b/lib/reek/smells/long_yield_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/module_initialize.rb
+++ b/lib/reek/smells/module_initialize.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/nil_check.rb
+++ b/lib/reek/smells/nil_check.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/prima_donna_method.rb
+++ b/lib/reek/smells/prima_donna_method.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../ast/node'
 require_relative 'smell_detector'
 require_relative 'smell_warning'

--- a/lib/reek/smells/smell_configuration.rb
+++ b/lib/reek/smells/smell_configuration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module Smells
     #

--- a/lib/reek/smells/smell_detector.rb
+++ b/lib/reek/smells/smell_detector.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'set'
 require_relative 'smell_configuration'
 

--- a/lib/reek/smells/smell_repository.rb
+++ b/lib/reek/smells/smell_repository.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../smells'
 require_relative 'smell_detector'
 require_relative '../configuration/app_configuration'

--- a/lib/reek/smells/smell_warning.rb
+++ b/lib/reek/smells/smell_warning.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'forwardable'
 
 module Reek

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/too_many_methods.rb
+++ b/lib/reek/smells/too_many_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/too_many_statements.rb
+++ b/lib/reek/smells/too_many_statements.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/uncommunicative_method_name.rb
+++ b/lib/reek/smells/uncommunicative_method_name.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 

--- a/lib/reek/smells/unused_private_method.rb
+++ b/lib/reek/smells/unused_private_method.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'smell_detector'
 require_relative 'smell_warning'
 require_relative '../context/method_context'

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../ast/reference_collector'
 require_relative 'smell_detector'
 require_relative 'smell_warning'

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../cli/silencer'
 Reek::CLI::Silencer.silently do
   require 'parser/ruby23'

--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'find'
 require 'pathname'
 

--- a/lib/reek/spec.rb
+++ b/lib/reek/spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'spec/should_reek'
 require_relative 'spec/should_reek_of'
 require_relative 'spec/should_reek_only_of'

--- a/lib/reek/spec/should_reek.rb
+++ b/lib/reek/spec/should_reek.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../examiner'
 require_relative '../report/formatter'
 

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../examiner'
 require_relative 'smell_matcher'
 

--- a/lib/reek/spec/should_reek_only_of.rb
+++ b/lib/reek/spec/should_reek_only_of.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative '../examiner'
 require_relative '../report/formatter'
 require_relative 'should_reek_of'

--- a/lib/reek/spec/smell_matcher.rb
+++ b/lib/reek/spec/smell_matcher.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Reek
   module Spec
     #

--- a/lib/reek/tree_dresser.rb
+++ b/lib/reek/tree_dresser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'ast/ast_node_class_map'
 
 module Reek

--- a/lib/reek/version.rb
+++ b/lib/reek/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # @public
 module Reek
   #


### PR DESCRIPTION
Follow-up for #850.

I decided to separate this out because:
* Frozen string literals is really a thing that only becomes relevant with Ruby 3.0
* There is no actual code change yet enforced by this cop
* We may accidentally return frozen strings from our API that may trip up downstream users
* RuboCop's autocorrect results are ugly at the moment