### PR TITLE
Fix link to Utility-Function in docs/Feature-Envy

### DIFF
--- a/docs/Feature-Envy.md
+++ b/docs/Feature-Envy.md
@@ -42,7 +42,7 @@ _Feature Envy_ reports any method that refers to self less often than it refers 
 
 ## Differences to _Utility Function_
 
-_Feature Envy_ is only triggered if there are some references to self and _[Utility Function](Utility Function.md)_ is triggered if there are no references to self.
+_Feature Envy_ is only triggered if there are some references to self and _[Utility Function](Utility-Function.md)_ is triggered if there are no references to self.
 
 ## Configuration
 


### PR DESCRIPTION
Missing dash. This one is correct https://github.com/troessner/reek/blob/master/docs/Utility-Function.md