### PR TITLE
Clean up Examiner constructor.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -32,7 +32,7 @@ source = <<-EOS
 EOS
 
 reporter = Reek::Report::TextReport.new
-examiner = Reek::Examiner.new(source)
+examiner = Reek::Examiner.new source
 reporter.add_examiner examiner
 reporter.show
 ```
@@ -175,7 +175,7 @@ source = <<-END
   end
 END
 
-examiner = Reek::Examiner.new(source)
+examiner = Reek::Examiner.new source
 examiner.smells.each do |smell|
   puts smell.message
 end

--- a/lib/reek/cli/command/report_command.rb
+++ b/lib/reek/cli/command/report_command.rb
@@ -21,7 +21,7 @@ module Reek
         def populate_reporter_with_smells(app)
           sources.each do |source|
             reporter.add_examiner Examiner.new(source,
-                                               smell_names,
+                                               filter_by_smells: smell_names,
                                                configuration: app.configuration)
           end
         end

--- a/lib/reek/cli/command/todo_list_command.rb
+++ b/lib/reek/cli/command/todo_list_command.rb
@@ -30,7 +30,7 @@ module Reek
         def scan_for_smells(app)
           sources.map do |source|
             Examiner.new(source,
-                         smell_names,
+                         filter_by_smells: smell_names,
                          configuration: app.configuration)
           end.map(&:smells).flatten
         end

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -27,7 +27,7 @@ module Reek
     #
     # @public
     def initialize(source,
-                   filter_by_smells = [],
+                   filter_by_smells: [],
                    configuration: Configuration::AppConfiguration.default)
       @source           = Source::SourceCode.from(source)
       @collector        = CLI::WarningCollector.new

--- a/lib/reek/spec/should_reek.rb
+++ b/lib/reek/spec/should_reek.rb
@@ -12,8 +12,8 @@ module Reek
         @configuration = configuration
       end
 
-      def matches?(actual)
-        self.examiner = Examiner.new(actual, configuration: configuration)
+      def matches?(source)
+        self.examiner = Examiner.new(source, configuration: configuration)
         examiner.smelly?
       end
 

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -19,8 +19,8 @@ module Reek
         @configuration  = configuration
       end
 
-      def matches?(actual)
-        self.examiner = Examiner.new(actual, [smell_type], configuration: configuration)
+      def matches?(source)
+        self.examiner = Examiner.new(source, configuration: configuration)
         set_failure_messages
         matching_smell_types? && matching_smell_details?
       end

--- a/lib/reek/spec/should_reek_only_of.rb
+++ b/lib/reek/spec/should_reek_only_of.rb
@@ -11,8 +11,8 @@ module Reek
     # code smell and no others.
     #
     class ShouldReekOnlyOf < ShouldReekOf
-      def matches?(actual)
-        matches_examiner?(Examiner.new(actual, configuration: configuration))
+      def matches?(source)
+        matches_examiner?(Examiner.new(source, configuration: configuration))
       end
 
       def matches_examiner?(examiner)

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -42,7 +42,11 @@ RSpec.describe Reek::Examiner do
 
   context 'with a partially masked smelly File' do
     let(:configuration) { test_configuration_for(path) }
-    let(:examiner) { described_class.new(smelly_file, [], configuration: configuration) }
+    let(:examiner) do
+      described_class.new(smelly_file,
+                          filter_by_smells: [],
+                          configuration: configuration)
+    end
     let(:path) { SAMPLES_PATH.join('all_but_one_masked/masked.reek') }
     let(:smelly_file) { Pathname.glob(SAMPLES_PATH.join('all_but_one_masked/d*.rb')).first }
 
@@ -59,7 +63,7 @@ RSpec.describe Reek::Examiner do
   describe '#smells' do
     it 'returns the detected smell warnings' do
       code     = 'def foo; bar.call_me(); bar.call_me(); end'
-      examiner = described_class.new code, ['DuplicateMethodCall']
+      examiner = described_class.new code, filter_by_smells: ['DuplicateMethodCall']
 
       smell = examiner.smells.first
       expect(smell).to be_a(Reek::Smells::SmellWarning)

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Reek::Smells::FeatureEnvy do
           #{receiver}.fred
         end
       EOS
-      Reek::Examiner.new(src, ['FeatureEnvy']).smells.first
+      Reek::Examiner.new(src, filter_by_smells: ['FeatureEnvy']).smells.first
     end
 
     it_should_behave_like 'common fields set correctly'

--- a/spec/reek/smells/unused_private_method_spec.rb
+++ b/spec/reek/smells/unused_private_method_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
         end
       EOF
 
-      examiner = Reek::Examiner.new(source, 'UnusedPrivateMethod', configuration: configuration)
+      examiner = Reek::Examiner.new(source,
+                                    filter_by_smells: 'UnusedPrivateMethod',
+                                    configuration: configuration)
 
       first_warning = examiner.smells.first
       expect(first_warning.smell_type).to eq(Reek::Smells::UnusedPrivateMethod.smell_type)
@@ -62,7 +64,9 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
         end
       EOF
 
-      examiner = Reek::Examiner.new(source, 'UnusedPrivateMethod', configuration: configuration)
+      examiner = Reek::Examiner.new(source,
+                                    filter_by_smells: 'UnusedPrivateMethod',
+                                    configuration: configuration)
 
       expect(examiner.smells.size).to eq(1)
       warning_for_drive = examiner.smells.first

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
             arga.b.c
           end
         EOS
-        Reek::Examiner.new(src, ['UtilityFunction']).smells[0]
+        Reek::Examiner.new(src, filter_by_smells: ['UtilityFunction']).smells[0]
       end
 
       it_should_behave_like 'common fields set correctly'


### PR DESCRIPTION
Fixes #650, has #869 as precondition (specs and features pass, but rubocop complains)