### PR TITLE
Introduce `private_constant`.

### DIFF
--- a/lib/reek/smells/control_parameter.rb
+++ b/lib/reek/smells/control_parameter.rb
@@ -90,6 +90,8 @@ module Reek
         attr_reader :occurences, :param
       end
 
+      private_constant :FoundControlParameter
+
       # Finds cases of ControlParameter in a particular node for a particular parameter
       class ControlParameterFinder
         CONDITIONAL_NODE_TYPES = [:if, :case, :and, :or].freeze
@@ -166,6 +168,8 @@ module Reek
         end
       end
 
+      private_constant :ControlParameterFinder
+
       #
       # Collects all control parameters in a given context.
       #
@@ -192,6 +196,8 @@ module Reek
           ControlParameterFinder.new(context.exp, param).find_matches
         end
       end
+
+      private_constant :ControlParameterCollector
     end
   end
 end

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -89,6 +89,8 @@ module Reek
         attr_reader :call_node, :occurences
       end
 
+      private_constant :FoundCall
+
       # Collects all calls in a given context
       class CallCollector
         attr_reader :context
@@ -139,6 +141,8 @@ module Reek
           allow_calls.any? { |allow| /#{allow}/ =~ method }
         end
       end
+
+      private_constant :CallCollector
     end
   end
 end

--- a/lib/reek/smells/nil_check.rb
+++ b/lib/reek/smells/nil_check.rb
@@ -45,6 +45,8 @@ module Reek
         attr_reader :detector, :nodes
       end
 
+      private_constant :NodeFinder
+
       # Detect 'call' nodes which perform a nil check.
       module NilCallNodeDetector
         module_function


### PR DESCRIPTION
I started out with the obvious cases which are inner classes. (And yes, Ruby has them, and no, i don't care that they mean something different in other languages ;) )
Note that there are quite a few other classes where we should use `private_constant` as well like DataClump. But there the soon-to-be private classes are at package level, not scoped to the actual class that uses them. 
So I'd like to refactor those classes (especially DataClump!) before introducing `private_constant` there.