### PR TITLE
Integrate mutant in our CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ bundler_args: --without debugging
 script:
 - bundle exec rake
 - bundle exec ataru check
+- bundle exec mutant --include lib --require reek --use rspec --since master --jobs 4 "Reek*"
 rvm:
   - 2.1
   - 2.2

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development do
   gem 'rubocop',       '~> 0.37.0'
   gem 'yard',          '~> 0.8.7'
   gem 'simplecov',     '~> 0.11.1'
+  gem 'mutant-rspec',  '~> 0.8.8'
 
   platforms :mri do
     gem 'redcarpet', '~> 3.3.1'


### PR DESCRIPTION
WIP PR - i wanted to discuss this first before going further.

* This runs mutant against everything we marked as public api (except for version.rb) comparing it to the master branch (--since master)
* Speed: In case there are no changes of our subjects in regards to the master branch the whole mutant run takes less than 3 seconds on my machine

Missing:

* Proper rake task integration, right now it's just a wall of hard to read text in our travis configuration

cc @mbj - what do you think of this set up?

P.S.: The travis failure come from ruby 2.0 which will be gone [pretty soon anyway](https://github.com/troessner/reek/pull/869)