### PR TITLE
Issue with unused param detection.

### DIFF
--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -66,5 +66,10 @@ RSpec.describe Reek::Smells::UnusedParameters do
       expect('def simple(var, kw: :val, **args); @var, @kw, @args = var, kw, args; end').
         not_to reek_of(:UnusedParameters)
     end
+
+    it 'reports nothing when using a parameter on a rescue' do
+      expect('def simple(tries = 3); puts "nothing"; rescue; retry if tries =- 1 > 0; raise; end').
+        not_to reek_of(:UnusedParameters)
+    end
   end
 end


### PR DESCRIPTION
I've found an edge case for the UnusedParam smell. In a case like this:

```ruby
def with_retries(tries = 3)
  yield
rescue
  retry if tries =- 1 > 0
  raise
end
```

It detects `tries` as an unused param while it is used in the rescue. Is this the expected behavior? Or is it a false positive?

Kudos for such an amazing and useful gem.