### PR TITLE
Fix UnusedParameter detector for lvasgn.

### DIFF
--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -66,5 +66,14 @@ RSpec.describe Reek::Smells::UnusedParameters do
       expect('def simple(var, kw: :val, **args); @var, @kw, @args = var, kw, args; end').
         not_to reek_of(:UnusedParameters)
     end
+
+    it 'reports nothing when using a parameter via self assignment' do
+      expect('def simple(counter); counter += 1; end').not_to reek_of(:UnusedParameters)
+    end
+
+    it 'reports nothing when using a parameter on a rescue' do
+      expect('def simple(tries = 3); puts "nothing"; rescue; retry if tries -= 1 > 0; raise; end').
+        not_to reek_of(:UnusedParameters)
+    end
   end
 end


### PR DESCRIPTION
Same as #880 but now with more appropriate branch name and commit message.
Fixes #878 
