### PR TITLE
Add rb-readline as development dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ group :development do
 end
 
 group :debugging do
+  # Fixing https://github.com/guard/guard/wiki/Add-Readline-support-to-Ruby-on-Mac-OS-X#option-4-using-a-pure-ruby-readline-implementation
+  gem 'rb-readline', '~> 0.5.3'
   gem 'pry'
   platforms :mri do
     gem 'pry-byebug'


### PR DESCRIPTION
Solves [pry history not working correctly under macos](https://github.com/guard/guard/wiki/Add-Readline-support-to-Ruby-on-Mac-OS-X#option-4-using-a-pure-ruby-readline-implementation)