### PR TITLE
Fix `accept` and `reject` configuration handling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tags
 .tags*
 .DS_Store
 .idea/
+.rbenv-gemsets

--- a/docs/Uncommunicative-Method-Name.md
+++ b/docs/Uncommunicative-Method-Name.md
@@ -20,5 +20,35 @@ Reek's Uncommunicative Method Name detector supports the [Basic Smell Options](B
 
 | Option         | Value       | Effect  |
 | ---------------|-------------|---------|
-| `reject` | array of regular expressions | The set of regular expressions that Reek uses to check for bad names. Defaults to `[/^[a-z]$/, /[0-9]$/, /[A-Z]/]`. |
-| `accept` | array of strings or regular expressions | Name that will be accepted (not reported) even if they match one of the `reject` expressions. |
+| `reject` | array of regular expressions or strings | The set of patterns / names that Reek uses to check for bad names. Defaults to `[/^[a-z]$/, /[0-9]$/, /[A-Z]/]`. |
+| `accept` | array of regular expressions or strings | The set of patterns / names that Reek will accept (and not report) even if they match one of the `reject` expressions. |
+
+An example configuration could look like this:
+
+```Yaml
+---
+UncommunicativeMethodName:
+  accept:
+    - !ruby/regexp /x/
+    - meth1
+  reject:
+    - !ruby/regexp /helper/
+    - foobar
+```
+
+Applying a configuration to a source file like this:
+
+```Ruby
+def x; end # Should not be reported
+def meth1; end # Should not be reported
+def foobar; end # Should be reported
+def awesome_helper; end # Should be reported
+```
+
+Reek would report:
+
+```
+smelly.rb -- 2 warnings:
+  [4]:UncommunicativeMethodName: awesome_helper has the name 'awesome_helper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+  [3]:UncommunicativeMethodName: foobar has the name 'foobar' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+```

--- a/docs/Uncommunicative-Module-Name.md
+++ b/docs/Uncommunicative-Module-Name.md
@@ -19,5 +19,32 @@ Reek's `Uncommunicative Module Name` detector supports the [Basic Smell Options]
 
 | Option         | Value       | Effect  |
 | ---------------|-------------|---------|
-| `reject` | array of regular expressions | The set of regular expressions that Reek uses to check for bad names. Defaults to `[/^.$/, /[0-9]$/]`. |
-| `accept` | array of names as strings | List of names that will be accepted (not reported) even if they match one of the `reject` expressions. Empty by default.|
+| `reject` | array of regular expressions or strings | The set of patterns / names that Reek uses to check for bad names. Defaults to `[/^.$/, /[0-9]$/]`. |
+| `accept` | array of regular expressions or strings | The set of patterns / names that Reek will accept (and not report) even if they match one of the `reject` expressions. Empty by default.|
+
+An example configuration could look like this:
+
+```Yaml
+---
+UncommunicativeModuleName:
+  accept:
+    - !ruby/regexp /lassy/
+    - M
+  reject:
+    - !ruby/regexp /Helper/
+```
+
+Applying a configuration to a source file like this:
+
+```Ruby
+class Classy1; end # Should not be reported
+class M; end # Should not be reported
+class BaseHelper; end # Should be reported
+```
+
+Reek would report:
+
+```
+smelly.rb -- 1 warning:
+  [3]:UncommunicativeModuleName: BaseHelper has the name 'BaseHelper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Module-Name.md]
+```

--- a/docs/Uncommunicative-Parameter-Name.md
+++ b/docs/Uncommunicative-Parameter-Name.md
@@ -20,5 +20,33 @@ Reek's Uncommunicative Parameter Name detector supports the [Basic Smell Options
 
 | Option         | Value       | Effect  |
 | ---------------|-------------|---------|
-| `reject` | array of regular expressions | The set of regular expressions that Reek uses to check for bad names. Defaults to `[/^.$/, /[0-9]$/, /[A-Z]/]@. |
-| `accept` | array of strings or regular expressions | Name that will be accepted (not reported) even if they match one of the `reject` expressions. |
+| `reject` | array of regular expressions or strings | The set of patterns / names that Reek uses to check for bad names. Defaults to `[/^.$/, /[0-9]$/, /[A-Z]/, /^_/]. |
+| `accept` | array of regular expressions or strings | The set of patterns / names that Reek will accept (and not report) even if they match one of the `reject` expressions. |
+
+
+An example configuration could look like this:
+
+```Yaml
+---
+UncommunicativeParameterName:
+  accept:
+    - !ruby/regexp /x/
+    - arg1
+  reject:
+    - !ruby/regexp /foobar/
+```
+
+Applying a configuration to a source file like this:
+
+```Ruby
+def omg(x); x; end # Should not be reported
+def omg(arg1); arg1; end # Should not be reported
+def omg(foobar); foobar; end # Should be reported
+```
+
+Reek would report:
+
+```
+smelly.rb -- 1 warning:
+  [3]:UncommunicativeParameterName: omg has the parameter name 'foobar' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md]
+```

--- a/features/configuration_files/accept_setting.feature
+++ b/features/configuration_files/accept_setting.feature
@@ -1,0 +1,70 @@
+Feature: `accept` configuration setting
+  In order to have a more fine-grained control over what Reek reports
+  As a user
+  I want to be able to accept specific patterns and names to exclude them from reporting
+
+  Scenario: Accept names as list and as single item
+    Given a file named "config.reek" with:
+      """
+      ---
+      UncommunicativeMethodName:
+        accept:
+          - m1
+          - m2
+      UncommunicativeParameterName:
+        accept:
+          - a1
+          - a2
+      UncommunicativeModuleName:
+        accept: C1
+      """
+    And a file named "smelly.rb" with:
+      """
+      # Should not report UncommunicativeModuleName
+      class C1
+        # Should not report UncommunicativeMethodName and UncommunicativeParameterName
+        def m1(a1); a1; end
+        # Should not report UncommunicativeMethodName and UncommunicativeParameterName
+        def m2(a2); a2; end
+        # Should report UncommunicativeMethodName and UncommunicativeParameterName
+        def m3(a3); a3; end
+      end
+      """
+    When I run `reek -c config.reek smelly.rb`
+    Then it reports:
+    """
+    smelly.rb -- 2 warnings:
+      [8]:UncommunicativeMethodName: C1#m3 has the name 'm3' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      [8]:UncommunicativeParameterName: C1#m3 has the parameter name 'a3' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md]
+    """
+
+  Scenario: Accept regexes as list and as single item
+    Given a file named "config.reek" with:
+      """
+      ---
+      UncommunicativeMethodName:
+        accept:
+          - !ruby/regexp /oobar/
+      UncommunicativeParameterName:
+        accept:
+          - !ruby/regexp /ola/
+      UncommunicativeModuleName:
+        accept: !ruby/regexp /lassy/
+      """
+    And a file named "smelly.rb" with:
+      """
+      # Should not report UncommunicativeModuleName
+      class Classy1
+        # Should not report UncommunicativeMethodName and UncommunicativeParameterName
+        def foobar1(hola1); hola1; end
+        # Should report UncommunicativeMethodName and UncommunicativeParameterName
+        def m2(a2); a2; end
+      end
+      """
+    When I run `reek -c config.reek smelly.rb`
+    Then it reports:
+    """
+    smelly.rb -- 2 warnings:
+      [6]:UncommunicativeMethodName: Classy1#m2 has the name 'm2' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      [6]:UncommunicativeParameterName: Classy1#m2 has the parameter name 'a2' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md]
+    """

--- a/features/configuration_files/mix_accept_reject_setting.feature
+++ b/features/configuration_files/mix_accept_reject_setting.feature
@@ -1,0 +1,81 @@
+Feature: Mix `accept` and `reject` configuration settings
+  In order to have a more fine-grained control over what Reek reports
+  As a user
+  I want to be able to mix the `accept` and `reject` setting
+
+  Scenario: UncommunicativeMethodName
+    Given a file named "config.reek" with:
+      """
+      ---
+      UncommunicativeMethodName:
+        accept:
+          - !ruby/regexp /x/
+          - meth1
+        reject:
+          - !ruby/regexp /helper/
+          - foobar
+      """
+    And a file named "smelly.rb" with:
+      """
+      def x; end # Should not be reported
+      def meth1; end # Should not be reported
+      def foobar; end # Should be reported
+      def awesome_helper; end # Should be reported
+      """
+    When I run `reek -c config.reek smelly.rb`
+    Then it reports:
+    """
+    smelly.rb -- 2 warnings:
+      [4]:UncommunicativeMethodName: awesome_helper has the name 'awesome_helper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      [3]:UncommunicativeMethodName: foobar has the name 'foobar' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+    """
+
+  Scenario: UncommunicativeModuleName
+    Given a file named "config.reek" with:
+      """
+      ---
+      IrresponsibleModule:
+        enabled: false
+      UncommunicativeModuleName:
+        accept:
+          - !ruby/regexp /lassy/
+          - M
+        reject:
+          - !ruby/regexp /Helper/
+      """
+    And a file named "smelly.rb" with:
+      """
+      class Classy1; end # Should not be reported
+      class M; end # Should not be reported
+      class BaseHelper; end # Should be reported
+      """
+    When I run `reek -c config.reek smelly.rb`
+    Then it reports:
+    """
+    smelly.rb -- 1 warning:
+      [3]:UncommunicativeModuleName: BaseHelper has the name 'BaseHelper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Module-Name.md]
+    """
+
+  Scenario: UncommunicativeParameterName
+    Given a file named "config.reek" with:
+      """
+      ---
+      UncommunicativeParameterName:
+        accept:
+          - !ruby/regexp /x/
+          - arg1
+        reject:
+          - !ruby/regexp /foobar/
+      """
+    And a file named "smelly.rb" with:
+      """
+      def omg(x); x; end # Should not be reported
+      def omg(arg1); arg1; end # Should not be reported
+      def omg(foobar); foobar; end # Should be reported
+      """
+    When I run `reek -c config.reek smelly.rb`
+    Then it reports:
+    """
+    smelly.rb -- 1 warning:
+      [3]:UncommunicativeParameterName: omg has the parameter name 'foobar' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md]
+    """

--- a/features/configuration_files/reject_setting.feature
+++ b/features/configuration_files/reject_setting.feature
@@ -1,0 +1,78 @@
+Feature: `reject` configuration setting
+  In order to have a more fine-grained control over what Reek reports
+  As a user
+  I want to be able to reject specific patterns and names to include them into reporting
+
+  Scenario: reject names as list and as single item
+    Given a file named "config.reek" with:
+      """
+      ---
+      UncommunicativeMethodName:
+        reject:
+          - awesome_helper
+          - little_helper
+      UncommunicativeParameterName:
+        reject:
+          - solid_argument
+          - nifty_argument
+      UncommunicativeModuleName:
+        reject: Dummy
+      """
+    And a file named "smelly.rb" with:
+      """
+      # Should report UncommunicativeModuleName
+      class Dummy
+        # Should report UncommunicativeMethodName and UncommunicativeParameterName
+        def awesome_helper(solid_argument); solid_argument; end
+        # Should report UncommunicativeMethodName and UncommunicativeParameterName
+        def little_helper(nifty_argument); nifty_argument; end
+        # Should not report UncommunicativeMethodName and UncommunicativeParameterName
+        def meth(argument); argument; end
+      end
+      """
+    When I run `reek -c config.reek smelly.rb`
+    Then it reports:
+    """
+    smelly.rb -- 5 warnings:
+      [4]:UncommunicativeMethodName: Dummy#awesome_helper has the name 'awesome_helper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      [6]:UncommunicativeMethodName: Dummy#little_helper has the name 'little_helper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      [2]:UncommunicativeModuleName: Dummy has the name 'Dummy' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Module-Name.md]
+      [4]:UncommunicativeParameterName: Dummy#awesome_helper has the parameter name 'solid_argument' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md]
+      [6]:UncommunicativeParameterName: Dummy#little_helper has the parameter name 'nifty_argument' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md]
+    """
+
+  Scenario: reject regexes as list and as single item
+    Given a file named "config.reek" with:
+      """
+      ---
+      UncommunicativeMethodName:
+        reject: !ruby/regexp /helper/
+      UncommunicativeParameterName:
+        reject:
+          - !ruby/regexp /solid/
+          - !ruby/regexp /nifty/
+      UncommunicativeModuleName:
+        reject: !ruby/regexp /ummy/
+      """
+    And a file named "smelly.rb" with:
+      """
+      # Should report UncommunicativeModuleName
+      class Dummy
+        # Should report UncommunicativeMethodName and UncommunicativeParameterName
+        def awesome_helper(solid_argument); solid_argument; end
+        # Should report UncommunicativeMethodName and UncommunicativeParameterName
+        def little_helper(nifty_argument); nifty_argument; end
+        # Should not report UncommunicativeMethodName and UncommunicativeParameterName
+        def meth(argument); argument; end
+      end
+      """
+    When I run `reek -c config.reek smelly.rb`
+    Then it reports:
+    """
+    smelly.rb -- 5 warnings:
+      [4]:UncommunicativeMethodName: Dummy#awesome_helper has the name 'awesome_helper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      [6]:UncommunicativeMethodName: Dummy#little_helper has the name 'little_helper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      [2]:UncommunicativeModuleName: Dummy has the name 'Dummy' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Module-Name.md]
+      [4]:UncommunicativeParameterName: Dummy#awesome_helper has the parameter name 'solid_argument' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md]
+      [6]:UncommunicativeParameterName: Dummy#little_helper has the parameter name 'nifty_argument' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md]
+    """

--- a/lib/reek/smells/uncommunicative_method_name.rb
+++ b/lib/reek/smells/uncommunicative_method_name.rb
@@ -16,18 +16,19 @@ module Reek
     # Currently +UncommunicativeMethodName+ checks for
     # * 1-character names
     # * names ending with a number
+    # * names containing a capital letter (assuming camelCase)
     #
     # See {file:docs/Uncommunicative-Method-Name.md} for details.
     class UncommunicativeMethodName < SmellDetector
       REJECT_KEY = 'reject'.freeze
       ACCEPT_KEY = 'accept'.freeze
       DEFAULT_REJECT_PATTERNS = [/^[a-z]$/, /[0-9]$/, /[A-Z]/].freeze
-      DEFAULT_ACCEPT_NAMES = [].freeze
+      DEFAULT_ACCEPT_PATTERNS = [].freeze
 
       def self.default_config
         super.merge(
           REJECT_KEY => DEFAULT_REJECT_PATTERNS,
-          ACCEPT_KEY => DEFAULT_ACCEPT_NAMES
+          ACCEPT_KEY => DEFAULT_ACCEPT_PATTERNS
         )
       end
 
@@ -50,16 +51,16 @@ module Reek
       private
 
       def acceptable_name?(name:, context:)
-        accept_names(context).any? { |accept_name| name == accept_name } ||
-          reject_patterns(context).none? { |pattern| name.match pattern }
+        accept_patterns(context).any? { |accept_pattern| name.match accept_pattern } ||
+          reject_patterns(context).none? { |reject_pattern| name.match reject_pattern }
       end
 
       def reject_patterns(context)
-        value(REJECT_KEY, context, DEFAULT_REJECT_PATTERNS)
+        Array value(REJECT_KEY, context, DEFAULT_REJECT_PATTERNS)
       end
 
-      def accept_names(context)
-        value(ACCEPT_KEY, context, DEFAULT_ACCEPT_NAMES)
+      def accept_patterns(context)
+        Array value(ACCEPT_KEY, context, DEFAULT_ACCEPT_PATTERNS)
       end
     end
   end

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -28,12 +28,12 @@ module Reek
       # to be treated as exceptions; these names will not be reported as
       # uncommunicative.
       ACCEPT_KEY = 'accept'.freeze
-      DEFAULT_ACCEPT_NAMES = [].freeze
+      DEFAULT_ACCEPT_PATTERNS = [].freeze
 
       def self.default_config
-        super.merge(
+        super().merge(
           REJECT_KEY => DEFAULT_REJECT_PATTERNS,
-          ACCEPT_KEY => DEFAULT_ACCEPT_NAMES
+          ACCEPT_KEY => DEFAULT_ACCEPT_PATTERNS
         )
       end
 
@@ -66,16 +66,16 @@ module Reek
 
       # :reek:ControlParameter
       def acceptable_name?(context:, module_name:, fully_qualified_name:)
-        accept_names(context).any? { |accept_name| fully_qualified_name == accept_name } ||
-          reject_patterns(context).none? { |pattern| module_name.match pattern }
+        accept_patterns(context).any? { |accept_pattern| fully_qualified_name.match accept_pattern } ||
+          reject_patterns(context).none? { |reject_pattern| module_name.match reject_pattern }
       end
 
       def reject_patterns(context)
-        value(REJECT_KEY, context, DEFAULT_REJECT_PATTERNS)
+        Array value(REJECT_KEY, context, DEFAULT_REJECT_PATTERNS)
       end
 
-      def accept_names(context)
-        value(ACCEPT_KEY, context, DEFAULT_ACCEPT_NAMES)
+      def accept_patterns(context)
+        Array value(ACCEPT_KEY, context, DEFAULT_ACCEPT_PATTERNS)
       end
     end
   end

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -16,6 +16,8 @@ module Reek
     # Currently +UncommunicativeParameterName+ checks for
     # * 1-character names
     # * names ending with a number
+    # * names beginning with an underscore
+    # * names containing a capital letter (assuming camelCase)
     #
     # See {file:docs/Uncommunicative-Parameter-Name.md} for details.
     class UncommunicativeParameterName < SmellDetector
@@ -23,12 +25,12 @@ module Reek
       DEFAULT_REJECT_PATTERNS = [/^.$/, /[0-9]$/, /[A-Z]/, /^_/].freeze
 
       ACCEPT_KEY = 'accept'.freeze
-      DEFAULT_ACCEPT_NAMES = [].freeze
+      DEFAULT_ACCEPT_PATTERNS = [].freeze
 
       def self.default_config
         super.merge(
           REJECT_KEY => DEFAULT_REJECT_PATTERNS,
-          ACCEPT_KEY => DEFAULT_ACCEPT_NAMES
+          ACCEPT_KEY => DEFAULT_ACCEPT_PATTERNS
         )
       end
 
@@ -58,16 +60,16 @@ module Reek
       end
 
       def acceptable_name?(name:, context:)
-        accept_names(context).any? { |accept_name| name == accept_name } ||
-          reject_patterns(context).none? { |pattern| name.match pattern }
+        accept_patterns(context).any? { |accept_pattern| name.match accept_pattern } ||
+          reject_patterns(context).none? { |reject_pattern| name.match reject_pattern }
       end
 
       def reject_patterns(context)
-        value(REJECT_KEY, context, DEFAULT_REJECT_PATTERNS)
+        Array value(REJECT_KEY, context, DEFAULT_REJECT_PATTERNS)
       end
 
-      def accept_names(context)
-        value(ACCEPT_KEY, context, DEFAULT_ACCEPT_NAMES)
+      def accept_patterns(context)
+        Array value(ACCEPT_KEY, context, DEFAULT_ACCEPT_PATTERNS)
       end
 
       # :reek:UtilityFunction

--- a/spec/reek/smells/uncommunicative_method_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_method_name_spec.rb
@@ -4,31 +4,87 @@ require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::UncommunicativeMethodName do
   let(:detector) { build(:smell_detector, smell_type: :UncommunicativeMethodName) }
-
   it_should_behave_like 'SmellDetector'
 
-  ['help', '+', '-', '/', '*'].each do |method_name|
-    it "accepts the method name '#{method_name}'" do
-      src = "def #{method_name}(arg) basics(17) end"
-      expect(src).not_to reek_of(:UncommunicativeMethodName)
+  describe 'default configuration' do
+    it 'reports one-word names' do
+      expect('def a; end').to reek_of(:UncommunicativeMethodName)
+    end
+
+    it 'reports names ending with a digit' do
+      expect('def xyz1; end').to reek_of(:UncommunicativeMethodName)
+    end
+
+    it 'reports camelcased names' do
+      expect('def aBBa; end').to reek_of(:UncommunicativeMethodName)
+    end
+
+    it 'does not report one-letter special characters' do
+      ['+', '-', '/', '*'].each do |symbol|
+        expect("def #{symbol}; end").not_to reek_of(:UncommunicativeMethodName)
+      end
     end
   end
 
-  ['x', 'x2', 'method2'].each do |method_name|
-    context 'with a bad name' do
-      let(:warning) do
-        src = "def #{method_name}; end"
-        ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-        detector.inspect(ctx).first
-      end
+  describe 'inspect' do
+    let(:source) { 'def x; end' }
+    let(:context) { code_context(source) }
+    let(:detector) { build(:smell_detector, smell_type: :UncommunicativeMethodName) }
 
-      it_should_behave_like 'common fields set correctly'
+    it 'returns an array of smell warnings' do
+      smells = detector.inspect(context)
+      expect(smells.length).to eq(1)
+      expect(smells[0]).to be_a_kind_of(Reek::Smells::SmellWarning)
+    end
 
-      it 'reports the correct values' do
-        expect(warning.parameters[:name]).to eq(method_name)
-        expect(warning.lines).to eq([1])
-        expect(warning.context).to eq(method_name)
+    it 'contains proper smell warnings' do
+      smells = detector.inspect(context)
+      warning = smells[0]
+
+      expect(warning.smell_type).to eq(Reek::Smells::UncommunicativeMethodName.smell_type)
+      expect(warning.parameters[:name]).to eq('x')
+      expect(warning.context).to match(/#{warning.parameters[:name]}/)
+      expect(warning.lines).to eq([1])
+    end
+  end
+
+  describe '`accept` patterns' do
+    let(:source) { 'def x; end' }
+
+    it 'make smelly names pass via regex / strings given by list / literal' do
+      [[/x/], /x/, ['x'], 'x'].each do |pattern|
+        configuration = accept_configuration_for(described_class, pattern: pattern)
+        expect(source).to_not reek_of(described_class, {}, configuration)
       end
+    end
+  end
+
+  describe '`reject` patterns' do
+    let(:source) { 'def helper; end' }
+
+    it 'reject smelly names via regex / strings given by list / literal' do
+      [[/helper/], /helper/, ['helper'], 'helper'].each do |pattern|
+        configuration = reject_configuration_for(described_class, pattern: pattern)
+        expect(source).to reek_of(described_class, {}, configuration)
+      end
+    end
+  end
+
+  describe '.default_config' do
+    it 'should merge in the default accept and reject patterns' do
+      expected = {
+        'enabled' => true,
+        'exclude' => [],
+        'reject'  => [/^[a-z]$/, /[0-9]$/, /[A-Z]/],
+        'accept'  => []
+      }
+      expect(described_class.default_config).to eq(expected)
+    end
+  end
+
+  describe '.contexts' do
+    it 'should be scoped to classes and modules' do
+      expect(described_class.contexts).to eq([:def, :defs])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,33 @@ module Helpers
     Reek::Source::SourceCode.from(code).syntax_tree
   end
 
+  # @param code [String] The given code.
+  #
+  # @return syntax_tree [Reek::Context::CodeContext]
+  def code_context(code)
+    Reek::Context::CodeContext.new(nil, syntax_tree(code))
+  end
+
+  # @param code [String] The given code.
+  #
+  # @return syntax_tree [Reek::Context::MethodContext]
+  def method_context(code)
+    Reek::Context::MethodContext.new(nil, syntax_tree(code))
+  end
+
+  # Helper methods to generate a configuration for smell types that support
+  # `accept` and `reject` settings.
+  %w(accept reject).each do |switch|
+    define_method("#{switch}_configuration_for") do |smell_type, pattern:|
+      hash = {
+        smell_type => {
+          switch => pattern
+        }
+      }
+      Reek::Configuration::AppConfiguration.from_hash(hash)
+    end
+  end
+
   # :reek:UncommunicativeMethodName
   def sexp(type, *children)
     @klass_map ||= Reek::AST::ASTNodeClassMap.new


### PR DESCRIPTION
Preliminary PR, fixes #886, successor of #887 (which had a bad branch name in the end)
What does this bad boy do?
Glad you asked!

* consistent handling of `reject` and `accept`
* makes both settings handle strings and regexes properly
* makes both settings handle list and single values
* tests!
* Updates and improves our documentation

Tomorrow I'll make some final tweaks and then this is ready for review!