### PR TITLE
Remove deprecated method `from_map` from AppConfiguration.

### DIFF
--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -31,36 +31,6 @@ module Reek
 
       # Instantiate a configuration by passing everything in.
       #
-      # @deprecated This method will be removed in Reek 4.0.
-      #
-      # @param [Hash] map a hash with three possible keys representing
-      # different types of directives.
-      # @option map [Hash] :directory_directives Directory specific configuration
-      #   for instance:
-      #     { Pathname("spec/samples/three_clean_files/") =>
-      #       { Reek::Smells::UtilityFunction => { "enabled" => false } } }
-      # @option map [Hash] :default_directive Default configuration
-      #   for instance:
-      #     { Reek::Smells::IrresponsibleModule => { "enabled" => false } }
-      # @option map [Array] :excluded_paths list of paths to exclude from analysis
-      #   for instance:
-      #     [ Pathname('spec/samples/two_smelly_files') ]
-      #
-      # @return [AppConfiguration]
-      #
-      # @public
-      def self.from_map(map = {})
-        allocate.tap do |instance|
-          instance.instance_eval do
-            load_values map.fetch(:directory_directives, {})
-            load_values map.fetch(:default_directive, {})
-            load_values EXCLUDE_PATHS_KEY => map.fetch(:excluded_paths, [])
-          end
-        end
-      end
-
-      # Instantiate a configuration by passing everything in.
-      #
       # Loads the configuration from a hash of the form that is loaded from a
       # +.reek+ config file.
       # @param [Hash] hash The configuration hash to load.

--- a/spec/reek/configuration/app_configuration_spec.rb
+++ b/spec/reek/configuration/app_configuration_spec.rb
@@ -57,28 +57,6 @@ RSpec.describe Reek::Configuration::AppConfiguration do
       end
     end
 
-    describe '#from_map' do
-      it 'properly sets the configuration from simple data structures' do
-        config = described_class.from_map(directory_directives: directory_directives_value,
-                                          default_directive: default_directive_value,
-                                          excluded_paths: exclude_paths_value)
-
-        expect(config.send(:excluded_paths)).to eq(expected_excluded_paths)
-        expect(config.send(:default_directive)).to eq(expected_default_directive)
-        expect(config.send(:directory_directives)).to eq(expected_directory_directives)
-      end
-
-      it 'properly sets the configuration from native structures' do
-        config = described_class.from_map(directory_directives: expected_directory_directives,
-                                          default_directive: expected_default_directive,
-                                          excluded_paths: expected_excluded_paths)
-
-        expect(config.send(:excluded_paths)).to eq(expected_excluded_paths)
-        expect(config.send(:default_directive)).to eq(expected_default_directive)
-        expect(config.send(:directory_directives)).to eq(expected_directory_directives)
-      end
-    end
-
     describe '#from_hash' do
       it 'sets the configuration a unified simple data structure' do
         config = described_class.from_hash(combined_value)
@@ -104,7 +82,7 @@ RSpec.describe Reek::Configuration::AppConfiguration do
       end
 
       it 'returns the corresponding directive' do
-        configuration = described_class.from_map directory_directives: directory_directives
+        configuration = described_class.from_hash directory_directives
         expect(configuration.directive_for(source_via)).to eq(bang_config)
       end
     end
@@ -120,11 +98,12 @@ RSpec.describe Reek::Configuration::AppConfiguration do
         }
       end
       let(:source_via) { "#{directory}/dummy.rb" }
+      let(:configuration_as_hash) { directory_directives.merge(default_directive) }
 
       it 'returns the directory directive with the default directive reverse-merged' do
-        configuration = described_class.from_map directory_directives: directory_directives,
-                                                 default_directive: default_directive
+        configuration = described_class.from_hash configuration_as_hash
         actual = configuration.directive_for(source_via)
+
         expect(actual[Reek::Smells::IrresponsibleModule]).to be_truthy
         expect(actual[Reek::Smells::TooManyStatements]).to be_truthy
         expect(actual[Reek::Smells::TooManyStatements][:max_statements]).to eq(8)
@@ -138,10 +117,10 @@ RSpec.describe Reek::Configuration::AppConfiguration do
       let(:directory_directives) do
         { 'spec/samples/two_smelly_files' => attribute_config }
       end
+      let(:configuration_as_hash) { directory_directives.merge(default_directive) }
 
       it 'returns the default directive' do
-        configuration = described_class.from_map directory_directives: directory_directives,
-                                                 default_directive: default_directive
+        configuration = described_class.from_hash configuration_as_hash
         expect(configuration.directive_for(source_via)).to eq(default_directive)
       end
     end

--- a/spec/reek/smells/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_module_name_spec.rb
@@ -39,13 +39,11 @@ RSpec.describe Reek::Smells::UncommunicativeModuleName do
   context 'accept patterns' do
     let(:configuration) do
       default_directive_for_smell = {
-        default_directive: {
-          Reek::Smells::UncommunicativeModuleName => {
-            'accept' => ['Inline::C']
-          }
+        Reek::Smells::UncommunicativeModuleName => {
+          'accept' => ['Inline::C']
         }
       }
-      Reek::Configuration::AppConfiguration.from_map(default_directive_for_smell)
+      Reek::Configuration::AppConfiguration.from_hash(default_directive_for_smell)
     end
 
     it 'make smelly name pass' do

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -220,13 +220,11 @@ RSpec.describe Reek::Smells::UtilityFunction do
   describe 'disabling UtilityFunction via configuration for non-public methods' do
     let(:configuration) do
       default_directive = {
-        default_directive: {
-          Reek::Smells::UtilityFunction => {
-            Reek::Smells::UtilityFunction::PUBLIC_METHODS_ONLY_KEY => true
-          }
+        Reek::Smells::UtilityFunction => {
+          Reek::Smells::UtilityFunction::PUBLIC_METHODS_ONLY_KEY => true
         }
       }
-      Reek::Configuration::AppConfiguration.from_map(default_directive)
+      Reek::Configuration::AppConfiguration.from_hash(default_directive)
     end
 
     context 'public methods' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ module Helpers
     when Pathname
       configuration = Reek::Configuration::AppConfiguration.from_path(config)
     when Hash
-      configuration = Reek::Configuration::AppConfiguration.from_map default_directive: config
+      configuration = Reek::Configuration::AppConfiguration.from_hash config
     else
       raise "Unknown config given in `test_configuration_for`: #{config.inspect}"
     end


### PR DESCRIPTION
Fixes the second part of #891 
Speedy review would be awesome since this blocks my rspec refactoring necessary for mutant necessary for #890 