### PR TITLE
Fix excluded paths for custom config formats

### DIFF
--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -13,13 +13,14 @@ module Reek
     # command line.
     #
     class Application
+      include Input
       attr_reader :configuration
 
       def initialize(argv)
         @options = configure_options(argv)
         @status = options.success_exit_code
         @configuration = configure_app_configuration(options.config_file)
-        @command = command_class.new(OptionInterpreter.new(options))
+        @command = command_class.new(OptionInterpreter.new(options), sources: sources)
       end
 
       def execute
@@ -47,6 +48,10 @@ module Reek
 
       def command_class
         options.generate_todo_list ? Command::TodoListCommand : Command::ReportCommand
+      end
+
+      def argv
+        options.argv
       end
     end
   end

--- a/lib/reek/cli/command/base_command.rb
+++ b/lib/reek/cli/command/base_command.rb
@@ -6,20 +6,17 @@ module Reek
       # Base class for all commands
       #
       class BaseCommand
-        def initialize(options)
+        def initialize(options, sources:)
           @options = options
+          @sources = sources
         end
 
         private
 
-        attr_reader :options
+        attr_reader :options, :sources
 
         def smell_names
           @smell_names ||= options.smells_to_detect
-        end
-
-        def sources
-          @sources ||= options.sources
         end
       end
     end

--- a/lib/reek/cli/input.rb
+++ b/lib/reek/cli/input.rb
@@ -34,7 +34,7 @@ module Reek
 
       # :reek:UtilityFunction
       def working_directory_as_source
-        Source::SourceLocator.new(['.']).sources
+        Source::SourceLocator.new(['.'], configuration: configuration).sources
       end
 
       def sources_from_argv

--- a/lib/reek/cli/option_interpreter.rb
+++ b/lib/reek/cli/option_interpreter.rb
@@ -9,7 +9,6 @@ module Reek
     # Interprets the options set from the command line
     #
     class OptionInterpreter
-      include Input
       extend Forwardable
       def_delegators :options, :smells_to_detect, :success_exit_code, :failure_exit_code
 

--- a/spec/reek/cli/command/report_command_spec.rb
+++ b/spec/reek/cli/command/report_command_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Reek::CLI::Command::ReportCommand do
     let(:reporter) { double 'reporter' }
     let(:app) { double 'app' }
 
-    let(:command) { described_class.new option_interpreter }
+    let(:command) { described_class.new(option_interpreter, sources: []) }
 
     before do
       allow(option_interpreter).to receive(:reporter).and_return reporter
@@ -20,7 +20,6 @@ RSpec.describe Reek::CLI::Command::ReportCommand do
 
     context 'when no smells are found' do
       before do
-        allow(option_interpreter).to receive(:sources).and_return []
         allow(reporter).to receive(:smells?).and_return false
       end
 
@@ -32,7 +31,6 @@ RSpec.describe Reek::CLI::Command::ReportCommand do
 
     context 'when smells are found' do
       before do
-        allow(option_interpreter).to receive(:sources).and_return []
         allow(reporter).to receive(:smells?).and_return true
       end
 

--- a/spec/reek/cli/command/todo_list_command_spec.rb
+++ b/spec/reek/cli/command/todo_list_command_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Reek::CLI::Command::TodoListCommand do
   describe '#execute' do
     let(:option_interpreter) { FactoryGirl.build(:options_interpreter_with_empty_sources) }
     let(:app) { double 'app' }
-    let(:command) { described_class.new option_interpreter }
+    let(:command) { described_class.new(option_interpreter, sources: []) }
 
     before do
       $stdout = StringIO.new
@@ -52,7 +52,7 @@ RSpec.describe Reek::CLI::Command::TodoListCommand do
     end
 
     describe 'groups_for' do
-      let(:command) { described_class.new({}) }
+      let(:command) { described_class.new({}, sources: []) }
 
       it 'returns a proper hash representation of the smells found' do
         smells = [FactoryGirl.build(:smell_warning)]

--- a/spec/reek/cli/input_spec.rb
+++ b/spec/reek/cli/input_spec.rb
@@ -7,9 +7,21 @@ RSpec.describe Reek::CLI::Input do
     include Reek::CLI::Input
 
     def argv; end
+
+    def configuration; end
   end
 
+  let(:path_excluded_in_configuration) do
+    SAMPLES_PATH.join('source_with_exclude_paths/ignore_me/uncommunicative_method_name.rb')
+  end
+
+  let(:configuration) { test_configuration_for(SAMPLES_PATH.join('configuration/with_excluded_paths.reek')) }
+
   subject { DummyClass.new }
+
+  before do
+    allow(subject).to receive(:configuration).and_return(configuration)
+  end
 
   describe '#sources' do
     context 'when no source files given' do
@@ -37,6 +49,10 @@ RSpec.describe Reek::CLI::Input do
 
         it 'should use working directory as source' do
           expect(subject.sources).to_not be_empty
+        end
+
+        it 'should use configuration for excluded paths' do
+          expect(subject.sources).to_not include(path_excluded_in_configuration)
         end
       end
     end


### PR DESCRIPTION
In current master, configuration is never passed to source locator, so it uses default value:
```ruby
# /lib/reek/source/source_locator.rb
  def initialize(paths, configuration: Configuration::AppConfiguration.default)
```

`Configuration::AppConfiguration.default` finds `*.reek` files in you app directory and uses them. Which causes problems in the following case:
If your configuration file isn't located in project root, or uses different format, like `config.reek.yml`, `exclude_paths` option would not work. But if you have `*.reek` file in your app root, reek will use `exclude_paths` from there, not from specified configuration file.

In my fix configuration is passed from `Application` down to ` Source::SourceLocator`