### PR TITLE
Corrects the name of the conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Reek is a tool that examines Ruby classes, modules and methods and reports any
 
 For an excellent introduction to
 [Code Smells](docs/Code-Smells.md) and Reek check out [this blog post](https://blog.codeship.com/how-to-find-ruby-code-smells-with-reek/)
-or [that one](https://troessner.wordpress.com/2016/01/01/the-latest-and-greatest-additions-to-reek/). There is also [this talk](https://www.youtube.com/watch?v=ZzqOuHI5MkA) from the RUBYCONF Porto.
+or [that one](https://troessner.wordpress.com/2016/01/01/the-latest-and-greatest-additions-to-reek/). There is also [this talk](https://www.youtube.com/watch?v=ZzqOuHI5MkA) from the [RubyConf Portugal](http://rubyconf.pt/).
 
 Install it via rubygems:
 


### PR DESCRIPTION
The talk given by Piotr was at RubyConf Portugal, not RubyConf Porto. :)