### PR TITLE
Use parser's preferred lambda representation

### DIFF
--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -6,6 +6,9 @@ end
 require_relative '../tree_dresser'
 require_relative '../ast/node'
 
+# Opt in to new way of representing lambdas
+Parser::Builders::Default.emit_lambda = true
+
 module Reek
   module Source
     #


### PR DESCRIPTION
This has no functional effect at the moment, but may influence implementation of future features. 

#924.