### PR TITLE
Allow building branches only for the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,6 @@ notifications:
     - matijs@matijs.net
     - chastell@chastell.net
   irc: irc.freenode.org#reek
+branches:
+  only:
+    - master


### PR DESCRIPTION
By using this setting, we can turn building for pushes back on in Travis CI, so we can have an actual build history for master.