### PR TITLE
Remove unused fallback parameter from config handling

### DIFF
--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -53,8 +53,8 @@ module Reek
       #
       # :reek:FeatureEnvy
       def inspect(ctx)
-        max_copies = value(MAX_COPIES_KEY, ctx, DEFAULT_MAX_COPIES)
-        min_clump_size = value(MIN_CLUMP_SIZE_KEY, ctx, DEFAULT_MIN_CLUMP_SIZE)
+        max_copies = value(MAX_COPIES_KEY, ctx)
+        min_clump_size = value(MIN_CLUMP_SIZE_KEY, ctx)
         MethodGroup.new(ctx, min_clump_size, max_copies).clumps.map do |clump, methods|
           methods_length = methods.length
           smell_warning(

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -45,8 +45,8 @@ module Reek
       # :reek:FeatureEnvy
       # :reek:DuplicateMethodCall: { max_calls: 2 }
       def inspect(ctx)
-        max_allowed_calls = value(MAX_ALLOWED_CALLS_KEY, ctx, DEFAULT_MAX_CALLS)
-        allow_calls = value(ALLOW_CALLS_KEY, ctx, DEFAULT_ALLOW_CALLS)
+        max_allowed_calls = value(MAX_ALLOWED_CALLS_KEY, ctx)
+        allow_calls = value(ALLOW_CALLS_KEY, ctx)
 
         collector = CallCollector.new(ctx, max_allowed_calls, allow_calls)
         collector.smelly_calls.map do |found_call|

--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -35,7 +35,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def inspect(ctx)
-        max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, ctx, DEFAULT_MAX_ALLOWED_PARAMS)
+        max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, ctx)
         exp = ctx.exp
         count = exp.arg_names.length
         return [] if count <= max_allowed_params

--- a/lib/reek/smells/long_yield_list.rb
+++ b/lib/reek/smells/long_yield_list.rb
@@ -27,9 +27,7 @@ module Reek
       # :reek:FeatureEnvy
       # :reek:DuplicateMethodCall: { max_calls: 2 }
       def inspect(ctx)
-        max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY,
-                                   ctx,
-                                   DEFAULT_MAX_ALLOWED_PARAMS)
+        max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, ctx)
         ctx.local_nodes(:yield).select do |yield_node|
           yield_node.args.length > max_allowed_params
         end.map do |yield_node|

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -108,7 +108,7 @@ module Reek
       end
 
       def configure_ignore_iterators(ctx)
-        self.ignore_iterators = value(IGNORE_ITERATORS_KEY, ctx, DEFAULT_IGNORE_ITERATORS)
+        self.ignore_iterators = value(IGNORE_ITERATORS_KEY, ctx)
       end
 
       def increment_depth(iterator, depth)
@@ -116,7 +116,7 @@ module Reek
       end
 
       def max_nesting(ctx)
-        value(MAX_ALLOWED_NESTING_KEY, ctx, DEFAULT_MAX_ALLOWED_NESTING)
+        value(MAX_ALLOWED_NESTING_KEY, ctx)
       end
 
       # :reek:FeatureEnvy

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -49,7 +49,7 @@ module Reek
       # :reek:TooManyStatements: { max_statements: 6 }
       # :reek:DuplicateMethodCall: { max_calls: 2 }
       def inspect(ctx)
-        max_identical_ifs = value(MAX_IDENTICAL_IFS_KEY, ctx, DEFAULT_MAX_IFS)
+        max_identical_ifs = value(MAX_IDENTICAL_IFS_KEY, ctx)
         conditional_counts(ctx).select do |_key, lines|
           lines.length > max_identical_ifs
         end.map do |key, lines|

--- a/lib/reek/smells/smell_configuration.rb
+++ b/lib/reek/smells/smell_configuration.rb
@@ -29,13 +29,14 @@ module Reek
         Overrides.new(options.fetch(OVERRIDES_KEY, {})).for_context(context)
       end
 
-      # Retrieves the value, if any, for the given +key+.
+      # Retrieves the value, if any, for the given +key+ in the given +context+.
       #
-      # Returns +fall_back+ if this config has no value for the key.
+      # Raises an error if neither the context nor this config have a value for
+      # the key.
       #
-      def value(key, context, fall_back)
+      def value(key, context)
         overrides_for(context).each { |conf| return conf[key] if conf.key?(key) }
-        options.fetch(key, fall_back)
+        options.fetch(key)
       end
 
       private

--- a/lib/reek/smells/smell_detector.rb
+++ b/lib/reek/smells/smell_detector.rb
@@ -52,7 +52,7 @@ module Reek
       end
 
       def exception?(context)
-        context.matches?(value(EXCLUDE_KEY, context, DEFAULT_EXCLUDE_SET))
+        context.matches?(value(EXCLUDE_KEY, context))
       end
 
       def self.todo_configuration_for(smells)
@@ -69,8 +69,8 @@ module Reek
         config.enabled? && config_for(context)[SmellConfiguration::ENABLED_KEY] != false
       end
 
-      def value(key, ctx, fall_back)
-        config_for(ctx)[key] || config.value(key, ctx, fall_back)
+      def value(key, ctx)
+        config_for(ctx)[key] || config.value(key, ctx)
       end
 
       def config_for(ctx)

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -35,7 +35,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def inspect(ctx)
-        max_allowed_ivars = value(MAX_ALLOWED_IVARS_KEY, ctx, DEFAULT_MAX_IVARS)
+        max_allowed_ivars = value(MAX_ALLOWED_IVARS_KEY, ctx)
         count = ctx.local_nodes(:ivasgn).map { |ivasgn| ivasgn.children.first }.uniq.length
         return [] if count <= max_allowed_ivars
         [smell_warning(

--- a/lib/reek/smells/too_many_methods.rb
+++ b/lib/reek/smells/too_many_methods.rb
@@ -37,7 +37,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def inspect(ctx)
-        max_allowed_methods = value(MAX_ALLOWED_METHODS_KEY, ctx, DEFAULT_MAX_METHODS)
+        max_allowed_methods = value(MAX_ALLOWED_METHODS_KEY, ctx)
         # TODO: Only checks instance methods!
         actual = ctx.node_instance_methods.length
         return [] if actual <= max_allowed_methods

--- a/lib/reek/smells/too_many_statements.rb
+++ b/lib/reek/smells/too_many_statements.rb
@@ -29,9 +29,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def inspect(ctx)
-        max_allowed_statements = value(MAX_ALLOWED_STATEMENTS_KEY,
-                                       ctx,
-                                       DEFAULT_MAX_STATEMENTS)
+        max_allowed_statements = value(MAX_ALLOWED_STATEMENTS_KEY, ctx)
         count = ctx.number_of_statements
         return [] if count <= max_allowed_statements
         [smell_warning(

--- a/lib/reek/smells/uncommunicative_method_name.rb
+++ b/lib/reek/smells/uncommunicative_method_name.rb
@@ -56,11 +56,11 @@ module Reek
       end
 
       def reject_patterns(context)
-        Array value(REJECT_KEY, context, DEFAULT_REJECT_PATTERNS)
+        Array value(REJECT_KEY, context)
       end
 
       def accept_patterns(context)
-        Array value(ACCEPT_KEY, context, DEFAULT_ACCEPT_PATTERNS)
+        Array value(ACCEPT_KEY, context)
       end
     end
   end

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -71,11 +71,11 @@ module Reek
       end
 
       def reject_patterns(context)
-        Array value(REJECT_KEY, context, DEFAULT_REJECT_PATTERNS)
+        Array value(REJECT_KEY, context)
       end
 
       def accept_patterns(context)
-        Array value(ACCEPT_KEY, context, DEFAULT_ACCEPT_PATTERNS)
+        Array value(ACCEPT_KEY, context)
       end
     end
   end

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -65,11 +65,11 @@ module Reek
       end
 
       def reject_patterns(context)
-        Array value(REJECT_KEY, context, DEFAULT_REJECT_PATTERNS)
+        Array value(REJECT_KEY, context)
       end
 
       def accept_patterns(context)
-        Array value(ACCEPT_KEY, context, DEFAULT_ACCEPT_PATTERNS)
+        Array value(ACCEPT_KEY, context)
       end
 
       # :reek:UtilityFunction

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -49,8 +49,8 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def inspect(ctx)
-        self.reject_names = value(REJECT_KEY, ctx, DEFAULT_REJECT_SET)
-        self.accept_names = value(ACCEPT_KEY, ctx, DEFAULT_ACCEPT_SET)
+        self.reject_names = value(REJECT_KEY, ctx)
+        self.accept_names = value(ACCEPT_KEY, ctx)
         variable_names(ctx.exp).select do |name, _lines|
           bad_name?(name, ctx)
         end.map do |name, lines|

--- a/lib/reek/smells/unused_private_method.rb
+++ b/lib/reek/smells/unused_private_method.rb
@@ -81,7 +81,7 @@ module Reek
       # :reek:FeatureEnvy
       def ignore_method?(ctx, method)
         # ignore_contexts will be e.g. ["Foo::Smelly#my_method", "..."]
-        ignore_contexts = value(EXCLUDE_KEY, ctx, DEFAULT_EXCLUDE_SET)
+        ignore_contexts = value(EXCLUDE_KEY, ctx)
         ignore_contexts.any? do |ignore_context|
           full_name = "#{method.parent.full_name}##{method.name}"
           full_name[ignore_context]

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -76,7 +76,7 @@ module Reek
 
       def ignore_method?(method_ctx)
         method_ctx.non_public_visibility? &&
-          value(PUBLIC_METHODS_ONLY_KEY, method_ctx, PUBLIC_METHODS_ONLY_DEFAULT)
+          value(PUBLIC_METHODS_ONLY_KEY, method_ctx)
       end
     end
   end

--- a/spec/reek/smells/smell_configuration_spec.rb
+++ b/spec/reek/smells/smell_configuration_spec.rb
@@ -2,11 +2,6 @@ require_relative '../../spec_helper'
 require_lib 'reek/smells/smell_configuration'
 
 RSpec.describe Reek::Smells::SmellConfiguration do
-  it 'returns the default value when key not found' do
-    cf = described_class.new({})
-    expect(cf.value('fred', nil, 27)).to eq(27)
-  end
-
   context 'when overriding default configs' do
     let(:base_config) do
       {


### PR DESCRIPTION
The fallback value is already set in the (default) configuration, so there is no need to specify it again when fetching the value.