### PR TITLE
Add `name` to `parameters` for `SmellWarnings`.

### DIFF
--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -43,7 +43,7 @@ module Reek
           context: ctx,
           lines: [exp.line],
           message: "has #{count} parameters",
-          parameters: { count: count })]
+          parameters: { count: count, name: ctx.name })]
       end
     end
   end

--- a/lib/reek/smells/long_yield_list.rb
+++ b/lib/reek/smells/long_yield_list.rb
@@ -36,7 +36,7 @@ module Reek
             context: ctx,
             lines: [yield_node.line],
             message: "yields #{count} parameters",
-            parameters: { count: count })
+            parameters: { count: count, name: ctx.name })
         end
       end
     end

--- a/lib/reek/smells/module_initialize.rb
+++ b/lib/reek/smells/module_initialize.rb
@@ -28,7 +28,8 @@ module Reek
               smell_warning(
                 context: ctx,
                 lines:   [ctx.exp.line],
-                message: 'has initialize method')
+                message: 'has initialize method',
+                parameters: { name: ctx.name })
             ]
           end
         end

--- a/lib/reek/smells/nil_check.rb
+++ b/lib/reek/smells/nil_check.rb
@@ -18,7 +18,8 @@ module Reek
           smell_warning(
             context: ctx,
             lines: [node.line],
-            message: 'performs a nil-check')
+            message: 'performs a nil-check',
+            parameters: { name: ctx.name })
         end
       end
 

--- a/lib/reek/smells/prima_donna_method.rb
+++ b/lib/reek/smells/prima_donna_method.rb
@@ -46,11 +46,11 @@ module Reek
         end
 
         return if version_without_bang
-
         smell_warning(
           context: ctx,
           lines: [ctx.exp.line],
-          message: "has prima donna method `#{method_sexp.name}`")
+          message: "has prima donna method `#{method_sexp.name}`",
+          parameters: { name: ctx.name })
       end
     end
   end

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -68,7 +68,7 @@ module Reek
           context: ctx,
           lines: [ctx.exp.line],
           message: "doesn't depend on instance state (maybe move it to another class?)",
-          parameters: { name: ctx.full_name })]
+          parameters: { name: ctx.name.to_s })]
       end
 
       private

--- a/spec/reek/smells/long_parameter_list_spec.rb
+++ b/spec/reek/smells/long_parameter_list_spec.rb
@@ -96,8 +96,16 @@ RSpec.describe Reek::Smells::LongParameterList do
       expect(warning.parameters[:count]).to eq(4)
     end
 
+    it 'reports the name' do
+      expect(warning.parameters[:name]).to eq(:badguy)
+    end
+
     it 'reports the line number of the method' do
       expect(warning.lines).to eq([1])
+    end
+
+    it 'reports the message' do
+      expect(warning.message).to eq('has 4 parameters')
     end
   end
 end

--- a/spec/reek/smells/long_yield_list_spec.rb
+++ b/spec/reek/smells/long_yield_list_spec.rb
@@ -13,14 +13,17 @@ RSpec.describe Reek::Smells::LongYieldList do
       src = 'def simple(arga, argb, &blk) f(3);yield; end'
       expect(src).not_to reek_of(:LongYieldList)
     end
+
     it 'should not report yield with few parameters' do
       src = 'def simple(arga, argb, &blk) f(3);yield a,b; end'
       expect(src).not_to reek_of(:LongYieldList)
     end
+
     it 'should report yield with many parameters' do
       src = 'def simple(arga, argb, &blk) f(3);yield arga,argb,arga,argb; end'
       expect(src).to reek_of(:LongYieldList, count: 4)
     end
+
     it 'should not report yield of a long expression' do
       src = 'def simple(arga, argb, &blk) f(3);yield(if @dec then argb else 5+3 end); end'
       expect(src).not_to reek_of(:LongYieldList)
@@ -33,7 +36,7 @@ RSpec.describe Reek::Smells::LongYieldList do
         def simple(arga, argb, &blk)
           f(3)
           yield(arga,argb,arga,argb)
-          end
+        end
       EOS
       ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
       detector.inspect(ctx).first
@@ -43,7 +46,9 @@ RSpec.describe Reek::Smells::LongYieldList do
 
     it 'reports the correct values' do
       expect(warning.parameters[:count]).to eq(4)
+      expect(warning.parameters[:name]).to eq(:simple)
       expect(warning.lines).to eq([3])
+      expect(warning.message).to eq('yields 4 parameters')
     end
   end
 end

--- a/spec/reek/smells/module_initialize_spec.rb
+++ b/spec/reek/smells/module_initialize_spec.rb
@@ -3,42 +3,52 @@ require_lib 'reek/smells/module_initialize'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::ModuleInitialize do
-  context 'module' do
-    context 'with method named initialize' do
-      it 'smells' do
-        src = <<-EOF
-          module A
+  it 'does not report other methods than initialize' do
+    src = <<-EOF
+      module A
+        def foo; end
+      end
+    EOF
+    expect(src).not_to reek_of(:ModuleInitialize)
+  end
+
+  context 'with method named initialize' do
+    it 'smells' do
+      src = <<-EOF
+        module A
+          def initialize; end
+        end
+      EOF
+      expect(src).to reek_of :ModuleInitialize,
+                             name: 'A',
+                             lines: [1],
+                             message: 'has initialize method'
+    end
+  end
+
+  context 'with method named initialize in a nested class' do
+    it 'does not smell' do
+      src = <<-EOF
+        module A
+          class B
             def initialize; end
           end
-        EOF
-        expect(src).to reek_of(:ModuleInitialize)
-      end
+        end
+      EOF
+      expect(src).not_to reek_of(:ModuleInitialize)
     end
+  end
 
-    context 'with method named initialize in a nested class' do
-      it 'does not smell' do
-        src = <<-EOF
-          module A
-            class B
-              def initialize; end
-            end
+  context 'with method named initialize in a nested struct' do
+    it 'does not smell' do
+      src = <<-EOF
+        module A
+          B = Struct.new(:c) do
+            def initialize; end
           end
-        EOF
-        expect(src).not_to reek_of(:ModuleInitialize)
-      end
-    end
-
-    context 'with method named initialize in a nested struct' do
-      it 'does not smell' do
-        src = <<-EOF
-          module A
-            B = Struct.new(:c) do
-              def initialize; end
-            end
-          end
-        EOF
-        expect(src).not_to reek_of(:ModuleInitialize)
-      end
+        end
+      EOF
+      expect(src).not_to reek_of(:ModuleInitialize)
     end
   end
 end

--- a/spec/reek/smells/nil_check_spec.rb
+++ b/spec/reek/smells/nil_check_spec.rb
@@ -4,73 +4,71 @@ require_lib 'reek/smells/nil_check'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::NilCheck do
-  context 'for methods' do
-    it 'reports the correct line number' do
-      src = <<-EOS
+  it 'reports correctly the basic use case' do
+    src = <<-EOS
       def nilcheck foo
         foo.nil?
       end
-      EOS
-      ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      detector = build(:smell_detector, smell_type: :NilCheck)
-      smells = detector.inspect(ctx)
-      expect(smells[0].lines).to eq [2]
-    end
+    EOS
+    expect(src).to reek_of :NilCheck,
+                           name: :nilcheck,
+                           lines: [2],
+                           message: 'performs a nil-check'
+  end
 
-    it 'reports nothing when scope includes no nil checks' do
-      expect('def no_nils; end').not_to reek_of(:NilCheck)
-    end
+  it 'reports nothing when scope includes no nil checks' do
+    expect('def no_nils; end').not_to reek_of(:NilCheck)
+  end
 
-    it 'reports when scope uses multiple nil? methods' do
-      src = <<-EOS
-      def chk_multi_nil(para)
-        para.nil?
-        puts "Hello"
-        \"\".nil?
+  it 'reports when scope uses multiple nil? methods' do
+    src = <<-EOS
+    def chk_multi_nil(para)
+      para.nil?
+      puts "Hello"
+      \"\".nil?
+    end
+    EOS
+    expect(src).to reek_of(:NilCheck)
+  end
+
+  it 'reports twice when scope uses == nil and === nil' do
+    src = <<-EOS
+    def chk_eq_nil(para)
+      para == nil
+      para === nil
+    end
+    EOS
+    expect(src).to reek_of(:NilCheck)
+  end
+
+  it 'reports when scope uses nil ==' do
+    expect('def chk_eq_nil_rev(para); nil == para; end').to reek_of(:NilCheck)
+  end
+
+  it 'reports when scope uses multiple case-clauses checking nil' do
+    src = <<-EOS
+    def case_nil
+      case @inst_var
+      when nil then puts "Nil"
       end
-      EOS
-      expect(src).to reek_of(:NilCheck)
-    end
-
-    it 'reports twice when scope uses == nil and === nil' do
-      src = <<-EOS
-      def chk_eq_nil(para)
-        para == nil
-        para === nil
+      puts "Hello"
+      case @inst_var2
+      when 1 then puts 1
+      when nil then puts nil.inspect
       end
-      EOS
-      expect(src).to reek_of(:NilCheck)
     end
+    EOS
+    expect(src).to reek_of(:NilCheck)
+  end
 
-    it 'reports when scope uses nil ==' do
-      expect('def chk_eq_nil_rev(para); nil == para; end').to reek_of(:NilCheck)
-    end
-
-    it 'reports when scope uses multiple case-clauses checking nil' do
-      src = <<-EOS
-      def case_nil
-        case @inst_var
-        when nil then puts "Nil"
-        end
-        puts "Hello"
-        case @inst_var2
-        when 1 then puts 1
-        when nil then puts nil.inspect
-        end
+  it 'reports a when clause that checks nil and other values' do
+    src = <<-EOS
+    def case_nil
+      case @inst_var
+      when nil, false then puts "Hello"
       end
-      EOS
-      expect(src).to reek_of(:NilCheck)
     end
-
-    it 'reports a when clause that checks nil and other values' do
-      src = <<-EOS
-      def case_nil
-        case @inst_var
-        when nil, false then puts "Hello"
-        end
-      end
-      EOS
-      expect(src).to reek_of(:NilCheck)
-    end
+    EOS
+    expect(src).to reek_of(:NilCheck)
   end
 end

--- a/spec/reek/smells/prima_donna_method_spec.rb
+++ b/spec/reek/smells/prima_donna_method_spec.rb
@@ -3,28 +3,19 @@ require_lib 'reek/context/module_context'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::PrimaDonnaMethod do
+  it 'reports the right values' do
+    src = 'class C; def m!; end; end'
+    expect(src).to reek_of :PrimaDonnaMethod,
+                           lines: [1],
+                           name: 'C',
+                           message: 'has prima donna method `m!`'
+  end
+
   it 'should report nothing when method and bang counterpart exist' do
     expect('class C; def m; end; def m!; end; end').not_to reek_of(:PrimaDonnaMethod)
   end
 
   it 'should report PrimaDonnaMethod when only bang method exists' do
     expect('class C; def m!; end; end').to reek_of(:PrimaDonnaMethod)
-  end
-
-  describe 'the right smell' do
-    let(:detector) { build(:smell_detector, smell_type: :PrimaDonnaMethod) }
-    let(:src)      { 'class C; def m!; end; end' }
-    let(:ctx)      do
-      Reek::Context::ModuleContext.new(nil,
-                                       Reek::Source::SourceCode.from(src).syntax_tree)
-    end
-
-    it 'should be reported' do
-      smells = detector.inspect(ctx)
-      warning = smells[0]
-
-      expect(warning.smell_type).to eq('PrimaDonnaMethod')
-      expect(warning.lines).to eq([1])
-    end
   end
 end

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Reek::Smells::UtilityFunction do
       it 'reports the line number of the method' do
         expect(warning.lines).to eq([1])
       end
+
+      it 'reports the right message' do
+        expect(warning.message).to eq("doesn't depend on instance state (maybe move it to another class?)")
+      end
     end
   end
 
@@ -251,7 +255,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
             def m1(a) a.to_s; end
           end
         EOS
-        expect(src).to reek_of(:UtilityFunction, name: 'C#m1').with_config(config)
+        expect(src).to reek_of(:UtilityFunction, name: 'm1').with_config(config)
       end
     end
 


### PR DESCRIPTION
Fixes #939 

@mvz wdyt? I believe it does make indeed sense to add this everywhere.

I'll stop here to get your feedback first.

Missing so far:

* Everything below "TooManyInstanceVariables"
* DataClump (kind of missed that)