### PR TITLE
Fix crash when NestedIterators found a lambda #947

### DIFF
--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -136,7 +136,9 @@ module Reek
 
       # :reek:FeatureEnvy
       def ignored_iterator?(exp)
-        ignore_iterators.any? { |pattern| /#{pattern}/ =~ exp.call.name } ||
+        call = exp.call
+
+        ignore_iterators.any? { |pattern| call.respond_to?(:name) && /#{pattern}/ =~ call.name } ||
           exp.without_block_arguments?
       end
     end

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe Reek::Smells::NestedIterators do
     end
   end
 
+  context 'with lambdas' do
+    it 'does not crash' do
+      src = 'def fred() mult = ->(one, two) {(1..one).map { |n| two}.sum}; mult.call(4, 3) end'
+      expect(src).to reek_of(:NestedIterators)
+    end
+  end
+
   it 'should report nested iterators in a method' do
     src = 'def bad(fred) @fred.each {|item| item.each {|ting| ting.ting} } end'
     expect(src).to reek_of(:NestedIterators)


### PR DESCRIPTION
When NestedIterators found a (failing) lambda, it crashed. Convoluted example:

```ruby
def fred()
  mult = ->(one, two) {(1..one).map { |n| two}.sum}
  mult.call(4, 3)
end
```