### PR TITLE
Upgrade RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,10 @@ Style/FrozenStringLiteralComment:
 Style/MultilineBlockChain:
   Enabled: false
 
+# Always put the closing brace on the last line
+Style/MultilineMethodCallBraceLayout:
+  EnforcedStyle: same_line
+
 # Indent one level for follow-up lines
 Style/MultilineMethodCallIndentation:
   EnforcedStyle: indented

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :development do
   gem 'mutant-rspec',  '~> 0.8.8'
   gem 'rake',          '~> 11.1'
   gem 'rspec',         '~> 3.0'
-  gem 'rubocop',       '~> 0.39.0'
+  gem 'rubocop',       '~> 0.40.0'
   gem 'simplecov',     '~> 0.11.1'
   gem 'yard',          '~> 0.8.7'
 

--- a/defaults.reek
+++ b/defaults.reek
@@ -115,3 +115,4 @@ UnusedPrivateMethod:
 UtilityFunction:
   enabled: true
   exclude: []
+  public_methods_only: false

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -109,8 +109,7 @@ module Reek
         parser.on(
           '-f', '--format FORMAT', [:html, :text, :yaml, :json, :xml, :code_climate],
           'Report smells in the given format:',
-          '  html', '  text (default)', '  yaml', '  json', '  xml', '  code_climate'
-        ) do |opt|
+          '  html', '  text (default)', '  yaml', '  json', '  xml', '  code_climate') do |opt|
           self.report_format = opt
         end
       end

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -72,10 +72,9 @@ module Reek
 
       def load_values(configuration_hash)
         configuration_hash.each do |key, value|
-          case
-          when key == EXCLUDE_PATHS_KEY
+          if key == EXCLUDE_PATHS_KEY
             excluded_paths.add value
-          when smell_type?(key)
+          elsif smell_type?(key)
             default_directive.add key, value
           else
             directory_directives.add key, value

--- a/lib/reek/report.rb
+++ b/lib/reek/report.rb
@@ -25,7 +25,8 @@ module Reek
 
     HEADING_FORMATTERS = {
       verbose: HeadingFormatter::Verbose,
-      quiet: HeadingFormatter::Quiet }.freeze
+      quiet: HeadingFormatter::Quiet
+    }.freeze
 
     WARNING_FORMATTER_CLASSES = {
       wiki_links: WikiLinkWarningFormatter,

--- a/lib/reek/report/code_climate/code_climate_formatter.rb
+++ b/lib/reek/report/code_climate/code_climate_formatter.rb
@@ -15,8 +15,7 @@ module Reek
                             categories: categories,
                             location: location,
                             remediation_points: remediation_points,
-                            content: content
-                           ).render
+                            content: content).render
       end
 
       private
@@ -39,8 +38,7 @@ module Reek
         warning_lines = warning.lines
         CCEngine::Location::LineRange.new(
           path: warning.source,
-          line_range: warning_lines.first..warning_lines.last
-        )
+          line_range: warning_lines.first..warning_lines.last)
       end
 
       def remediation_points

--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -42,8 +42,7 @@ module Reek
       def self.default_config
         super.merge(
           MAX_COPIES_KEY => DEFAULT_MAX_COPIES,
-          MIN_CLUMP_SIZE_KEY => DEFAULT_MIN_CLUMP_SIZE
-        )
+          MIN_CLUMP_SIZE_KEY => DEFAULT_MIN_CLUMP_SIZE)
       end
 
       #

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -33,8 +33,7 @@ module Reek
       def self.default_config
         super.merge(
           MAX_ALLOWED_CALLS_KEY => DEFAULT_MAX_CALLS,
-          ALLOW_CALLS_KEY => DEFAULT_ALLOW_CALLS
-        )
+          ALLOW_CALLS_KEY => DEFAULT_ALLOW_CALLS)
       end
 
       #

--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -25,8 +25,7 @@ module Reek
           MAX_ALLOWED_PARAMS_KEY => DEFAULT_MAX_ALLOWED_PARAMS,
           SmellConfiguration::OVERRIDES_KEY => {
             'initialize' => { MAX_ALLOWED_PARAMS_KEY => 5 }
-          }
-        )
+          })
       end
 
       #

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -31,8 +31,7 @@ module Reek
       def self.default_config
         super.merge(
           MAX_ALLOWED_NESTING_KEY => DEFAULT_MAX_ALLOWED_NESTING,
-          IGNORE_ITERATORS_KEY => DEFAULT_IGNORE_ITERATORS
-        )
+          IGNORE_ITERATORS_KEY => DEFAULT_IGNORE_ITERATORS)
       end
 
       # Generates a smell warning for each independent deepest nesting depth

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -25,8 +25,7 @@ module Reek
       def self.default_config
         super.merge(
           MAX_ALLOWED_IVARS_KEY => DEFAULT_MAX_IVARS,
-          EXCLUDE_KEY => []
-        )
+          EXCLUDE_KEY => [])
       end
 
       #

--- a/lib/reek/smells/too_many_methods.rb
+++ b/lib/reek/smells/too_many_methods.rb
@@ -27,8 +27,7 @@ module Reek
       def self.default_config
         super.merge(
           MAX_ALLOWED_METHODS_KEY => DEFAULT_MAX_METHODS,
-          EXCLUDE_KEY => []
-        )
+          EXCLUDE_KEY => [])
       end
 
       #

--- a/lib/reek/smells/too_many_statements.rb
+++ b/lib/reek/smells/too_many_statements.rb
@@ -19,8 +19,7 @@ module Reek
       def self.default_config
         super.merge(
           MAX_ALLOWED_STATEMENTS_KEY => DEFAULT_MAX_STATEMENTS,
-          EXCLUDE_KEY => ['initialize']
-        )
+          EXCLUDE_KEY => ['initialize'])
       end
 
       #

--- a/lib/reek/smells/uncommunicative_method_name.rb
+++ b/lib/reek/smells/uncommunicative_method_name.rb
@@ -28,8 +28,7 @@ module Reek
       def self.default_config
         super.merge(
           REJECT_KEY => DEFAULT_REJECT_PATTERNS,
-          ACCEPT_KEY => DEFAULT_ACCEPT_PATTERNS
-        )
+          ACCEPT_KEY => DEFAULT_ACCEPT_PATTERNS)
       end
 
       #

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -33,8 +33,7 @@ module Reek
       def self.default_config
         super().merge(
           REJECT_KEY => DEFAULT_REJECT_PATTERNS,
-          ACCEPT_KEY => DEFAULT_ACCEPT_PATTERNS
-        )
+          ACCEPT_KEY => DEFAULT_ACCEPT_PATTERNS)
       end
 
       def self.contexts

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -30,8 +30,7 @@ module Reek
       def self.default_config
         super.merge(
           REJECT_KEY => DEFAULT_REJECT_PATTERNS,
-          ACCEPT_KEY => DEFAULT_ACCEPT_PATTERNS
-        )
+          ACCEPT_KEY => DEFAULT_ACCEPT_PATTERNS)
       end
 
       #

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -35,8 +35,7 @@ module Reek
       def self.default_config
         super.merge(
           REJECT_KEY => DEFAULT_REJECT_SET,
-          ACCEPT_KEY => DEFAULT_ACCEPT_SET
-        )
+          ACCEPT_KEY => DEFAULT_ACCEPT_SET)
       end
 
       def self.contexts

--- a/spec/reek/report/code_climate_formatter_spec.rb
+++ b/spec/reek/report/code_climate_formatter_spec.rb
@@ -11,34 +11,35 @@ RSpec.describe Reek::Report::CodeClimateFormatter, '#render' do
                       source:         'a/ruby/source/file.rb')
   end
   let(:rendered) { Reek::Report::CodeClimateFormatter.new(warning).render }
+  let(:json) { JSON.parse rendered.chop }
 
   it "sets the type as 'issue'" do
-    expect(rendered).to match(/\"type\":\"issue\"/)
+    expect(json['type']).to eq 'issue'
   end
 
   it 'sets the category' do
-    expect(rendered).to match(/\"categories\":\[\"Complexity\"\]/)
+    expect(json['categories']).to eq ['Complexity']
   end
 
   it 'constructs a description based on the context and message' do
-    expect(rendered).to match(/\"description\":\"context foo message bar\"/)
+    expect(json['description']).to eq 'context foo message bar'
   end
 
   it 'sets a check name based on the smell detector' do
-    expect(rendered).to match(/\"check_name\":\"UtilityFunction\"/)
+    expect(json['check_name']).to eq 'UtilityFunction'
   end
 
   it 'sets the location' do
-    expect(rendered).to match(%r{\"location\":{\"path\":\"a/ruby/source/file.rb\",\"lines\":{\"begin\":1,\"end\":2}}})
+    expect(json['location']).to eq('path' => 'a/ruby/source/file.rb',
+                                   'lines' => { 'begin' => 1, 'end' => 2 })
   end
 
   it 'sets a content based on the smell detector' do
-    expect(rendered).to match(
-      /\"body\":\"A _Utility Function_ is any instance method that has no dependency on the state of the instance.\\n\"/
-    )
+    expect(json['content']['body']).
+      to eq "A _Utility Function_ is any instance method that has no dependency on the state of the instance.\n"
   end
 
   it 'sets remediation points based on the smell detector' do
-    expect(rendered).to match(/\"remediation_points\":250000/)
+    expect(json['remediation_points']).to eq 250_000
   end
 end


### PR DESCRIPTION
This upgrades RuboCop to version 0.40 and fixes newly detected offences.

I have chosen to configure Style/MultilineMethodCallBraceLayout with the style same_line since that matches most of our code and looks better to me.