### PR TITLE
Loosen activesupport dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem 'rubocop',       '~> 0.41.1'
   gem 'simplecov',     '~> 0.11.1'
   gem 'yard',          '~> 0.8.7'
-  gem 'activesupport', '~> 4.2.7.rc1'
+  gem 'activesupport', '~> 4.2'
 
   platforms :mri do
     gem 'redcarpet', '~> 3.3.1'


### PR DESCRIPTION
I don't think we particularly need version `4.2.7.rc1`.