### PR TITLE
Allow longer timeout for debugging purposes

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,7 +85,7 @@ RSpec.configure do |config|
 
   # Avoid infinitely running tests. This is mainly useful when running mutant.
   config.around(:each) do |example|
-    Timeout.timeout(5, &example)
+    Timeout.timeout(60, &example)
   end
 end
 


### PR DESCRIPTION
Stops specs from failing while debugging with pry.