### PR TITLE
Allow disabling spec Timeout for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,23 @@ bundle exec rake console
 => Reek::Examiner
 ```
 
+You can also use Pry while running the tests by adding the following at the
+point where you want to start debugging:
+
+```ruby
+require 'pry'
+binding.pry
+```
+
+If you do this, you need to also run the specs with `DEBUG=1` set, e.g.:
+
+```
+DEBUG=1 bundle exec rspec spec/your/file_spec.rb:23
+```
+
+This is necessary because normally all specs run with a timeout of 5 seconds,
+which isn't much if you're busy using Pry.
+
 Have a look at our [Developer API](docs/API.md) for more inspiration.
 
 From then on you should check out:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,8 +84,12 @@ RSpec.configure do |config|
   end
 
   # Avoid infinitely running tests. This is mainly useful when running mutant.
-  config.around(:each) do |example|
-    Timeout.timeout(5, &example)
+  # Set the DEBUG environment variable to something truthy like '1' to disable
+  # this and allow using pry without specs failing.
+  unless ENV['DEBUG']
+    config.around(:each) do |example|
+      Timeout.timeout(5, &example)
+    end
   end
 end
 


### PR DESCRIPTION
Alternative for #967.

I'll still add the README bit.