### PR TITLE
Stop hiding AppConfiguration.new

### DIFF
--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -47,12 +47,7 @@ module Reek
       end
 
       def self.default
-        from_path nil
-      end
-
-      def self.new(*)
-        raise NotImplementedError,
-              'Calling `new` is not supported, please use one of the factory methods'
+        new
       end
 
       # Returns the directive for a given directory.

--- a/spec/reek/configuration/app_configuration_spec.rb
+++ b/spec/reek/configuration/app_configuration_spec.rb
@@ -6,12 +6,6 @@ require_lib 'reek/configuration/default_directive'
 require_lib 'reek/configuration/excluded_paths'
 
 RSpec.describe Reek::Configuration::AppConfiguration do
-  describe '#new' do
-    it 'raises NotImplementedError' do
-      expect { subject }.to raise_error(NotImplementedError)
-    end
-  end
-
   describe 'factory methods' do
     let(:expected_excluded_paths) do
       [SAMPLES_PATH.join('two_smelly_files'),
@@ -65,6 +59,16 @@ RSpec.describe Reek::Configuration::AppConfiguration do
         expect(config.send(:default_directive)).to eq(expected_default_directive)
         expect(config.send(:directory_directives)).to eq(expected_directory_directives)
       end
+    end
+  end
+
+  describe '#default' do
+    it 'returns a blank AppConfiguration' do
+      config = described_class.default
+      expect(config).to be_instance_of described_class
+      expect(config.send(:excluded_paths)).to eq([])
+      expect(config.send(:default_directive)).to eq({})
+      expect(config.send(:directory_directives)).to eq({})
     end
   end
 


### PR DESCRIPTION
Since `AppConfiguration.default` is effectively the same as `AppConfiguration.new`, we can safely implement one using the other and stop hiding `.new`.