### PR TITLE
Remove guard exceptions from Reek::Report

### DIFF
--- a/lib/reek/report.rb
+++ b/lib/reek/report.rb
@@ -6,8 +6,6 @@ require_relative 'report/heading_formatter'
 module Reek
   # Reek reporting functionality.
   module Report
-    module_function
-
     REPORT_CLASSES = {
       yaml: YAMLReport,
       json: JSONReport,
@@ -39,7 +37,7 @@ module Reek
     #
     # @return The mapped report class
     #
-    def report_class(report_format)
+    def self.report_class(report_format)
       REPORT_CLASSES.fetch(report_format)
     end
 
@@ -49,7 +47,7 @@ module Reek
     #
     # @return The mapped location class
     #
-    def location_formatter(location_format)
+    def self.location_formatter(location_format)
       LOCATION_FORMATTERS.fetch(location_format)
     end
 
@@ -59,7 +57,7 @@ module Reek
     #
     # @return The mapped heading class
     #
-    def heading_formatter(heading_format)
+    def self.heading_formatter(heading_format)
       HEADING_FORMATTERS.fetch(heading_format)
     end
 
@@ -69,7 +67,7 @@ module Reek
     #
     # @return The mapped warning class
     #
-    def warning_formatter_class(warning_format)
+    def self.warning_formatter_class(warning_format)
       WARNING_FORMATTER_CLASSES.fetch(warning_format)
     end
   end

--- a/lib/reek/report.rb
+++ b/lib/reek/report.rb
@@ -40,27 +40,37 @@ module Reek
     # @return The mapped report class
     #
     def report_class(report_format)
-      REPORT_CLASSES.fetch(report_format) do
-        raise "Unknown report format: #{report_format}"
-      end
+      REPORT_CLASSES.fetch(report_format)
     end
 
+    # Map location format symbol to a report class.
+    #
+    # @param [Symbol] location_format The format to map
+    #
+    # @return The mapped location class
+    #
     def location_formatter(location_format)
-      LOCATION_FORMATTERS.fetch(location_format) do
-        raise "Unknown location format: #{location_format}"
-      end
+      LOCATION_FORMATTERS.fetch(location_format)
     end
 
+    # Map heading format symbol to a report class.
+    #
+    # @param [Symbol] heading_format The format to map
+    #
+    # @return The mapped heading class
+    #
     def heading_formatter(heading_format)
-      HEADING_FORMATTERS.fetch(heading_format) do
-        raise "Unknown heading format: #{heading_format}"
-      end
+      HEADING_FORMATTERS.fetch(heading_format)
     end
 
+    # Map warning format symbol to a report class.
+    #
+    # @param [Symbol] warning_format The format to map
+    #
+    # @return The mapped warning class
+    #
     def warning_formatter_class(warning_format)
-      WARNING_FORMATTER_CLASSES.fetch(warning_format) do
-        raise "Unknown warning format: #{warning_format}"
-      end
+      WARNING_FORMATTER_CLASSES.fetch(warning_format)
     end
   end
 end

--- a/spec/reek/report_spec.rb
+++ b/spec/reek/report_spec.rb
@@ -1,0 +1,28 @@
+require_relative '../spec_helper'
+require_lib 'reek/report'
+
+RSpec.describe Reek::Report do
+  describe '.report_class' do
+    it 'returns the correct class' do
+      expect(Reek::Report.report_class(:text)).to eq Reek::Report::TextReport
+    end
+  end
+
+  describe '.location_formatter' do
+    it 'returns the correct class' do
+      expect(Reek::Report.location_formatter(:plain)).to eq Reek::Report::BlankLocationFormatter
+    end
+  end
+
+  describe '.heading_formatter' do
+    it 'returns the correct class' do
+      expect(Reek::Report.heading_formatter(:quiet)).to eq Reek::Report::HeadingFormatter::Quiet
+    end
+  end
+
+  describe '.warning_formatter_class' do
+    it 'returns the correct class' do
+      expect(Reek::Report.warning_formatter_class(:simple)).to eq Reek::Report::SimpleWarningFormatter
+    end
+  end
+end


### PR DESCRIPTION
- `Hash#fetch` already raises if the key is not found, which is enough for a non-public API.
- These exceptions were untested

To allow mutant to check this properly, I had to remove `module_function`. See https://github.com/mbj/mutant/issues/459.