### PR TITLE
Optionally show the examiner progress

### DIFF
--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -46,6 +46,9 @@ Feature: Reek can be controlled using command-line options
       Generate a todo list:
           -t, --todo                       Generate a todo list
 
+      Show progress:
+          -p, --progress                   Show progress of each file
+
       Report format:
           -f, --format FORMAT              Report smells in the given format:
                                              html

--- a/features/command_line_interface/show_progress.feature
+++ b/features/command_line_interface/show_progress.feature
@@ -1,0 +1,30 @@
+Feature: Show progress
+  In order to see the progress of the examiners
+  As a developer
+  I want to be able to selectively activate progress reporting
+
+  Scenario: --progress activates progress output on clean files
+    Given a directory called 'clean_files' containing some clean files
+    When I run reek --progress clean_files
+    Then it succeeds
+    And it reports:
+      """
+      Inspecting 3 file(s):
+      ...
+
+      0 total warnings
+      """
+  Scenario: --progress activates progress output on smelly files
+    Given a smelly file called 'smelly.rb'
+    When I run reek --progress smelly.rb
+    Then the exit status indicates smells
+    And it reports:
+      """
+      Inspecting 1 file(s):
+      S
+
+      smelly.rb -- 3 warnings:
+        [4, 5]:DuplicateMethodCall: Smelly#m calls @foo.bar 2 times [https://github.com/troessner/reek/blob/master/docs/Duplicate-Method-Call.md]
+        [4, 5]:DuplicateMethodCall: Smelly#m calls puts @foo.bar 2 times [https://github.com/troessner/reek/blob/master/docs/Duplicate-Method-Call.md]
+        [3]:UncommunicativeMethodName: Smelly#m has the name 'm' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      """

--- a/lib/reek/cli/command/report_command.rb
+++ b/lib/reek/cli/command/report_command.rb
@@ -20,12 +20,21 @@ module Reek
         private
 
         def populate_reporter_with_smells
+          puts "Inspecting #{sources.length} file(s):" if options.show_progress
+
           sources.each do |source|
-            reporter.add_examiner Examiner.new(source,
-                                               filter_by_smells: smell_names,
-                                               configuration: configuration)
+            examiner = Examiner.new(source,
+                                    filter_by_smells: smell_names,
+                                    configuration: configuration)
+
+            print examiner.smelly? ? 'S' : '.' if options.show_progress
+
+            reporter.add_examiner examiner
           end
+
+          puts "\n\n" if options.show_progress
         end
+
 
         def result_code
           reporter.smells? ? options.failure_exit_code : options.success_exit_code

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -28,7 +28,8 @@ module Reek
                     :sorting,
                     :success_exit_code,
                     :failure_exit_code,
-                    :generate_todo_list
+                    :generate_todo_list,
+                    :show_progress
 
       def initialize(argv = [])
         @argv               = argv
@@ -41,6 +42,7 @@ module Reek
         @success_exit_code  = DEFAULT_SUCCESS_EXIT_CODE
         @failure_exit_code  = DEFAULT_FAILURE_EXIT_CODE
         @generate_todo_list = false
+        @show_progress      = false
 
         set_up_parser
       end
@@ -63,6 +65,7 @@ module Reek
         set_banner
         set_configuration_options
         set_generate_todo_list_options
+        set_show_progress_options
         set_alternative_formatter_options
         set_report_formatting_options
         set_exit_codes
@@ -110,6 +113,13 @@ module Reek
           'Report smells in the given format:',
           '  html', '  text (default)', '  yaml', '  json', '  xml', '  code_climate') do |opt|
           self.report_format = opt
+        end
+      end
+
+      def set_show_progress_options
+        parser.separator "\nShow progress:"
+        parser.on('-p', '--progress', 'Show progress of each file') do
+          self.show_progress = true
         end
       end
 


### PR DESCRIPTION
This adds an option to the cli that shows a `.` or a `S` for each file as they are examined. There may be a more elegant way to accomplish this, or to have it as a reporter, but this accomplished my needs and I haven't spent too much time understanding all of the complexities of the reek reporters.

![image](https://cloud.githubusercontent.com/assets/3384/16897788/2ad6542e-4b71-11e6-8d1d-fe319285e51e.png)

Per #980 