### PR TITLE
Add a progress report format on top of the text format

### DIFF
--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -54,12 +54,12 @@ Feature: Reek can be controlled using command-line options
                                              json
                                              xml
                                              code_climate
-                                             progress
 
       Text format options:
               --[no-]color                 Use colors for the output (default: true)
           -V, --[no-]empty-headings        Show headings for smell-free source files (default: false)
           -U, --[no-]wiki-links            Show link to related wiki page for each smell (default: true)
+          -P, --[no-]progress              Show progress of each file (default: true)
           -n, --[no-]line-numbers          Show line numbers in the output (default: true)
           -s, --single-line                Show location in editor-compatible single-line-per-smell format
               --sort-by SORTING            Sort reported files by the given criterium:

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -54,6 +54,7 @@ Feature: Reek can be controlled using command-line options
                                              json
                                              xml
                                              code_climate
+                                             progress
 
       Text format options:
               --[no-]color                 Use colors for the output (default: true)

--- a/features/command_line_interface/show_progress.feature
+++ b/features/command_line_interface/show_progress.feature
@@ -3,28 +3,17 @@ Feature: Show progress
   As a developer
   I want to be able to selectively activate progress reporting
 
-  Scenario: --progress activates progress output on clean files
-    Given a directory called 'clean_files' containing some clean files
-    When I run reek -f progress clean_files
-    Then it succeeds
-    And it reports:
-      """
-      Inspecting 3 file(s):
-      ...
-
-      0 total warnings
-      """
-  Scenario: --progress activates progress output on smelly files
-    Given a smelly file called 'smelly.rb'
-    When I run reek -f progress smelly.rb
+  Scenario: --progress activates progress output on mixed files
+    Given a directory called 'mixed_files' containing some clean and smelly files
+    When I run reek -f progress mixed_files
     Then the exit status indicates smells
     And it reports:
       """
-      Inspecting 1 file(s):
-      S
+      Inspecting 2 file(s):
+      .S
 
-      smelly.rb -- 3 warnings:
-        [4, 5]:DuplicateMethodCall: Smelly#m calls @foo.bar 2 times [https://github.com/troessner/reek/blob/master/docs/Duplicate-Method-Call.md]
-        [4, 5]:DuplicateMethodCall: Smelly#m calls puts @foo.bar 2 times [https://github.com/troessner/reek/blob/master/docs/Duplicate-Method-Call.md]
-        [3]:UncommunicativeMethodName: Smelly#m has the name 'm' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      mixed_files/dirty.rb -- 2 warnings:
+        [1]:IrresponsibleModule: Dirty has no descriptive comment [https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md]
+        [2]:UncommunicativeMethodName: Dirty#a has the name 'a' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      2 total warnings
       """

--- a/features/command_line_interface/show_progress.feature
+++ b/features/command_line_interface/show_progress.feature
@@ -1,0 +1,30 @@
+Feature: Show progress
+  In order to see the progress of the examiners
+  As a developer
+  I want to be able to selectively activate progress reporting
+
+  Scenario: --progress activates progress output on clean files
+    Given a directory called 'clean_files' containing some clean files
+    When I run reek -f progress clean_files
+    Then it succeeds
+    And it reports:
+      """
+      Inspecting 3 file(s):
+      ...
+
+      0 total warnings
+      """
+  Scenario: --progress activates progress output on smelly files
+    Given a smelly file called 'smelly.rb'
+    When I run reek -f progress smelly.rb
+    Then the exit status indicates smells
+    And it reports:
+      """
+      Inspecting 1 file(s):
+      S
+
+      smelly.rb -- 3 warnings:
+        [4, 5]:DuplicateMethodCall: Smelly#m calls @foo.bar 2 times [https://github.com/troessner/reek/blob/master/docs/Duplicate-Method-Call.md]
+        [4, 5]:DuplicateMethodCall: Smelly#m calls puts @foo.bar 2 times [https://github.com/troessner/reek/blob/master/docs/Duplicate-Method-Call.md]
+        [3]:UncommunicativeMethodName: Smelly#m has the name 'm' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      """

--- a/features/command_line_interface/show_progress.feature
+++ b/features/command_line_interface/show_progress.feature
@@ -3,15 +3,27 @@ Feature: Show progress
   As a developer
   I want to be able to selectively activate progress reporting
 
-  Scenario: --progress activates progress output on mixed files
+  Scenario: shows progress output on mixed files by default
     Given a directory called 'mixed_files' containing some clean and smelly files
-    When I run reek -f progress mixed_files
+    When I run reek mixed_files
     Then the exit status indicates smells
     And it reports:
       """
       Inspecting 2 file(s):
       .S
 
+      mixed_files/dirty.rb -- 2 warnings:
+        [1]:IrresponsibleModule: Dirty has no descriptive comment [https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md]
+        [2]:UncommunicativeMethodName: Dirty#a has the name 'a' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+      2 total warnings
+      """
+
+  Scenario: --no-progress disables progress output
+    Given a directory called 'mixed_files' containing some clean and smelly files
+    When I run reek --no-progress mixed_files
+    Then the exit status indicates smells
+    And it reports:
+      """
       mixed_files/dirty.rb -- 2 warnings:
         [1]:IrresponsibleModule: Dirty has no descriptive comment [https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md]
         [2]:UncommunicativeMethodName: Dirty#a has the name 'a' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]

--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -64,6 +64,23 @@ Given(/^a directory called 'clean_files' containing some clean files$/) do
   write_file 'clean_files/clean_three.rb', contents
 end
 
+Given(/^a directory called 'mixed_files' containing some clean and smelly files$/) do
+  write_file('mixed_files/clean.rb', <<-EOS.strip_heredoc)
+    # clean class for testing purposes
+    class Clean
+      def assign
+        puts @sub.title
+        @sub.map {|para| para.name }
+      end
+    end
+  EOS
+  write_file('mixed_files/dirty.rb', <<-EOS.strip_heredoc)
+    class Dirty
+      def a; end
+    end
+  EOS
+end
+
 Given(/^a directory called 'smelly' containing two smelly files$/) do
   write_file('smelly/dirty_one.rb', <<-EOS.strip_heredoc)
     class Dirty

--- a/lib/reek/cli/command/report_command.rb
+++ b/lib/reek/cli/command/report_command.rb
@@ -38,7 +38,8 @@ module Reek
               report_formatter: Report::Formatter,
               sort_by_issue_count: sort_by_issue_count,
               heading_formatter: heading_formatter,
-              sources_count: sources.length)
+              sources_count: sources.length,
+              show_progress: options.show_progress)
         end
 
         def report_class

--- a/lib/reek/cli/command/report_command.rb
+++ b/lib/reek/cli/command/report_command.rb
@@ -37,7 +37,8 @@ module Reek
               warning_formatter: warning_formatter,
               report_formatter: Report::Formatter,
               sort_by_issue_count: sort_by_issue_count,
-              heading_formatter: heading_formatter)
+              heading_formatter: heading_formatter,
+              sources_count: sources.length)
         end
 
         def report_class

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -25,6 +25,7 @@ module Reek
                     :report_format,
                     :show_empty,
                     :show_links,
+                    :show_progress,
                     :sorting,
                     :success_exit_code,
                     :failure_exit_code,
@@ -36,6 +37,7 @@ module Reek
         @report_format      = :text
         @location_format    = :numbers
         @show_links         = true
+        @show_progress      = true
         @smells_to_detect   = []
         @colored            = color_support?
         @success_exit_code  = DEFAULT_SUCCESS_EXIT_CODE
@@ -106,9 +108,9 @@ module Reek
       def set_alternative_formatter_options
         parser.separator "\nReport format:"
         parser.on(
-          '-f', '--format FORMAT', [:html, :text, :yaml, :json, :xml, :code_climate, :progress],
+          '-f', '--format FORMAT', [:html, :text, :yaml, :json, :xml, :code_climate],
           'Report smells in the given format:',
-          '  html', '  text (default)', '  yaml', '  json', '  xml', '  code_climate', '  progress') do |opt|
+          '  html', '  text (default)', '  yaml', '  json', '  xml', '  code_climate') do |opt|
           self.report_format = opt
         end
       end
@@ -135,6 +137,9 @@ module Reek
         parser.on('-U', '--[no-]wiki-links',
                   'Show link to related wiki page for each smell (default: true)') do |show_links|
           self.show_links = show_links
+        end
+        parser.on('-P', '--[no-]progress', 'Show progress of each file (default: true)') do |show_progress|
+          self.show_progress = show_progress
         end
       end
 

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -10,7 +10,7 @@ module Reek
     #
     # See {file:docs/Command-Line-Options.md} for details.
     #
-    # :reek:TooManyInstanceVariables: { max_instance_variables: 10 }
+    # :reek:TooManyInstanceVariables: { max_instance_variables: 11 }
     # :reek:Attribute: { enabled: false }
     #
     class Options
@@ -129,6 +129,7 @@ module Reek
         end
       end
 
+      # :reek:TooManyStatements: { max_statements: 6 }
       def set_up_verbosity_options
         parser.on('-V', '--[no-]empty-headings',
                   'Show headings for smell-free source files (default: false)') do |show_empty|

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -106,9 +106,9 @@ module Reek
       def set_alternative_formatter_options
         parser.separator "\nReport format:"
         parser.on(
-          '-f', '--format FORMAT', [:html, :text, :yaml, :json, :xml, :code_climate],
+          '-f', '--format FORMAT', [:html, :text, :yaml, :json, :xml, :code_climate, :progress],
           'Report smells in the given format:',
-          '  html', '  text (default)', '  yaml', '  json', '  xml', '  code_climate') do |opt|
+          '  html', '  text (default)', '  yaml', '  json', '  xml', '  code_climate', '  progress') do |opt|
           self.report_format = opt
         end
       end

--- a/lib/reek/report.rb
+++ b/lib/reek/report.rb
@@ -12,6 +12,7 @@ module Reek
       html: HTMLReport,
       xml: XMLReport,
       text: TextReport,
+      progress: ProgressReport,
       code_climate: CodeClimateReport
     }.freeze
 

--- a/lib/reek/report.rb
+++ b/lib/reek/report.rb
@@ -12,7 +12,6 @@ module Reek
       html: HTMLReport,
       xml: XMLReport,
       text: TextReport,
-      progress: ProgressReport,
       code_climate: CodeClimateReport
     }.freeze
 

--- a/lib/reek/report/report.rb
+++ b/lib/reek/report/report.rb
@@ -15,7 +15,7 @@ module Reek
     #
     # @public
     #
-    # :reek:TooManyInstanceVariables: { max_instance_variables: 6 }
+    # :reek:TooManyInstanceVariables: { max_instance_variables: 7 }
     class Base
       NO_WARNINGS_COLOR = :green
       WARNINGS_COLOR = :red
@@ -25,13 +25,15 @@ module Reek
       # :reek:BooleanParameter
       def initialize(heading_formatter: HeadingFormatter::Quiet,
                      report_formatter: Formatter, sort_by_issue_count: false,
-                     warning_formatter: SimpleWarningFormatter.new)
+                     warning_formatter: SimpleWarningFormatter.new,
+                     sources_count: 0)
         @examiners           = []
         @heading_formatter   = heading_formatter.new(report_formatter)
         @report_formatter    = report_formatter
         @sort_by_issue_count = sort_by_issue_count
         @total_smell_count   = 0
         @warning_formatter   = warning_formatter
+        @sources_count       = sources_count
 
         # TODO: Only used in TextReport and YAMLReport
       end
@@ -117,6 +119,41 @@ module Reek
       def total_smell_count_message
         colour = smells? ? WARNINGS_COLOR : NO_WARNINGS_COLOR
         Rainbow("#{total_smell_count} total warning#{total_smell_count == 1 ? '' : 's'}\n").color(colour)
+      end
+    end
+
+    #
+    # Displays the status of each file as it is examined
+    # Displays the text report when complete
+    #
+    # @public
+    class ProgressReport < TextReport
+      # @public
+      def initialize(*args)
+        super(*args)
+        print "Inspecting #{@sources_count} file(s):\n"
+      end
+
+      # @public
+      def add_examiner(examiner)
+        print examiner.smelly? ? display_smelly : display_clean
+        super(examiner)
+      end
+
+      # @public
+      def show
+        print "\n\n"
+        super
+      end
+
+      private
+
+      def display_clean
+        Rainbow('.').color(NO_WARNINGS_COLOR)
+      end
+
+      def display_smelly
+        Rainbow('S').color(WARNINGS_COLOR)
       end
     end
 

--- a/lib/reek/report/report.rb
+++ b/lib/reek/report/report.rb
@@ -15,7 +15,8 @@ module Reek
     #
     # @public
     #
-    # :reek:TooManyInstanceVariables: { max_instance_variables: 7 }
+    # :reek:TooManyInstanceVariables: { max_instance_variables: 8 }
+    # :reek:LongParameterList
     class Base
       NO_WARNINGS_COLOR = :green
       WARNINGS_COLOR = :red


### PR DESCRIPTION
This is an alternate take on #982 that uses a format built on top of the text format to display the progress as it runs. The downside is that it only works for the specific format instead of being independent of the format choice, but it seems to fit more closely with how the reporting has been designed.

Per #980 