### PR TITLE
Make mutant task more robust

### DIFF
--- a/tasks/mutant.rake
+++ b/tasks/mutant.rake
@@ -1,18 +1,13 @@
 desc 'Runs mutant'
 task :mutant do
   command = <<-EOS
-    branch_name=$(git symbolic-ref HEAD 2>/dev/null | cut -d"/" -f 3)
-    if [ "$branch_name" != "master" ]; then
-      RUBY_THREAD_VM_STACK_SIZE=64000\
-      bundle exec mutant\
-        --include lib\
-        --require reek\
-        --use rspec\
-        --since master\
-        --jobs 4 'Reek*'
-    else
-      echo "!!! Not running mutant on master branch !!!"
-    fi
+    RUBY_THREAD_VM_STACK_SIZE=64000\
+    bundle exec mutant\
+      --include lib\
+      --require reek\
+      --use rspec\
+      --since master^\
+      --jobs 4 'Reek*'
   EOS
   system command
   abort unless $CHILD_STATUS.success?


### PR DESCRIPTION
Specifying 'master^' makes sure that in most day-to-day cases, the
mutant task will find some commits to check. The is preferable to
checking for the current branch, which seems to fail on Travis.

An alternative is to use HEAD~n, for some value of n. However, this
could hide problems while a PR is being developed, while potentially
prolonging build failures on master after merging a branch that mutant
does not approve of.