### PR TITLE
Make our parameter handling consistent in smell detectors.

### DIFF
--- a/features/reports/json.feature
+++ b/features/reports/json.feature
@@ -64,8 +64,7 @@ Feature: Report smells using simple JSON layout
                   1
               ],
               "message": "has no descriptive comment",
-              "wiki_link": "https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md",
-              "name": "Turn"
+              "wiki_link": "https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md"
           }
       ]
       """

--- a/features/reports/yaml.feature
+++ b/features/reports/yaml.feature
@@ -60,6 +60,5 @@ Feature: Report smells using simple YAML layout
         lines:
         - 1
         message: has no descriptive comment
-        name: Turn
         wiki_link: https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md
       """

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -31,12 +31,11 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def sniff(ctx)
-        attributes_in(ctx).map do |attribute, line|
+        attributes_in(ctx).map do |_attribute, line|
           smell_warning(
             context: ctx,
             lines: [line],
-            message: 'is a writable attribute',
-            parameters: { name: attribute.to_s })
+            message: 'is a writable attribute')
         end
       end
 

--- a/lib/reek/smells/boolean_parameter.rb
+++ b/lib/reek/smells/boolean_parameter.rb
@@ -28,7 +28,7 @@ module Reek
             context: ctx,
             lines: [ctx.exp.line],
             message: "has boolean parameter '#{parameter}'",
-            parameters: { name: parameter.to_s })
+            parameters: { parameter: parameter.to_s })
         end
       end
     end

--- a/lib/reek/smells/control_parameter.rb
+++ b/lib/reek/smells/control_parameter.rb
@@ -52,12 +52,12 @@ module Reek
       # :reek:FeatureEnvy
       def sniff(ctx)
         ControlParameterCollector.new(ctx).control_parameters.map do |control_parameter|
-          name = control_parameter.name.to_s
+          argument = control_parameter.name.to_s
           smell_warning(
             context: ctx,
             lines: control_parameter.lines,
-            message: "is controlled by argument #{name}",
-            parameters: { name: name })
+            message: "is controlled by argument #{argument}",
+            parameters: { argument: argument })
         end
       end
 

--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -63,8 +63,7 @@ module Reek
                      "to #{methods_length} methods",
             parameters: {
               parameters: clump.map(&:to_s),
-              count: methods_length,
-              methods: methods.map(&:name)
+              count: methods_length
             })
         end
       end

--- a/lib/reek/smells/feature_envy.rb
+++ b/lib/reek/smells/feature_envy.rb
@@ -49,7 +49,7 @@ module Reek
             context: ctx,
             lines: lines,
             message: "refers to #{name} more than self (maybe move it to another class?)",
-            parameters: { name: name.to_s, count: lines.size })
+            parameters: { name: name.to_s })
         end
       end
 

--- a/lib/reek/smells/irresponsible_module.rb
+++ b/lib/reek/smells/irresponsible_module.rb
@@ -25,8 +25,7 @@ module Reek
         [smell_warning(
           context: ctx,
           lines: [expression.line],
-          message: 'has no descriptive comment',
-          parameters: { name: expression.name })]
+          message: 'has no descriptive comment')]
       end
 
       private

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -51,7 +51,7 @@ module Reek
             context: ctx,
             lines: lines,
             message: "contains iterators nested #{depth} deep",
-            parameters: { name: ctx.full_name, count: depth })
+            parameters: { depth: depth })
         end
       end
 

--- a/lib/reek/smells/prima_donna_method.rb
+++ b/lib/reek/smells/prima_donna_method.rb
@@ -38,6 +38,7 @@ module Reek
       private
 
       # :reek:FeatureEnvy
+      # :reek:TooManyStatements: { max_statements: 6 }
       def check_for_smells(method_sexp, ctx)
         return unless method_sexp.ends_with_bang?
 
@@ -47,10 +48,12 @@ module Reek
 
         return if version_without_bang
 
+        name = method_sexp.name
         smell_warning(
           context: ctx,
           lines: [ctx.exp.line],
-          message: "has prima donna method `#{method_sexp.name}`")
+          message: "has prima donna method `#{name}`",
+          parameters: { name: name })
       end
     end
   end

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -67,8 +67,7 @@ module Reek
         [smell_warning(
           context: ctx,
           lines: [ctx.exp.line],
-          message: "doesn't depend on instance state (maybe move it to another class?)",
-          parameters: { name: ctx.full_name })]
+          message: "doesn't depend on instance state (maybe move it to another class?)")]
       end
 
       private

--- a/spec/reek/report/json_report_spec.rb
+++ b/spec/reek/report/json_report_spec.rb
@@ -46,8 +46,7 @@ RSpec.describe Reek::Report::JSONReport do
             "lines":          [1],
             "message":        "doesn't depend on instance state (maybe move it to another class?)",
             "smell_type":     "UtilityFunction",
-            "source":         "string",
-            "name":           "simple"
+            "source":         "string"
           }
         ]
       EOS
@@ -80,7 +79,6 @@ RSpec.describe Reek::Report::JSONReport do
               "message":        "doesn't depend on instance state (maybe move it to another class?)",
               "smell_type":     "UtilityFunction",
               "source":         "string",
-              "name":           "simple",
               "wiki_link":      "https://github.com/troessner/reek/blob/master/docs/Utility-Function.md"
             }
           ]

--- a/spec/reek/report/yaml_report_spec.rb
+++ b/spec/reek/report/yaml_report_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe Reek::Report::YAMLReport do
   message:        "doesn't depend on instance state (maybe move it to another class?)"
   smell_type:     "UtilityFunction"
   source:         "string"
-  name:           "simple"
       EOS
 
       expect(result).to eq expected
@@ -75,7 +74,6 @@ RSpec.describe Reek::Report::YAMLReport do
   message:        "doesn't depend on instance state (maybe move it to another class?)"
   smell_type:     "UtilityFunction"
   source:         "string"
-  name:           "simple"
   wiki_link:      "https://github.com/troessner/reek/blob/master/docs/Utility-Function.md"
         EOS
 

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -7,6 +7,17 @@ RSpec.describe Reek::Smells::Attribute do
 
   it_should_behave_like 'SmellDetector'
 
+  it 'reports the right values' do
+    src = <<-EOS
+      class Klass
+        attr_writer :my_attr
+      end
+    EOS
+    expect(src).to reek_of(:Attribute,
+                           lines: [2],
+                           message: 'is a writable attribute')
+  end
+
   context 'with no attributes' do
     it 'records nothing' do
       src = <<-EOS
@@ -34,7 +45,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr_writer :my_attr
         end
       EOS
-      expect(src).to reek_of(:Attribute, name: 'my_attr')
+      expect(src).to reek_of(:Attribute, context: 'Klass#my_attr')
     end
 
     it 'does not record writer attribute if suppressed with a preceding code comment' do
@@ -53,7 +64,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr_writer :my_attr
         end
       EOS
-      expect(src).to reek_of(:Attribute, name: 'my_attr')
+      expect(src).to reek_of(:Attribute, context: 'Mod#my_attr')
     end
 
     it 'records accessor attribute' do
@@ -62,7 +73,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr_accessor :my_attr
         end
       EOS
-      expect(src).to reek_of(:Attribute, name: 'my_attr')
+      expect(src).to reek_of(:Attribute, context: 'Klass#my_attr')
     end
 
     it 'records attr defining a writer' do
@@ -71,7 +82,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr :my_attr, true
         end
       EOS
-      expect(src).to reek_of(:Attribute, name: 'my_attr')
+      expect(src).to reek_of(:Attribute, context: 'Klass#my_attr')
     end
 
     it "doesn't record protected attributes" do
@@ -110,7 +121,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr_writer :my_attr
         end
       EOS
-      expect(src).to reek_of(:Attribute, name: 'my_attr')
+      expect(src).to reek_of(:Attribute, context: 'Klass#my_attr')
     end
 
     it 'records attr_writer after switching visbility to public' do
@@ -121,7 +132,7 @@ RSpec.describe Reek::Smells::Attribute do
           public :my_attr
         end
       EOS
-      expect(src).to reek_of(:Attribute, name: 'my_attr')
+      expect(src).to reek_of(:Attribute, context: 'Klass#my_attr')
     end
 
     it 'resets visibility in new contexts' do
@@ -135,7 +146,7 @@ RSpec.describe Reek::Smells::Attribute do
           attr_writer :attr1
         end
       '
-      expect(src).to reek_of(:Attribute)
+      expect(src).to reek_of(:Attribute, context: 'OtherKlass#attr1')
     end
 
     it 'records attr_writer defining a class attribute' do
@@ -146,7 +157,7 @@ RSpec.describe Reek::Smells::Attribute do
           end
         end
       EOS
-      expect(src).to reek_of(:Attribute, name: 'my_attr')
+      expect(src).to reek_of(:Attribute, context: 'Klass#my_attr')
     end
 
     it 'does not record private class attributes' do
@@ -158,7 +169,7 @@ RSpec.describe Reek::Smells::Attribute do
           end
         end
       EOS
-      expect(src).not_to reek_of(:Attribute, name: 'my_attr')
+      expect(src).not_to reek_of(:Attribute)
     end
 
     it 'tracks visibility in metaclasses separately' do
@@ -170,7 +181,7 @@ RSpec.describe Reek::Smells::Attribute do
           end
         end
       EOS
-      expect(src).to reek_of(:Attribute, name: 'my_attr')
+      expect(src).to reek_of(:Attribute, context: 'Klass#my_attr')
     end
   end
 end

--- a/spec/reek/smells/boolean_parameter_spec.rb
+++ b/spec/reek/smells/boolean_parameter_spec.rb
@@ -7,24 +7,24 @@ RSpec.describe Reek::Smells::BooleanParameter do
     context 'in a method' do
       it 'reports a parameter defaulted to true' do
         src = 'def cc(arga = true); arga; end'
-        expect(src).to reek_of(:BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, parameter: 'arga')
       end
 
       it 'reports a parameter defaulted to false' do
         src = 'def cc(arga = false) end'
-        expect(src).to reek_of(:BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, parameter: 'arga')
       end
 
       it 'reports two parameters defaulted to booleans' do
         src = 'def cc(nowt, arga = true, argb = false, &blk) end'
-        expect(src).to reek_of(:BooleanParameter, name: 'arga')
-        expect(src).to reek_of(:BooleanParameter, name: 'argb')
+        expect(src).to reek_of(:BooleanParameter, parameter: 'arga')
+        expect(src).to reek_of(:BooleanParameter, parameter: 'argb')
       end
 
       it 'reports keyword parameters defaulted to booleans' do
         src = 'def cc(arga: true, argb: false) end'
-        expect(src).to reek_of(:BooleanParameter, name: 'arga')
-        expect(src).to reek_of(:BooleanParameter, name: 'argb')
+        expect(src).to reek_of(:BooleanParameter, parameter: 'arga')
+        expect(src).to reek_of(:BooleanParameter, parameter: 'argb')
       end
 
       it 'does not report regular parameters' do
@@ -51,18 +51,18 @@ RSpec.describe Reek::Smells::BooleanParameter do
     context 'in a singleton method' do
       it 'reports a parameter defaulted to true' do
         src = 'def self.cc(arga = true) end'
-        expect(src).to reek_of(:BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, parameter: 'arga')
       end
 
       it 'reports a parameter defaulted to false' do
         src = 'def fred.cc(arga = false) end'
-        expect(src).to reek_of(:BooleanParameter, name: 'arga')
+        expect(src).to reek_of(:BooleanParameter, parameter: 'arga')
       end
 
       it 'reports two parameters defaulted to booleans' do
         src = 'def Module.cc(nowt, arga = true, argb = false, &blk) end'
-        expect(src).to reek_of(:BooleanParameter, name: 'arga')
-        expect(src).to reek_of(:BooleanParameter, name: 'argb')
+        expect(src).to reek_of(:BooleanParameter, parameter: 'arga')
+        expect(src).to reek_of(:BooleanParameter, parameter: 'argb')
       end
     end
   end
@@ -82,8 +82,9 @@ RSpec.describe Reek::Smells::BooleanParameter do
       it_should_behave_like 'common fields set correctly'
 
       it 'reports the correct values' do
-        expect(warning.parameters[:name]).to eq('arga')
+        expect(warning.parameters[:parameter]).to eq('arga')
         expect(warning.lines).to eq([1])
+        expect(warning.message).to eq("has boolean parameter 'arga'")
       end
     end
   end

--- a/spec/reek/smells/control_parameter_spec.rb
+++ b/spec/reek/smells/control_parameter_spec.rb
@@ -32,72 +32,72 @@ RSpec.describe Reek::Smells::ControlParameter do
   context 'parameter only used to determine code path' do
     it 'reports a ternary check on a parameter' do
       src = 'def simple(arga) arga ? @ivar : 3 end'
-      expect(src).to reek_of(:ControlParameter, name: 'arga')
+      expect(src).to reek_of(:ControlParameter, argument: 'arga')
     end
 
     it 'reports a couple inside a block' do
       src = 'def blocks(arg) @text.map { |blk| arg ? blk : "#{blk}" } end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on an if statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => \'A\') if arg end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on an unless statement modifier' do
       src = 'def simple(arg) args = {}; args.merge(\'a\' => \'A\') unless arg end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on if control expression' do
       src = 'def simple(arg) args = {}; if arg then args.merge(\'a\' => \'A\') end end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on if control expression with &&' do
       src = 'def simple(arg) if arg && true then puts "arg" end end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on if control expression with preceding &&' do
       src = 'def simple(arg) if true && arg then puts "arg" end end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on if control expression with two && conditions' do
       src = 'def simple(a) ag = {}; if a && true && true then puts "2" end end'
-      expect(src).to reek_of(:ControlParameter, name: 'a')
+      expect(src).to reek_of(:ControlParameter, argument: 'a')
     end
 
     it 'reports on if control expression with ||' do
       src = 'def simple(arg) args = {}; if arg || true then puts "arg" end end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on if control expression with or' do
       src = 'def simple(arg) args = {}; if arg or true then puts "arg" end end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on if control expression with if' do
       src = 'def simple(arg) args = {}; if (arg if true) then puts "arg" end end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on && notation' do
       src = 'def simple(arg) args = {}; arg && args.merge(\'a\' => \'A\') end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on || notation' do
       src = 'def simple(arg) args = {}; arg || args.merge(\'a\' => \'A\') end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on case statement' do
       src = 'def simple(arg) case arg when nil; nil when false; nil else nil end end'
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on nested if statements that are both control parameters' do
@@ -109,7 +109,7 @@ RSpec.describe Reek::Smells::ControlParameter do
           end
         end
       EOS
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on nested if statements where the inner if is a control parameter' do
@@ -121,7 +121,7 @@ RSpec.describe Reek::Smells::ControlParameter do
           end
         end
       EOS
-      expect(src).to reek_of(:ControlParameter, name: 'arg')
+      expect(src).to reek_of(:ControlParameter, argument: 'arg')
     end
 
     it 'reports on explicit comparison in the condition' do
@@ -277,9 +277,16 @@ RSpec.describe Reek::Smells::ControlParameter do
 
     it_should_behave_like 'common fields set correctly'
 
-    it 'has the correct fields' do
-      expect(warning.parameters[:name]).to eq('arg')
+    it 'reports the argument' do
+      expect(warning.parameters[:argument]).to eq('arg')
+    end
+
+    it 'reports the lines' do
       expect(warning.lines).to eq([3, 5])
+    end
+
+    it 'has the right message' do
+      expect(warning.message).to eq('is controlled by argument arg')
     end
   end
 end

--- a/spec/reek/smells/data_clump_spec.rb
+++ b/spec/reek/smells/data_clump_spec.rb
@@ -41,10 +41,6 @@ RSpec.shared_examples_for 'a data clump detector' do
       expect(smells[0].parameters[:count]).to eq(3)
     end
 
-    it 'reports all methods' do
-      expect(smells[0].parameters[:methods]).to eq([:first, :second, :third])
-    end
-
     it 'reports the declaration line numbers' do
       expect(smells[0].lines).to eq([2, 3, 4])
     end
@@ -55,6 +51,10 @@ RSpec.shared_examples_for 'a data clump detector' do
 
     it 'reports the context fq name' do
       expect(smells[0].context).to eq(module_name)
+    end
+
+    it 'has the right message' do
+      expect(smells[0].message).to eq('takes parameters [pa, pb] to 3 methods')
     end
   end
 

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -235,10 +235,16 @@ RSpec.describe Reek::Smells::FeatureEnvy do
 
     it_should_behave_like 'common fields set correctly'
 
-    it 'reports the correct values' do
+    it 'reports the name' do
       expect(warning.parameters[:name]).to eq(receiver)
-      expect(warning.parameters[:count]).to eq(3)
+    end
+
+    it 'reports the lines' do
       expect(warning.lines).to eq([2, 4, 5])
+    end
+
+    it 'has the right message' do
+      expect(warning.message).to eq('refers to other more than self (maybe move it to another class?)')
     end
   end
 end

--- a/spec/reek/smells/irresponsible_module_spec.rb
+++ b/spec/reek/smells/irresponsible_module_spec.rb
@@ -6,12 +6,14 @@ require_relative 'smell_detector_shared'
 RSpec.describe Reek::Smells::IrresponsibleModule do
   it 'reports a class without a comment' do
     src = 'class BadClass; end'
-    expect(src).to reek_of :IrresponsibleModule, name: 'BadClass'
+    expect(src).to reek_of :IrresponsibleModule,
+                           lines: [1],
+                           message: 'has no descriptive comment'
   end
 
   it 'reports a module without a comment' do
     src = 'module BadClass; end'
-    expect(src).to reek_of :IrresponsibleModule, name: 'BadClass'
+    expect(src).to reek_of(:IrresponsibleModule, context: 'BadClass')
   end
 
   it 'does not report re-opened modules' do
@@ -39,7 +41,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
       #
       class BadClass; end
     EOS
-    expect(src).to reek_of :IrresponsibleModule
+    expect(src).to reek_of(:IrresponsibleModule, context: 'BadClass')
   end
 
   it 'reports a class with a preceding comment with intermittent material' do
@@ -50,7 +52,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
 
       class Bar; end
     EOS
-    expect(src).to reek_of(:IrresponsibleModule)
+    expect(src).to reek_of(:IrresponsibleModule, context: 'Bar')
   end
 
   it 'reports a class with a trailing comment' do
@@ -58,12 +60,12 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
       class BadClass
       end # end BadClass
     EOS
-    expect(src).to reek_of(:IrresponsibleModule)
+    expect(src).to reek_of(:IrresponsibleModule, context: 'BadClass')
   end
 
   it 'reports a fully qualified class name correctly' do
     src = 'class Foo::Bar; end'
-    expect(src).to reek_of :IrresponsibleModule, name: 'Foo::Bar'
+    expect(src).to reek_of(:IrresponsibleModule, context: 'Foo::Bar')
   end
 
   it 'does not report modules used only as namespaces' do
@@ -102,7 +104,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
         end
       end
     EOS
-    expect(src).to reek_of(:IrresponsibleModule)
+    expect(src).to reek_of(:IrresponsibleModule, context: 'Foo')
   end
 
   it 'reports modules that have both nested modules and singleton methods' do
@@ -115,7 +117,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
         end
       end
     EOS
-    expect(src).to reek_of(:IrresponsibleModule)
+    expect(src).to reek_of(:IrresponsibleModule, context: 'Foo')
   end
 
   it 'reports modules that have both nested modules and methods on the singleton class' do
@@ -130,7 +132,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
         end
       end
     EOS
-    expect(src).to reek_of(:IrresponsibleModule)
+    expect(src).to reek_of(:IrresponsibleModule, context: 'Foo')
   end
 
   it 'does not report namespace modules that have a nested class through assignment' do
@@ -149,7 +151,7 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
     src = <<-EOS
       class Foo < Bar; end
     EOS
-    expect(src).to reek_of(:IrresponsibleModule)
+    expect(src).to reek_of(:IrresponsibleModule, context: 'Foo')
   end
 
   it 'reports classes defined through assignment' do
@@ -159,14 +161,14 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
         Foo = Class.new Bar
       end
     EOS
-    expect(src).to reek_of(:IrresponsibleModule, name: 'Foo')
+    expect(src).to reek_of(:IrresponsibleModule, context: 'Qux::Foo')
   end
 
   it 'reports top level classes defined through assignment' do
     src = <<-EOS
       Foo = Class.new Bar
     EOS
-    expect(src).to reek_of(:IrresponsibleModule, name: 'Foo')
+    expect(src).to reek_of(:IrresponsibleModule, context: 'Foo')
   end
 
   it 'reports structs defined through assignment' do
@@ -176,14 +178,14 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
         Foo = Struct.new(:x, :y)
       end
     EOS
-    expect(src).to reek_of(:IrresponsibleModule, name: 'Foo')
+    expect(src).to reek_of(:IrresponsibleModule, context: 'Qux::Foo')
   end
 
   it 'reports top level structs defined through assignment' do
     src = <<-EOS
       Foo = Struct.new(:x, :y)
     EOS
-    expect(src).to reek_of(:IrresponsibleModule, name: 'Foo')
+    expect(src).to reek_of(:IrresponsibleModule, context: 'Foo')
   end
 
   it 'does not report constants that are not classes' do

--- a/spec/reek/smells/long_parameter_list_spec.rb
+++ b/spec/reek/smells/long_parameter_list_spec.rb
@@ -99,5 +99,9 @@ RSpec.describe Reek::Smells::LongParameterList do
     it 'reports the line number of the method' do
       expect(warning.lines).to eq([1])
     end
+
+    it 'has the right message' do
+      expect(warning.message).to eq('has 4 parameters')
+    end
   end
 end

--- a/spec/reek/smells/long_yield_list_spec.rb
+++ b/spec/reek/smells/long_yield_list_spec.rb
@@ -13,14 +13,17 @@ RSpec.describe Reek::Smells::LongYieldList do
       src = 'def simple(arga, argb, &blk) f(3);yield; end'
       expect(src).not_to reek_of(:LongYieldList)
     end
+
     it 'should not report yield with few parameters' do
       src = 'def simple(arga, argb, &blk) f(3);yield a,b; end'
       expect(src).not_to reek_of(:LongYieldList)
     end
+
     it 'should report yield with many parameters' do
       src = 'def simple(arga, argb, &blk) f(3);yield arga,argb,arga,argb; end'
       expect(src).to reek_of(:LongYieldList, count: 4)
     end
+
     it 'should not report yield of a long expression' do
       src = 'def simple(arga, argb, &blk) f(3);yield(if @dec then argb else 5+3 end); end'
       expect(src).not_to reek_of(:LongYieldList)
@@ -33,7 +36,7 @@ RSpec.describe Reek::Smells::LongYieldList do
         def simple(arga, argb, &blk)
           f(3)
           yield(arga,argb,arga,argb)
-          end
+        end
       EOS
       ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
       detector.sniff(ctx).first

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Reek::Smells::NestedIterators do
         ) { |qux| qux.quuz }
       end
     EOS
-    expect(src).to reek_of(:NestedIterators, count: 2)
+    expect(src).to reek_of(:NestedIterators, depth: 2)
   end
 
   it 'reports the deepest level of nesting only' do
@@ -82,8 +82,8 @@ RSpec.describe Reek::Smells::NestedIterators do
         }
       end
     EOS
-    expect(src).not_to reek_of(:NestedIterators, count: 2)
-    expect(src).to reek_of(:NestedIterators, count: 3)
+    expect(src).not_to reek_of(:NestedIterators, depth: 2)
+    expect(src).to reek_of(:NestedIterators, depth: 3)
   end
 
   it 'handles the case where super receives a block' do
@@ -132,7 +132,7 @@ RSpec.describe Reek::Smells::NestedIterators do
           end
         end
       EOS
-      expect(source).to reek_of(:NestedIterators, name: 'foo', lines: [3])
+      expect(source).to reek_of(:NestedIterators, lines: [3])
     end
 
     it 'reports all lines on which nested iterators occur' do
@@ -143,7 +143,7 @@ RSpec.describe Reek::Smells::NestedIterators do
         end
       EOS
 
-      expect(source).to reek_of(:NestedIterators, name: 'bad', lines: [2, 3])
+      expect(source).to reek_of(:NestedIterators, lines: [2, 3])
     end
 
     it 'reports separete cases of nested iterators if levels are different' do
@@ -153,8 +153,8 @@ RSpec.describe Reek::Smells::NestedIterators do
           @jim.each {|ting| ting.each {|piece| piece.each {|atom| atom.foo } } }
         end
       EOS
-      expect(source).to reek_of(:NestedIterators, name: 'bad', lines: [2], count: 2)
-      expect(source).to reek_of(:NestedIterators, name: 'bad', lines: [3], count: 3)
+      expect(source).to reek_of(:NestedIterators, lines: [2], depth: 2)
+      expect(source).to reek_of(:NestedIterators, lines: [3], depth: 3)
     end
   end
 
@@ -274,7 +274,7 @@ RSpec.describe Reek::Smells::NestedIterators do
           @fred.ignore_me {|item| item.each {|ting| ting.each {|other| other.other} } }
         end
       '
-      expect(src).to reek_of(:NestedIterators, count: 2).with_config(config)
+      expect(src).to reek_of(:NestedIterators, depth: 2).with_config(config)
     end
 
     it 'should report nested iterators outside the ignored iterator' do
@@ -283,7 +283,7 @@ RSpec.describe Reek::Smells::NestedIterators do
           @fred.each {|item| item.each {|ting| ting.ignore_me {|other| other.other} } }
         end
       '
-      expect(src).to reek_of(:NestedIterators, count: 2).with_config(config)
+      expect(src).to reek_of(:NestedIterators, depth: 2).with_config(config)
     end
 
     it 'should report nested iterators with the ignored iterator between them' do
@@ -292,7 +292,7 @@ RSpec.describe Reek::Smells::NestedIterators do
           @fred.each {|item| item.ignore_me {|ting| ting.ting {|other| other.other} } }
         end
       '
-      expect(src).to reek_of(:NestedIterators, count: 2).with_config(config)
+      expect(src).to reek_of(:NestedIterators, depth: 2).with_config(config)
     end
   end
 end
@@ -318,7 +318,7 @@ RSpec.describe Reek::Smells::NestedIterators do
     it_should_behave_like 'common fields set correctly'
 
     it 'reports correct values' do
-      expect(warning.parameters[:count]).to eq(2)
+      expect(warning.parameters[:depth]).to eq(2)
       expect(warning.lines).to eq([3])
     end
   end

--- a/spec/reek/smells/nil_check_spec.rb
+++ b/spec/reek/smells/nil_check_spec.rb
@@ -4,73 +4,70 @@ require_lib 'reek/smells/nil_check'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::NilCheck do
-  context 'for methods' do
-    it 'reports the correct line number' do
-      src = <<-EOS
+  it 'reports correctly the basic use case' do
+    src = <<-EOS
       def nilcheck foo
         foo.nil?
       end
-      EOS
-      ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      detector = build(:smell_detector, smell_type: :NilCheck)
-      smells = detector.sniff(ctx)
-      expect(smells[0].lines).to eq [2]
-    end
+    EOS
+    expect(src).to reek_of :NilCheck,
+                           lines: [2],
+                           message: 'performs a nil-check'
+  end
 
-    it 'reports nothing when scope includes no nil checks' do
-      expect('def no_nils; end').not_to reek_of(:NilCheck)
-    end
+  it 'reports nothing when scope includes no nil checks' do
+    expect('def no_nils; end').not_to reek_of(:NilCheck)
+  end
 
-    it 'reports when scope uses multiple nil? methods' do
-      src = <<-EOS
-      def chk_multi_nil(para)
-        para.nil?
-        puts "Hello"
-        \"\".nil?
+  it 'reports when scope uses multiple nil? methods' do
+    src = <<-EOS
+    def chk_multi_nil(para)
+      para.nil?
+      puts "Hello"
+      \"\".nil?
+    end
+    EOS
+    expect(src).to reek_of(:NilCheck)
+  end
+
+  it 'reports twice when scope uses == nil and === nil' do
+    src = <<-EOS
+    def chk_eq_nil(para)
+      para == nil
+      para === nil
+    end
+    EOS
+    expect(src).to reek_of(:NilCheck)
+  end
+
+  it 'reports when scope uses nil ==' do
+    expect('def chk_eq_nil_rev(para); nil == para; end').to reek_of(:NilCheck)
+  end
+
+  it 'reports when scope uses multiple case-clauses checking nil' do
+    src = <<-EOS
+    def case_nil
+      case @inst_var
+      when nil then puts "Nil"
       end
-      EOS
-      expect(src).to reek_of(:NilCheck)
-    end
-
-    it 'reports twice when scope uses == nil and === nil' do
-      src = <<-EOS
-      def chk_eq_nil(para)
-        para == nil
-        para === nil
+      puts "Hello"
+      case @inst_var2
+      when 1 then puts 1
+      when nil then puts nil.inspect
       end
-      EOS
-      expect(src).to reek_of(:NilCheck)
     end
+    EOS
+    expect(src).to reek_of(:NilCheck)
+  end
 
-    it 'reports when scope uses nil ==' do
-      expect('def chk_eq_nil_rev(para); nil == para; end').to reek_of(:NilCheck)
-    end
-
-    it 'reports when scope uses multiple case-clauses checking nil' do
-      src = <<-EOS
-      def case_nil
-        case @inst_var
-        when nil then puts "Nil"
-        end
-        puts "Hello"
-        case @inst_var2
-        when 1 then puts 1
-        when nil then puts nil.inspect
-        end
+  it 'reports a when clause that checks nil and other values' do
+    src = <<-EOS
+    def case_nil
+      case @inst_var
+      when nil, false then puts "Hello"
       end
-      EOS
-      expect(src).to reek_of(:NilCheck)
     end
-
-    it 'reports a when clause that checks nil and other values' do
-      src = <<-EOS
-      def case_nil
-        case @inst_var
-        when nil, false then puts "Hello"
-        end
-      end
-      EOS
-      expect(src).to reek_of(:NilCheck)
-    end
+    EOS
+    expect(src).to reek_of(:NilCheck)
   end
 end

--- a/spec/reek/smells/prima_donna_method_spec.rb
+++ b/spec/reek/smells/prima_donna_method_spec.rb
@@ -3,6 +3,14 @@ require_lib 'reek/context/module_context'
 require_relative 'smell_detector_shared'
 
 RSpec.describe Reek::Smells::PrimaDonnaMethod do
+  it 'reports the right values' do
+    src = 'class C; def m!; end; end'
+    expect(src).to reek_of :PrimaDonnaMethod,
+                           lines: [1],
+                           message: 'has prima donna method `m!`',
+                           name: :m!
+  end
+
   it 'should report nothing when method and bang counterpart exist' do
     expect('class C; def m; end; def m!; end; end').not_to reek_of(:PrimaDonnaMethod)
   end

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Reek::Smells::UtilityFunction do
       it 'reports the line number of the method' do
         expect(warning.lines).to eq([1])
       end
+
+      it 'has the right message' do
+        expect(warning.message).to eq("doesn't depend on instance state (maybe move it to another class?)")
+      end
     end
   end
 
@@ -92,7 +96,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
             def simple(a) a.to_s; end
           end
         EOF
-        expect(src).to reek_of(:UtilityFunction)
+        expect(src).to reek_of(:UtilityFunction, context: 'M#simple')
       end
 
       it 'does not report when module_function is called in separate scope' do
@@ -153,18 +157,18 @@ RSpec.describe Reek::Smells::UtilityFunction do
 
   context 'with only one call' do
     it 'reports a call to a parameter' do
-      expect('def simple(arga) arga.to_s end').to reek_of(:UtilityFunction, name: 'simple')
+      expect('def simple(arga) arga.to_s end').to reek_of(:UtilityFunction, context: 'simple')
     end
 
     it 'reports a call to a constant' do
-      expect('def simple(arga) FIELDS[arga] end').to reek_of(:UtilityFunction)
+      expect('def simple(arga) FIELDS[arga] end').to reek_of(:UtilityFunction, context: 'simple')
     end
   end
 
   context 'with two or more calls' do
     it 'reports two calls' do
       src = 'def simple(arga) arga.to_s + arga.to_i end'
-      expect(src).to reek_of(:UtilityFunction, name: 'simple')
+      expect(src).to reek_of(:UtilityFunction, context: 'simple')
       expect(src).not_to reek_of(:FeatureEnvy)
     end
 
@@ -189,7 +193,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
 
     it 'should report message chain' do
       src = 'def simple(arga) arga.b.c end'
-      expect(src).to reek_of(:UtilityFunction, name: 'simple')
+      expect(src).to reek_of(:UtilityFunction, context: 'simple')
       expect(src).not_to reek_of(:FeatureEnvy)
     end
 
@@ -225,7 +229,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
             def m1(a) a.to_s; end
           end
       EOS
-      expect(src).to reek_of(:UtilityFunction)
+      expect(src).to reek_of(:UtilityFunction, context: 'C#m1')
     end
 
     it 'reports protected methods' do
@@ -235,7 +239,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
             def m1(a) a.to_s; end
           end
       EOS
-      expect(src).to reek_of(:UtilityFunction)
+      expect(src).to reek_of(:UtilityFunction, context: 'C#m1')
     end
   end
 
@@ -251,7 +255,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
             def m1(a) a.to_s; end
           end
         EOS
-        expect(src).to reek_of(:UtilityFunction, name: 'C#m1').with_config(config)
+        expect(src).to reek_of(:UtilityFunction, context: 'C#m1').with_config(config)
       end
     end
 


### PR DESCRIPTION
Follow-up to #940 

This PR makes our parameter handling in smell warnings created in our smell detectors (`SmellDetector#inspect` to be precise) consistent.
The rule is simple (quoting @mvz 
):

>> Another way of looking at it, is that :parameters should contain all values that we interpolate into the smell warning message. No more, no less.

That's what this PR implements. On top of that a significant amount of spec changes because of `mutant`.