### PR TITLE
Decouple initialization from action in Examiner.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -32,7 +32,7 @@ source = <<-EOS
 EOS
 
 reporter = Reek::Report::TextReport.new
-examiner = Reek::Examiner.new source
+examiner = Reek::Examiner.run(source)
 reporter.add_examiner examiner
 reporter.show
 ```
@@ -48,7 +48,7 @@ string -- 5 warnings:
   Dirty#m has unused parameter 'c' (UnusedParameters)
 ```
 
-Note that `Reek::Examiner.new` can take `source` as `String`, `Pathname`, `File` or `IO`.
+Note that `Reek::Examiner.run` can take `source` as `String`, `Pathname`, `File` or `IO`.
 
 ## API stability
 
@@ -129,7 +129,7 @@ source = <<-EOS
 EOS
 
 reporter = Reek::Report::TextReport.new
-examiner = Reek::Examiner.new(source, configuration: configuration); nil
+examiner = Reek::Examiner.run(source, configuration: configuration); nil
 reporter.add_examiner examiner; nil
 reporter.show
 ```
@@ -175,7 +175,7 @@ source = <<-END
   end
 END
 
-examiner = Reek::Examiner.new source
+examiner = Reek::Examiner.run(source)
 examiner.smells.each do |smell|
   puts smell.message
 end

--- a/features/programmatic_access.feature
+++ b/features/programmatic_access.feature
@@ -8,7 +8,7 @@ Feature: Using Reek programmatically
     And a file named "examine.rb" with:
       """
       require 'reek'
-      examiner = Reek::Examiner.new(File.new('smelly.rb'))
+      examiner = Reek::Examiner.run(File.new('smelly.rb'))
       examiner.smells.each do |smell|
         puts smell.message
       end
@@ -27,7 +27,7 @@ Feature: Using Reek programmatically
     And a file named "examine.rb" with:
       """
       require 'reek'
-      examiner = Reek::Examiner.new(File.new('smelly.rb'))
+      examiner = Reek::Examiner.run(File.new('smelly.rb'))
       report = Reek::Report::TextReport.new
       report.add_examiner examiner
       report.show

--- a/lib/reek/cli/command/report_command.rb
+++ b/lib/reek/cli/command/report_command.rb
@@ -21,7 +21,7 @@ module Reek
 
         def populate_reporter_with_smells
           sources.each do |source|
-            reporter.add_examiner Examiner.new(source,
+            reporter.add_examiner Examiner.run(source,
                                                filter_by_smells: smell_names,
                                                configuration: configuration)
           end

--- a/lib/reek/cli/command/todo_list_command.rb
+++ b/lib/reek/cli/command/todo_list_command.rb
@@ -29,7 +29,7 @@ module Reek
 
         def scan_for_smells
           sources.map do |source|
-            Examiner.new(source,
+            Examiner.run(source,
                          filter_by_smells: smell_names,
                          configuration: configuration)
           end.map(&:smells).flatten

--- a/lib/reek/spec/should_reek.rb
+++ b/lib/reek/spec/should_reek.rb
@@ -13,7 +13,7 @@ module Reek
       end
 
       def matches?(source)
-        self.examiner = Examiner.new(source, configuration: configuration)
+        self.examiner = Examiner.run(source, configuration: configuration)
         examiner.smelly?
       end
 

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -22,7 +22,7 @@ module Reek
 
       def matches?(source)
         @matching_smell_types = nil
-        self.examiner = Examiner.new(source, configuration: configuration)
+        self.examiner = Examiner.run(source, configuration: configuration)
         set_failure_messages
         matching_smell_details?
       end

--- a/lib/reek/spec/should_reek_only_of.rb
+++ b/lib/reek/spec/should_reek_only_of.rb
@@ -12,7 +12,7 @@ module Reek
     #
     class ShouldReekOnlyOf < ShouldReekOf
       def matches?(source)
-        matches_examiner?(Examiner.new(source, configuration: configuration))
+        matches_examiner?(Examiner.run(source, configuration: configuration))
       end
 
       def matches_examiner?(examiner)

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe Reek::Examiner do
   let(:expected_first_smell) { 'NestedIterators' }
 
   context 'with a fragrant String' do
-    let(:examiner) { described_class.new('def good() true; end') }
+    let(:examiner) { described_class.run('def good() true; end').run }
 
     it_should_behave_like 'no smells found'
   end
 
   context 'with a smelly String' do
-    let(:examiner) { described_class.new('def fine() y = 4; end') }
+    let(:examiner) { described_class.run('def fine() y = 4; end') }
     let(:expected_first_smell) { 'UncommunicativeVariableName' }
 
     it_should_behave_like 'one smell found'
@@ -43,7 +43,7 @@ RSpec.describe Reek::Examiner do
   context 'with a partially masked smelly File' do
     let(:configuration) { test_configuration_for(path) }
     let(:examiner) do
-      described_class.new(smelly_file,
+      described_class.run(smelly_file,
                           filter_by_smells: [],
                           configuration: configuration)
     end
@@ -55,15 +55,61 @@ RSpec.describe Reek::Examiner do
 
   context 'with a fragrant File' do
     let(:clean_file) { Pathname.glob(SAMPLES_PATH.join('three_clean_files/*.rb')).first }
-    let(:examiner) { described_class.new(clean_file) }
+    let(:examiner) { described_class.run(clean_file) }
 
     it_should_behave_like 'no smells found'
+  end
+
+  describe '.run' do
+    context 'returns an Examiner' do
+      let(:source) { 'class C; def f; end; end' }
+      let(:examiner) do
+        described_class.run(source)
+      end
+
+      it 'has been run on the given source' do
+        expect(examiner.description).to eq('string')
+      end
+
+      it 'has the right smells' do
+        smells = examiner.smells
+        expect(smells[0].message).to eq('has no descriptive comment')
+        expect(smells[1].message).to eq("has the name 'f'")
+        expect(smells[2].message).to eq("has the name 'C'")
+      end
+
+      it 'has the right smell count' do
+        expect(examiner.smells_count).to eq(3)
+      end
+    end
+  end
+
+  describe '#run' do
+    context 'source is empty' do
+      let(:source) do
+        <<-EOS
+            # Just a comment
+            # And another
+        EOS
+      end
+      let(:examiner) do
+        described_class.new(source)
+      end
+
+      it 'returns itself' do
+        expect(examiner.run).to eq(examiner)
+      end
+
+      it 'has no warnings' do
+        expect(examiner.run.smells).to eq([])
+      end
+    end
   end
 
   describe '#smells' do
     it 'returns the detected smell warnings' do
       code     = 'def foo; bar.call_me(); bar.call_me(); end'
-      examiner = described_class.new code, filter_by_smells: ['DuplicateMethodCall']
+      examiner = described_class.run(code, filter_by_smells: ['DuplicateMethodCall'])
 
       smell = examiner.smells.first
       expect(smell).to be_a(Reek::Smells::SmellWarning)

--- a/spec/reek/report/code_climate_report_spec.rb
+++ b/spec/reek/report/code_climate_report_spec.rb
@@ -9,7 +9,7 @@ require 'stringio'
 RSpec.describe Reek::Report::CodeClimateReport do
   let(:options) { {} }
   let(:instance) { Reek::Report::CodeClimateReport.new(options) }
-  let(:examiner) { Reek::Examiner.new(source) }
+  let(:examiner) { Reek::Examiner.run(source) }
 
   before do
     instance.add_examiner examiner

--- a/spec/reek/report/html_report_spec.rb
+++ b/spec/reek/report/html_report_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Reek::Report::HTMLReport do
   let(:instance) { Reek::Report::HTMLReport.new }
 
   context 'with an empty source' do
-    let(:examiner) { Reek::Examiner.new('') }
+    let(:examiner) { Reek::Examiner.run('') }
 
     before do
       instance.add_examiner examiner

--- a/spec/reek/report/json_report_spec.rb
+++ b/spec/reek/report/json_report_spec.rb
@@ -9,7 +9,7 @@ require 'stringio'
 RSpec.describe Reek::Report::JSONReport do
   let(:options) { {} }
   let(:instance) { Reek::Report::JSONReport.new(options) }
-  let(:examiner) { Reek::Examiner.new(source) }
+  let(:examiner) { Reek::Examiner.run(source) }
 
   before do
     instance.add_examiner examiner

--- a/spec/reek/report/text_report_spec.rb
+++ b/spec/reek/report/text_report_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Reek::Report::TextReport do
 
   context 'with a single empty source' do
     before do
-      instance.add_examiner Reek::Examiner.new('')
+      instance.add_examiner Reek::Examiner.run('')
     end
 
     it 'has an empty quiet_report' do
@@ -27,8 +27,8 @@ RSpec.describe Reek::Report::TextReport do
 
   context 'with non smelly files' do
     before do
-      instance.add_examiner(Reek::Examiner.new('def simple() puts "a" end'))
-      instance.add_examiner(Reek::Examiner.new('def simple() puts "a" end'))
+      instance.add_examiner(Reek::Examiner.run('def simple() puts "a" end'))
+      instance.add_examiner(Reek::Examiner.run('def simple() puts "a" end'))
     end
 
     context 'with colors disabled' do
@@ -54,8 +54,8 @@ RSpec.describe Reek::Report::TextReport do
 
   context 'with a couple of smells' do
     before do
-      instance.add_examiner(Reek::Examiner.new('def simple(a) a[3] end'))
-      instance.add_examiner(Reek::Examiner.new('def simple(a) a[3] end'))
+      instance.add_examiner(Reek::Examiner.run('def simple(a) a[3] end'))
+      instance.add_examiner(Reek::Examiner.run('def simple(a) a[3] end'))
     end
 
     context 'with colors disabled' do

--- a/spec/reek/report/xml_report_spec.rb
+++ b/spec/reek/report/xml_report_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Reek::Report::XMLReport do
 
   context 'empty source' do
     it 'prints empty checkstyle XML' do
-      xml_report.add_examiner Reek::Examiner.new('')
+      xml_report.add_examiner Reek::Examiner.run('')
       xml = "<?xml version='1.0'?>\n<checkstyle/>\n"
       expect { xml_report.show }.to output(xml).to_stdout
     end
@@ -16,7 +16,7 @@ RSpec.describe Reek::Report::XMLReport do
   context 'source with voliations' do
     it 'prints non-empty checkstyle XML' do
       path = SAMPLES_PATH.join('two_smelly_files/dirty_one.rb')
-      xml_report.add_examiner Reek::Examiner.new(path)
+      xml_report.add_examiner Reek::Examiner.run(path)
       xml = SAMPLES_PATH.join('checkstyle.xml').read
       xml = xml.gsub(path.to_s, path.expand_path.to_s)
       expect { xml_report.show }.to output(xml).to_stdout

--- a/spec/reek/report/yaml_report_spec.rb
+++ b/spec/reek/report/yaml_report_spec.rb
@@ -9,7 +9,7 @@ require 'stringio'
 RSpec.describe Reek::Report::YAMLReport do
   let(:options) { {} }
   let(:instance) { Reek::Report::YAMLReport.new(options) }
-  let(:examiner) { Reek::Examiner.new(source) }
+  let(:examiner) { Reek::Examiner.run(source) }
 
   before do
     instance.add_examiner examiner

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Reek::Smells::FeatureEnvy do
           #{receiver}.fred
         end
       EOS
-      Reek::Examiner.new(src, filter_by_smells: ['FeatureEnvy']).smells.first
+      Reek::Examiner.run(src, filter_by_smells: ['FeatureEnvy']).smells.first
     end
 
     it_should_behave_like 'common fields set correctly'

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Reek::Smells::UtilityFunction do
             arga.b.c
           end
         EOS
-        Reek::Examiner.new(src, filter_by_smells: ['UtilityFunction']).smells[0]
+        Reek::Examiner.run(src, filter_by_smells: ['UtilityFunction']).smells[0]
       end
 
       it_should_behave_like 'common fields set correctly'


### PR DESCRIPTION
I feel that the architecture of our Examiner is not where it could be.

**I see two problems:**

1.) We do **everything** in the initializer which couples initialization to action which is not best practice
2.) Regarding [1]: I find this counter-intuitive and always felt uneasy about it. I always thought "but wait, don't I have to call anything on that?"
I also believe it is not idiomatic Ruby compared with other gems (e.g. `mutant`)
3.) It makes testing the Examiner very hard and awkward which I realized working on #996 

I think we should fix this by decoupling initialization from our `run` action, with this PR being the first draft for it.

I wanted to discuss this first before going deeper ( there are still some failing examiner specs).
WDYT @waldyr && @mvz ?