### PR TITLE
Fix our rspec matcher warnings to include all details.

### DIFF
--- a/lib/reek/smells/smell_warning.rb
+++ b/lib/reek/smells/smell_warning.rb
@@ -53,11 +53,12 @@ module Reek
       end
 
       # @public
-      def yaml_hash
+      def to_hash
         stringified_params = Hash[parameters.map { |key, val| [key.to_s, val] }]
-        core_yaml_hash.
-          merge(stringified_params)
+        base_hash.merge(stringified_params)
       end
+
+      alias yaml_hash to_hash
 
       def base_message
         "#{smell_type}: #{context} #{message}"
@@ -75,7 +76,7 @@ module Reek
 
       private
 
-      def core_yaml_hash
+      def base_hash
         {
           'context'        => context,
           'lines'          => lines,

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -74,9 +74,20 @@ module Reek
 
       def set_failure_messages_for_smell_details
         self.failure_message = "Expected #{origin} to reek of #{smell_type} "\
-          "(which it did) with smell details #{smell_details}, which it didn't"
+          "(which it did) with smell details #{smell_details}, which it didn't.\n"\
+          "The number of smell details I had to compare with the given one was #{matching_smell_types.count} "\
+          "and here they are:\n"\
+          "#{all_relevant_smell_details_formatted}"
         self.failure_message_when_negated = "Expected #{origin} not to reek of "\
           "#{smell_type} with smell details #{smell_details}, but it did"
+      end
+
+      # :reek:FeatureEnvy
+      def all_relevant_smell_details_formatted
+        matching_smell_types.each_with_object([]).with_index do |(smell, accumulator), index|
+          accumulator << "#{index + 1}.)\n"
+          accumulator << "#{smell.smell_warning.to_hash.except('smell_type')}\n"
+        end.join
       end
 
       def origin


### PR DESCRIPTION
Fixes #994 