### PR TITLE
Enable bundler in test

### DIFF
--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -4,13 +4,13 @@ require 'rspec/core/rake_task'
 namespace 'test' do
   RSpec::Core::RakeTask.new('spec') do |t|
     t.pattern = 'spec/reek/**/*_spec.rb'
-    t.ruby_opts = ['-rsimplecov -Ilib -w']
+    t.ruby_opts = ['-rbundler/setup -rsimplecov -Ilib -w']
   end
 
   desc 'Tests code quality'
   RSpec::Core::RakeTask.new('quality') do |t|
     t.pattern = 'spec/quality/**/*_spec.rb'
-    t.ruby_opts = ['-Ilib']
+    t.ruby_opts = ['-rbundler/setup -Ilib']
   end
 
   Cucumber::Rake::Task.new(:features) do |t|


### PR DESCRIPTION
I did `git clone` the repo and tried to run test as `rake`. The result was an error because I have another version of JSON library installed:

```
/Users/soutaro/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.12.5/lib/bundler/runtime.rb:35:in `block in setup': You have already activated json 2.0.2, but your Gemfile requires json 1.8.3. Prepending `bundle exec` to your command may solve this. (Gem::LoadError)
```

I tried `bundle exec rake` as recommended, but did not solve the issue.

This PR is to make test setup Bundler. I'm not very sure this fix makes sense (but it works!).