### PR TITLE
Add SexpExtensions::CSendNode for safe navigation operator

### DIFF
--- a/lib/reek/ast/sexp_extensions/send.rb
+++ b/lib/reek/ast/sexp_extensions/send.rb
@@ -53,6 +53,7 @@ module Reek
       end
 
       Op_AsgnNode = SendNode
+      CSendNode = SendNode
     end
   end
 end

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -124,6 +124,26 @@ RSpec.describe Reek::AST::SexpExtensions::DefNode do
   end
 end
 
+RSpec.describe Reek::AST::SexpExtensions::CSendNode do
+  let(:node) { Reek::Source::SourceCode.from('1&.foo(true)').syntax_tree }
+
+  it 'has a class including SendNode' do
+    expect(node.class.included_modules).to include(Reek::AST::SexpExtensions::SendNode)
+  end
+
+  it 'has a receiver' do
+    expect(node.receiver).to eq(sexp(:int, 1))
+  end
+
+  it 'has a name' do
+    expect(node.name).to eq(:foo)
+  end
+
+  it 'has arguments' do
+    expect(node.args).to eq([sexp(:true)])
+  end
+end
+
 RSpec.describe Reek::AST::SexpExtensions::DefsNode do
   context 'with no parameters' do
     let(:node) { sexp(:defs, sexp(:lvar, :obj), :hello, sexp(:args)) }


### PR DESCRIPTION
Currently `:csend` node is not supported, and the following Ruby code may make reek crash:

```rb
foo&.bar()
```

This PR is to fix the issue by adding `CSendNode`.