### PR TITLE
[Breaking change] Decouple initialization from action in Examiner.

### DIFF
--- a/defaults.reek
+++ b/defaults.reek
@@ -119,3 +119,4 @@ UnusedPrivateMethod:
 UtilityFunction:
   enabled: true
   exclude: []
+  public_methods_only: false

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -97,7 +97,7 @@ module Reek
       end
 
       def set_generate_todo_list_options
-        parser.separator '\nGenerate a todo list:'
+        parser.separator "\nGenerate a todo list:"
         parser.on('-t', '--todo', 'Generate a todo list') do
           self.generate_todo_list = true
         end

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -10,7 +10,7 @@ module Reek
   #
   # @public
   #
-  # :reek:TooManyInstanceVariables: { max_instance_variables: 6 }
+  # :reek:TooManyInstanceVariables: { max_instance_variables: 7 }
   class Examiner
     #
     # Creates an Examiner which scans the given +source+ for code smells.
@@ -34,7 +34,27 @@ module Reek
       @smell_types      = Smells::SmellRepository.eligible_smell_types(filter_by_smells)
       @smell_repository = Smells::SmellRepository.new(smell_types: @smell_types,
                                                       configuration: configuration.directive_for(description))
-      run
+    end
+
+    # Runs the Examiner on the given source to scan for code smells
+    # and returns the corresponding Examiner instance.
+    #
+    # @return an instance of Examiner
+    #
+    # @public
+    #
+    # :reek:TooManyStatements: { max_statements: 6 }
+    def run
+      @run ||= begin
+        syntax_tree = source.syntax_tree
+        return self unless syntax_tree
+        ContextBuilder.new(syntax_tree).context_tree.each do |element|
+          smell_repository.examine(element)
+        end
+
+        smell_repository.report_on(collector)
+        self
+      end
     end
 
     # FIXME: Should be named "origin"
@@ -51,6 +71,7 @@ module Reek
     #
     # @public
     def smells
+      run
       @smells ||= collector.warnings
     end
 
@@ -73,15 +94,5 @@ module Reek
     private
 
     attr_reader :collector, :source, :smell_repository
-
-    def run
-      syntax_tree = source.syntax_tree
-      return unless syntax_tree
-      ContextBuilder.new(syntax_tree).context_tree.each do |element|
-        smell_repository.examine(element)
-      end
-
-      smell_repository.report_on(collector)
-    end
   end
 end

--- a/lib/reek/smells/attribute.rb
+++ b/lib/reek/smells/attribute.rb
@@ -30,7 +30,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(ctx)
+      def sniff(ctx)
         attributes_in(ctx).map do |attribute, line|
           smell_warning(
             context: ctx,

--- a/lib/reek/smells/boolean_parameter.rb
+++ b/lib/reek/smells/boolean_parameter.rb
@@ -20,7 +20,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       # :reek:FeatureEnvy
-      def inspect(ctx)
+      def sniff(ctx)
         ctx.default_assignments.select do |_param, value|
           [:true, :false].include?(value.type)
         end.map do |parameter, _value|

--- a/lib/reek/smells/class_variable.rb
+++ b/lib/reek/smells/class_variable.rb
@@ -24,7 +24,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(ctx)
+      def sniff(ctx)
         class_variables_in(ctx.exp).map do |variable, lines|
           smell_warning(
             context: ctx,

--- a/lib/reek/smells/control_parameter.rb
+++ b/lib/reek/smells/control_parameter.rb
@@ -50,7 +50,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       # :reek:FeatureEnvy
-      def inspect(ctx)
+      def sniff(ctx)
         ControlParameterCollector.new(ctx).control_parameters.map do |control_parameter|
           name = control_parameter.name.to_s
           smell_warning(

--- a/lib/reek/smells/data_clump.rb
+++ b/lib/reek/smells/data_clump.rb
@@ -51,7 +51,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       # :reek:FeatureEnvy
-      def inspect(ctx)
+      def sniff(ctx)
         max_copies = value(MAX_COPIES_KEY, ctx)
         min_clump_size = value(MIN_CLUMP_SIZE_KEY, ctx)
         MethodGroup.new(ctx, min_clump_size, max_copies).clumps.map do |clump, methods|

--- a/lib/reek/smells/duplicate_method_call.rb
+++ b/lib/reek/smells/duplicate_method_call.rb
@@ -43,7 +43,7 @@ module Reek
       #
       # :reek:FeatureEnvy
       # :reek:DuplicateMethodCall: { max_calls: 2 }
-      def inspect(ctx)
+      def sniff(ctx)
         max_allowed_calls = value(MAX_ALLOWED_CALLS_KEY, ctx)
         allow_calls = value(ALLOW_CALLS_KEY, ctx)
 

--- a/lib/reek/smells/feature_envy.rb
+++ b/lib/reek/smells/feature_envy.rb
@@ -42,7 +42,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(ctx)
+      def sniff(ctx)
         return [] unless ctx.references_self?
         envious_receivers(ctx).map do |name, lines|
           smell_warning(

--- a/lib/reek/smells/irresponsible_module.rb
+++ b/lib/reek/smells/irresponsible_module.rb
@@ -19,7 +19,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(ctx)
+      def sniff(ctx)
         return [] if descriptive?(ctx) || ctx.namespace_module?
         expression = ctx.exp
         [smell_warning(

--- a/lib/reek/smells/long_parameter_list.rb
+++ b/lib/reek/smells/long_parameter_list.rb
@@ -33,7 +33,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(ctx)
+      def sniff(ctx)
         max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, ctx)
         exp = ctx.exp
         count = exp.arg_names.length

--- a/lib/reek/smells/long_yield_list.rb
+++ b/lib/reek/smells/long_yield_list.rb
@@ -26,7 +26,7 @@ module Reek
       #
       # :reek:FeatureEnvy
       # :reek:DuplicateMethodCall: { max_calls: 2 }
-      def inspect(ctx)
+      def sniff(ctx)
         max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, ctx)
         ctx.local_nodes(:yield).select do |yield_node|
           yield_node.args.length > max_allowed_params

--- a/lib/reek/smells/module_initialize.rb
+++ b/lib/reek/smells/module_initialize.rb
@@ -21,7 +21,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       # :reek:FeatureEnvy
-      def inspect(ctx)
+      def sniff(ctx)
         ctx.local_nodes(:def) do |node|
           if node.name.to_s == 'initialize'
             return [

--- a/lib/reek/smells/nested_iterators.rb
+++ b/lib/reek/smells/nested_iterators.rb
@@ -41,7 +41,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(ctx)
+      def sniff(ctx)
         configure_ignore_iterators ctx
         violations = find_violations ctx
 

--- a/lib/reek/smells/nil_check.rb
+++ b/lib/reek/smells/nil_check.rb
@@ -9,7 +9,7 @@ module Reek
     #
     # See {file:docs/Nil-Check.md} for details.
     class NilCheck < SmellDetector
-      def inspect(ctx)
+      def sniff(ctx)
         call_node_finder = NodeFinder.new(ctx, :send, NilCallNodeDetector)
         case_node_finder = NodeFinder.new(ctx, :when, NilWhenNodeDetector)
         smelly_nodes = call_node_finder.smelly_nodes + case_node_finder.smelly_nodes

--- a/lib/reek/smells/prima_donna_method.rb
+++ b/lib/reek/smells/prima_donna_method.rb
@@ -29,7 +29,7 @@ module Reek
         [:class]
       end
 
-      def inspect(ctx)
+      def sniff(ctx)
         ctx.node_instance_methods.map do |method_sexp|
           check_for_smells(method_sexp, ctx)
         end.compact

--- a/lib/reek/smells/repeated_conditional.rb
+++ b/lib/reek/smells/repeated_conditional.rb
@@ -48,7 +48,7 @@ module Reek
       #
       # :reek:TooManyStatements: { max_statements: 6 }
       # :reek:DuplicateMethodCall: { max_calls: 2 }
-      def inspect(ctx)
+      def sniff(ctx)
         max_identical_ifs = value(MAX_IDENTICAL_IFS_KEY, ctx)
         conditional_counts(ctx).select do |_key, lines|
           lines.length > max_identical_ifs

--- a/lib/reek/smells/smell_detector.rb
+++ b/lib/reek/smells/smell_detector.rb
@@ -44,7 +44,7 @@ module Reek
         return unless enabled_for?(context)
         return if exception?(context)
 
-        self.smells_found = smells_found + inspect(context)
+        self.smells_found = smells_found + sniff(context)
       end
 
       def report_on(collector)

--- a/lib/reek/smells/smell_warning.rb
+++ b/lib/reek/smells/smell_warning.rb
@@ -53,11 +53,12 @@ module Reek
       end
 
       # @public
-      def yaml_hash
+      def to_hash
         stringified_params = Hash[parameters.map { |key, val| [key.to_s, val] }]
-        core_yaml_hash.
-          merge(stringified_params)
+        base_hash.merge(stringified_params)
       end
+
+      alias yaml_hash to_hash
 
       def base_message
         "#{smell_type}: #{context} #{message}"
@@ -75,7 +76,7 @@ module Reek
 
       private
 
-      def core_yaml_hash
+      def base_hash
         {
           'context'        => context,
           'lines'          => lines,

--- a/lib/reek/smells/subclassed_from_core_class.rb
+++ b/lib/reek/smells/subclassed_from_core_class.rb
@@ -26,17 +26,17 @@ module Reek
       # class Foo < Bar; end;
       #
       # @return [Array<SmellWarning>]
-      def inspect(ctx)
+      def sniff(ctx)
         superclass = ctx.exp.superclass
 
         return [] unless superclass
 
-        inspect_superclass(ctx, superclass.name)
+        sniff_superclass(ctx, superclass.name)
       end
 
       private
 
-      def inspect_superclass(ctx, superclass_name)
+      def sniff_superclass(ctx, superclass_name)
         return [] unless CORE_CLASSES.include?(superclass_name)
 
         [build_smell_warning(ctx, superclass_name)]

--- a/lib/reek/smells/too_many_constants.rb
+++ b/lib/reek/smells/too_many_constants.rb
@@ -34,7 +34,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(ctx)
+      def sniff(ctx)
         max_allowed_constants = value(MAX_ALLOWED_CONSTANTS_KEY, ctx)
 
         count = ctx.each_node(:casgn, IGNORED_NODES).delete_if(&:defines_module?).length

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -33,7 +33,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(ctx)
+      def sniff(ctx)
         max_allowed_ivars = value(MAX_ALLOWED_IVARS_KEY, ctx)
         count = ctx.local_nodes(:ivasgn).map { |ivasgn| ivasgn.children.first }.uniq.length
         return [] if count <= max_allowed_ivars

--- a/lib/reek/smells/too_many_methods.rb
+++ b/lib/reek/smells/too_many_methods.rb
@@ -35,7 +35,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(ctx)
+      def sniff(ctx)
         max_allowed_methods = value(MAX_ALLOWED_METHODS_KEY, ctx)
         # TODO: Only checks instance methods!
         actual = ctx.node_instance_methods.length

--- a/lib/reek/smells/too_many_statements.rb
+++ b/lib/reek/smells/too_many_statements.rb
@@ -27,7 +27,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(ctx)
+      def sniff(ctx)
         max_allowed_statements = value(MAX_ALLOWED_STATEMENTS_KEY, ctx)
         count = ctx.number_of_statements
         return [] if count <= max_allowed_statements

--- a/lib/reek/smells/uncommunicative_method_name.rb
+++ b/lib/reek/smells/uncommunicative_method_name.rb
@@ -36,7 +36,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(context)
+      def sniff(context)
         name = context.name.to_s
         return [] if acceptable_name?(name: name, context: context)
 

--- a/lib/reek/smells/uncommunicative_module_name.rb
+++ b/lib/reek/smells/uncommunicative_module_name.rb
@@ -45,7 +45,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(context)
+      def sniff(context)
         fully_qualified_name = context.full_name
         exp                  = context.exp
         module_name          = exp.simple_name

--- a/lib/reek/smells/uncommunicative_parameter_name.rb
+++ b/lib/reek/smells/uncommunicative_parameter_name.rb
@@ -38,7 +38,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(context)
+      def sniff(context)
         expression = context.exp
         expression.parameter_names.select do |name|
           sanitized_name = sanitize name

--- a/lib/reek/smells/uncommunicative_variable_name.rb
+++ b/lib/reek/smells/uncommunicative_variable_name.rb
@@ -47,7 +47,7 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def inspect(ctx)
+      def sniff(ctx)
         self.reject_names = value(REJECT_KEY, ctx)
         self.accept_names = value(ACCEPT_KEY, ctx)
         variable_names(ctx.exp).select do |name, _lines|

--- a/lib/reek/smells/unused_parameters.rb
+++ b/lib/reek/smells/unused_parameters.rb
@@ -15,7 +15,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       # :reek:FeatureEnvy
-      def inspect(ctx)
+      def sniff(ctx)
         return [] if ctx.uses_super_with_implicit_arguments?
         ctx.unused_params.map do |param|
           name = param.name.to_s

--- a/lib/reek/smells/unused_private_method.rb
+++ b/lib/reek/smells/unused_private_method.rb
@@ -37,7 +37,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       # :reek:FeatureEnvy
-      def inspect(ctx)
+      def sniff(ctx)
         hits(ctx).map do |hit|
           name = hit.name
           smell_warning(

--- a/lib/reek/smells/utility_function.rb
+++ b/lib/reek/smells/utility_function.rb
@@ -58,7 +58,7 @@ module Reek
       #
       # :reek:FeatureEnvy
       # :reek:TooManyStatements: { max_statements: 6 }
-      def inspect(ctx)
+      def sniff(ctx)
         return [] if ctx.singleton_method? || ctx.module_function?
         return [] if ctx.references_self?
         return [] if num_helper_methods(ctx).zero?

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -74,9 +74,20 @@ module Reek
 
       def set_failure_messages_for_smell_details
         self.failure_message = "Expected #{origin} to reek of #{smell_type} "\
-          "(which it did) with smell details #{smell_details}, which it didn't"
+          "(which it did) with smell details #{smell_details}, which it didn't.\n"\
+          "The number of smell details I had to compare with the given one was #{matching_smell_types.count} "\
+          "and here they are:\n"\
+          "#{all_relevant_smell_details_formatted}"
         self.failure_message_when_negated = "Expected #{origin} not to reek of "\
           "#{smell_type} with smell details #{smell_details}, but it did"
+      end
+
+      # :reek:FeatureEnvy
+      def all_relevant_smell_details_formatted
+        matching_smell_types.each_with_object([]).with_index do |(smell, accumulator), index|
+          accumulator << "#{index + 1}.)\n"
+          accumulator << "#{smell.smell_warning.to_hash.except('smell_type')}\n"
+        end.join
       end
 
       def origin

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -60,6 +60,30 @@ RSpec.describe Reek::Examiner do
     it_should_behave_like 'no smells found'
   end
 
+  describe '.new' do
+    context 'returns a proper Examiner' do
+      let(:source) { 'class C; def f; end; end' }
+      let(:examiner) do
+        described_class.new(source)
+      end
+
+      it 'has been run on the given source' do
+        expect(examiner.description).to eq('string')
+      end
+
+      it 'has the right smells' do
+        smells = examiner.smells
+        expect(smells[0].message).to eq('has no descriptive comment')
+        expect(smells[1].message).to eq("has the name 'f'")
+        expect(smells[2].message).to eq("has the name 'C'")
+      end
+
+      it 'has the right smell count' do
+        expect(examiner.smells_count).to eq(3)
+      end
+    end
+  end
+
   describe '#smells' do
     it 'returns the detected smell warnings' do
       code     = 'def foo; bar.call_me(); bar.call_me(); end'
@@ -68,6 +92,22 @@ RSpec.describe Reek::Examiner do
       smell = examiner.smells.first
       expect(smell).to be_a(Reek::Smells::SmellWarning)
       expect(smell.message).to eq('calls bar.call_me() 2 times')
+    end
+
+    context 'source is empty' do
+      let(:source) do
+        <<-EOS
+            # Just a comment
+            # And another
+        EOS
+      end
+      let(:examiner) do
+        described_class.new(source)
+      end
+
+      it 'has no warnings' do
+        expect(examiner.smells).to eq([])
+      end
     end
   end
 end

--- a/spec/reek/smells/boolean_parameter_spec.rb
+++ b/spec/reek/smells/boolean_parameter_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Reek::Smells::BooleanParameter do
       let(:warning) do
         src = 'def cc(arga = true) end'
         ctx = Reek::Context::MethodContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-        detector.inspect(ctx).first
+        detector.sniff(ctx).first
       end
 
       it_should_behave_like 'common fields set correctly'

--- a/spec/reek/smells/class_variable_spec.rb
+++ b/spec/reek/smells/class_variable_spec.rb
@@ -12,19 +12,19 @@ RSpec.describe Reek::Smells::ClassVariable do
   context 'with no class variables' do
     it 'records nothing in the class' do
       exp = sexp(:class, :Fred)
-      expect(detector.inspect(Reek::Context::CodeContext.new(nil, exp))).to be_empty
+      expect(detector.sniff(Reek::Context::CodeContext.new(nil, exp))).to be_empty
     end
 
     it 'records nothing in the module' do
       exp = sexp(:module, :Fred)
-      expect(detector.inspect(Reek::Context::CodeContext.new(nil, exp))).to be_empty
+      expect(detector.sniff(Reek::Context::CodeContext.new(nil, exp))).to be_empty
     end
   end
 
   context 'with one class variable' do
     shared_examples_for 'one variable found' do
       let(:ast) { Reek::Source::SourceCode.from(src).syntax_tree }
-      let(:smells) { detector.inspect(Reek::Context::CodeContext.new(nil, ast)) }
+      let(:smells) { detector.sniff(Reek::Context::CodeContext.new(nil, ast)) }
 
       it 'records only that class variable' do
         expect(smells.length).to eq(1)
@@ -85,7 +85,7 @@ RSpec.describe Reek::Smells::ClassVariable do
         end
       EOS
       ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      detector.inspect(ctx).first
+      detector.sniff(ctx).first
     end
 
     it_should_behave_like 'common fields set correctly'

--- a/spec/reek/smells/data_clump_spec.rb
+++ b/spec/reek/smells/data_clump_spec.rb
@@ -26,7 +26,7 @@ RSpec.shared_examples_for 'a data clump detector' do
         end
       EOS
       ctx = Reek::Context::ModuleContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      build(:smell_detector, smell_type: :DataClump).inspect(ctx)
+      build(:smell_detector, smell_type: :DataClump).sniff(ctx)
     end
 
     it 'records only the one smell' do

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Reek::Smells::DuplicateMethodCall do
         end
       EOS
       ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      smells = detector.inspect(ctx)
+      smells = detector.sniff(ctx)
       expect(smells.length).to eq(1)
       smells.first
     end

--- a/spec/reek/smells/long_parameter_list_spec.rb
+++ b/spec/reek/smells/long_parameter_list_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Reek::Smells::LongParameterList do
         end
       EOS
       ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      detector.inspect(ctx).first
+      detector.sniff(ctx).first
     end
 
     it_should_behave_like 'common fields set correctly'

--- a/spec/reek/smells/long_yield_list_spec.rb
+++ b/spec/reek/smells/long_yield_list_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Reek::Smells::LongYieldList do
           end
       EOS
       ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      detector.inspect(ctx).first
+      detector.sniff(ctx).first
     end
 
     it_should_behave_like 'common fields set correctly'

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Reek::Smells::NestedIterators do
     expect(src).to reek_of(:NestedIterators)
   end
 
-  describe 'inspect / warnings' do
+  describe 'sniff / warnings' do
     let(:detector) { build(:smell_detector, smell_type: :NestedIterators) }
 
     it 'reports a sensible warning message' do
@@ -288,7 +288,7 @@ RSpec.describe Reek::Smells::NestedIterators do
         end
       EOS
       ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      detector.inspect(ctx).first
+      detector.sniff(ctx).first
     end
 
     it_should_behave_like 'common fields set correctly'

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -193,6 +193,30 @@ RSpec.describe Reek::Smells::NestedIterators do
     end
   end
 
+  it 'reports nested iterators called via safe navigation' do
+    source = <<-EOS
+      def show_bottles(bars)
+        bars&.each do |bar|
+          bar&.each do |bottle|
+            puts bottle
+          end
+        end
+      end
+    EOS
+    expect(source).to reek_of(:NestedIterators)
+  end
+
+  it 'does not report unnested iterators called via safe navigation' do
+    source = <<-EOS
+      def show_bottles(bar)
+        bar&.each do |bottle|
+          puts bottle
+        end
+      end
+    EOS
+    expect(source).not_to reek_of(:NestedIterators)
+  end
+
   context 'when the allowed nesting depth is 3' do
     let(:config) do
       { Reek::Smells::NestedIterators::MAX_ALLOWED_NESTING_KEY => 3 }

--- a/spec/reek/smells/nil_check_spec.rb
+++ b/spec/reek/smells/nil_check_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Reek::Smells::NilCheck do
       EOS
       ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
       detector = build(:smell_detector, smell_type: :NilCheck)
-      smells = detector.inspect(ctx)
+      smells = detector.sniff(ctx)
       expect(smells[0].lines).to eq [2]
     end
 

--- a/spec/reek/smells/prima_donna_method_spec.rb
+++ b/spec/reek/smells/prima_donna_method_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Reek::Smells::PrimaDonnaMethod do
     end
 
     it 'should be reported' do
-      smells = detector.inspect(ctx)
+      smells = detector.sniff(ctx)
       warning = smells[0]
 
       expect(warning.smell_type).to eq('PrimaDonnaMethod')

--- a/spec/reek/smells/too_many_instance_variables_spec.rb
+++ b/spec/reek/smells/too_many_instance_variables_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
         end
       EOS
       ctx = Reek::Context::CodeContext.new(nil, Reek::Source::SourceCode.from(src).syntax_tree)
-      detector.inspect(ctx).first
+      detector.sniff(ctx).first
     end
 
     it_should_behave_like 'common fields set correctly'

--- a/spec/reek/smells/too_many_methods_spec.rb
+++ b/spec/reek/smells/too_many_methods_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Reek::Smells::TooManyMethods do
       EOS
       syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
       ctx = Reek::Context::ModuleContext.new(nil, syntax_tree)
-      expect(detector.inspect(ctx)).to be_empty
+      expect(detector.sniff(ctx)).to be_empty
     end
 
     it 'should report if we exceed max_methods' do
@@ -31,7 +31,7 @@ RSpec.describe Reek::Smells::TooManyMethods do
       EOS
       syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
       ctx = Reek::Context::ModuleContext.new(nil, syntax_tree)
-      smells = detector.inspect(ctx)
+      smells = detector.sniff(ctx)
       expect(smells.length).to eq(1)
       expect(smells[0].smell_type).to eq(described_class.smell_type)
       expect(smells[0].parameters[:count]).to eq(3)
@@ -54,7 +54,7 @@ RSpec.describe Reek::Smells::TooManyMethods do
       EOS
       syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
       ctx = Reek::Context::ModuleContext.new(nil, syntax_tree)
-      expect(detector.inspect(ctx)).to be_empty
+      expect(detector.sniff(ctx)).to be_empty
     end
   end
 
@@ -69,7 +69,7 @@ RSpec.describe Reek::Smells::TooManyMethods do
 
     syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
     ctx = Reek::Context::ModuleContext.new(nil, syntax_tree)
-    warning = detector.inspect(ctx)[0]
+    warning = detector.sniff(ctx)[0]
     expect(warning.source).to eq(source_name)
     expect(warning.smell_type).to eq(described_class.smell_type)
     expect(warning.parameters[:count]).to eq(3)

--- a/spec/reek/smells/too_many_statements_spec.rb
+++ b/spec/reek/smells/too_many_statements_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Reek::Smells::TooManyStatements do
       ctx = double('method_context').as_null_object
       expect(ctx).to receive(:number_of_statements).and_return(number_of_statements)
       expect(ctx).to receive(:config_for).with(described_class).and_return({})
-      detector.inspect(ctx)
+      detector.sniff(ctx)
     end
 
     it 'reports only 1 smell' do

--- a/spec/reek/smells/uncommunicative_method_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_method_name_spec.rb
@@ -26,19 +26,19 @@ RSpec.describe Reek::Smells::UncommunicativeMethodName do
     end
   end
 
-  describe 'inspect' do
+  describe 'sniff' do
     let(:source) { 'def x; end' }
     let(:context) { code_context(source) }
     let(:detector) { build(:smell_detector, smell_type: :UncommunicativeMethodName) }
 
     it 'returns an array of smell warnings' do
-      smells = detector.inspect(context)
+      smells = detector.sniff(context)
       expect(smells.length).to eq(1)
       expect(smells[0]).to be_a_kind_of(Reek::Smells::SmellWarning)
     end
 
     it 'contains proper smell warnings' do
-      smells = detector.inspect(context)
+      smells = detector.sniff(context)
       warning = smells[0]
 
       expect(warning.smell_type).to eq(Reek::Smells::UncommunicativeMethodName.smell_type)

--- a/spec/reek/smells/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_module_name_spec.rb
@@ -27,19 +27,19 @@ RSpec.describe Reek::Smells::UncommunicativeModuleName do
     end
   end
 
-  describe 'inspect' do
+  describe 'sniff' do
     let(:source) { 'class Foo::X; end' }
     let(:context) { code_context(source) }
     let(:detector) { build(:smell_detector, smell_type: :UncommunicativeModuleName) }
 
     it 'returns an array of smell warnings' do
-      smells = detector.inspect(context)
+      smells = detector.sniff(context)
       expect(smells.length).to eq(1)
       expect(smells[0]).to be_a_kind_of(Reek::Smells::SmellWarning)
     end
 
     it 'contains proper smell warnings' do
-      smells = detector.inspect(context)
+      smells = detector.sniff(context)
       warning = smells[0]
 
       expect(warning.smell_type).to eq(Reek::Smells::UncommunicativeModuleName.smell_type)

--- a/spec/reek/smells/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_parameter_name_spec.rb
@@ -72,19 +72,19 @@ RSpec.describe Reek::Smells::UncommunicativeParameterName do
     end
   end
 
-  describe 'inspect' do
+  describe 'sniff' do
     let(:source) { 'def foo(bar2); baz(bar2); end' }
     let(:context) { method_context(source) }
     let(:detector) { build(:smell_detector, smell_type: :UncommunicativeParameterName) }
 
     it 'returns an array of smell warnings' do
-      smells = detector.inspect(context)
+      smells = detector.sniff(context)
       expect(smells.length).to eq(1)
       expect(smells[0]).to be_a_kind_of(Reek::Smells::SmellWarning)
     end
 
     it 'contains proper smell warnings' do
-      smells = detector.inspect(context)
+      smells = detector.sniff(context)
       warning = smells[0]
 
       expect(warning.smell_type).to eq(Reek::Smells::UncommunicativeParameterName.smell_type)

--- a/spec/reek/smells/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_variable_name_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
       src = 'def simple(fred) x = jim(45); x = y end'
       syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
       ctx = Reek::Context::CodeContext.new(nil, syntax_tree)
-      smells = detector.inspect(ctx)
+      smells = detector.sniff(ctx)
       expect(smells.length).to eq(1)
       expect(smells[0].smell_type).to eq(described_class.smell_type)
       expect(smells[0].parameters[:name]).to eq('x')
@@ -164,7 +164,7 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
       EOS
       syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
       ctx = Reek::Context::CodeContext.new(nil, syntax_tree)
-      detector.inspect(ctx).first
+      detector.sniff(ctx).first
     end
 
     it_should_behave_like 'common fields set correctly'
@@ -180,7 +180,7 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
       src = 'def self.bad() x2 = 4; end'
       syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
       ctx = Reek::Context::CodeContext.new(nil, syntax_tree)
-      detector.inspect(ctx).first
+      detector.sniff(ctx).first
     end
 
     it_should_behave_like 'common fields set correctly'


### PR DESCRIPTION
The same as #997 but pointing to the reek-5 branch this time. 
Ready for review!

There are quite a few mutant failures I don't understand. 
E.g.:

````
     ContextBuilder.new(syntax_tree).context_tree.each do |element|
-      smell_repository.examine(element)
+      smell_repository.examine(nil)
     end
````

When I add this change manually literally **all** the specs for Examiner break. 

Same goes for 

```
     ContextBuilder.new(syntax_tree).context_tree.each do |element|
       smell_repository.examine(element)
     end
-    smell_repository.report_on(collector)
+    nil
     self
```

I don't understand what is happening here. But let's ignore this, this is a separate issue. 

I do however feel that this change has been spec'ed enough and I don't want to address the [mutant issue](https://github.com/troessner/reek/issues/1007) here.

Speedy review would be great so we can get this on the road :)

