### PR TITLE
Don't run mutant on CI.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,5 @@ require 'rake/clean'
 Dir['tasks/**/*.rake'].each { |t| load t }
 
 task local_test_run: [:test, :rubocop, 'test:quality']
-task ci: [:test, :rubocop, 'test:quality', :ataru, :mutant]
+task ci: [:test, :rubocop, 'test:quality', :ataru]
 task default: :local_test_run


### PR DESCRIPTION
Lgtm.
We can and should fix our mutant set up asap and then re-enable it but right now it's not working and having to check every red pull request is tedious.