### PR TITLE
Use double quotation for `\n` in --help

### DIFF
--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -97,7 +97,7 @@ module Reek
       end
 
       def set_generate_todo_list_options
-        parser.separator '\nGenerate a todo list:'
+        parser.separator "\nGenerate a todo list:"
         parser.on('-t', '--todo', 'Generate a todo list') do
           self.generate_todo_list = true
         end


### PR DESCRIPTION
`reek --help` displays a `\n`. Because single quotation is used.


```
$ reek --help
Usage: reek [options] [files]

Examples:

reek lib/*.rb
reek -s lib
cat my_class.rb | reek

See https://wiki.github.com/troessner/reek for detailed help.

Configuration:
    -c, --config FILE                Read configuration options from FILE
        --smell SMELL                Detect smell SMELL (default: all enabled smells)
\nGenerate a todo list:
    -t, --todo                       Generate a todo list

Report format:
    -f, --format FORMAT              Report smells in the given format:
                                       html
                                       text (default)
                                       yaml
                                       json
                                       xml
                                       code_climate

Text format options:
        --[no-]color                 Use colors for the output (default: true)
    -V, --[no-]empty-headings        Show headings for smell-free source files (default: false)
    -U, --[no-]wiki-links            Show link to related wiki page for each smell (default: true)
    -n, --[no-]line-numbers          Show line numbers in the output (default: true)
    -s, --single-line                Show location in editor-compatible single-line-per-smell format
        --sort-by SORTING            Sort reported files by the given criterium:
                                       smelliness ("smelliest" files first)
                                       none (default - output in processing order)

Exit codes:
        --success-exit-code CODE     The exit code when no smells are found (default: 0)
        --failure-exit-code CODE     The exit code when smells are found (default: 2)

Utility options:
    -h, --help                       Show this message
    -v, --version                    Show version
```
