### PR TITLE
Decouple initialization from action in Examiner.

### DIFF
--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -10,7 +10,7 @@ module Reek
   #
   # @public
   #
-  # :reek:TooManyInstanceVariables: { max_instance_variables: 6 }
+  # :reek:TooManyInstanceVariables: { max_instance_variables: 7 }
   class Examiner
     #
     # Creates an Examiner which scans the given +source+ for code smells.
@@ -34,7 +34,6 @@ module Reek
       @smell_types      = Smells::SmellRepository.eligible_smell_types(filter_by_smells)
       @smell_repository = Smells::SmellRepository.new(smell_types: @smell_types,
                                                       configuration: configuration.directive_for(description))
-      run
     end
 
     # FIXME: Should be named "origin"
@@ -51,6 +50,7 @@ module Reek
     #
     # @public
     def smells
+      run
       @smells ||= collector.warnings
     end
 
@@ -74,14 +74,23 @@ module Reek
 
     attr_reader :collector, :source, :smell_repository
 
+    # Runs the Examiner on the given source to scan for code smells
+    # and returns the corresponding Examiner instance.
+    #
+    # @return an instance of Examiner
+    #
+    # :reek:TooManyStatements: { max_statements: 6 }
     def run
-      syntax_tree = source.syntax_tree
-      return unless syntax_tree
-      ContextBuilder.new(syntax_tree).context_tree.each do |element|
-        smell_repository.examine(element)
-      end
+      @run ||= begin
+        syntax_tree = source.syntax_tree
+        return self unless syntax_tree
+        ContextBuilder.new(syntax_tree).context_tree.each do |element|
+          smell_repository.examine(element)
+        end
 
-      smell_repository.report_on(collector)
+        smell_repository.report_on(collector)
+        self
+      end
     end
   end
 end

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -60,6 +60,30 @@ RSpec.describe Reek::Examiner do
     it_should_behave_like 'no smells found'
   end
 
+  describe '.new' do
+    context 'returns a proper Examiner' do
+      let(:source) { 'class C; def f; end; end' }
+      let(:examiner) do
+        described_class.new(source)
+      end
+
+      it 'has been run on the given source' do
+        expect(examiner.description).to eq('string')
+      end
+
+      it 'has the right smells' do
+        smells = examiner.smells
+        expect(smells[0].message).to eq('has no descriptive comment')
+        expect(smells[1].message).to eq("has the name 'f'")
+        expect(smells[2].message).to eq("has the name 'C'")
+      end
+
+      it 'has the right smell count' do
+        expect(examiner.smells_count).to eq(3)
+      end
+    end
+  end
+
   describe '#smells' do
     it 'returns the detected smell warnings' do
       code     = 'def foo; bar.call_me(); bar.call_me(); end'
@@ -68,6 +92,22 @@ RSpec.describe Reek::Examiner do
       smell = examiner.smells.first
       expect(smell).to be_a(Reek::Smells::SmellWarning)
       expect(smell.message).to eq('calls bar.call_me() 2 times')
+    end
+
+    context 'source is empty' do
+      let(:source) do
+        <<-EOS
+            # Just a comment
+            # And another
+        EOS
+      end
+      let(:examiner) do
+        described_class.new(source)
+      end
+
+      it 'has no warnings' do
+        expect(examiner.smells).to eq([])
+      end
     end
   end
 end


### PR DESCRIPTION
Replacement for #1008 (it's not a breaking change anymore).