### PR TITLE
Remove memoized instance variables from accounting of TooManyInstanceVariables smell

### DIFF
--- a/lib/reek/context/code_context.rb
+++ b/lib/reek/context/code_context.rb
@@ -68,8 +68,9 @@ module Reek
       # @param type [Symbol] the type of the nodes we are looking for, e.g. :defs.
       # @yield block that is executed for every node.
       #
-      def local_nodes(type, &blk)
-        each_node(type, [:casgn, :class, :module], &blk)
+      def local_nodes(type, ignored = [], &blk)
+        ignored += [:casgn, :class, :module]
+        each_node(type, ignored, &blk)
       end
 
       # Iterate over `self` and child contexts.

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -35,13 +35,28 @@ module Reek
       #
       def sniff(ctx)
         max_allowed_ivars = value(MAX_ALLOWED_IVARS_KEY, ctx)
-        count = ctx.local_nodes(:ivasgn).map { |ivasgn| ivasgn.children.first }.uniq.length
+
+        count = count_instance_variables(ctx)
+
         return [] if count <= max_allowed_ivars
+
         [smell_warning(
           context: ctx,
           lines: [ctx.exp.line],
           message: "has at least #{count} instance variables",
           parameters: { count: count })]
+      end
+
+      private
+
+      def count_instance_variables(ctx)
+        ctx.each_node(:ivasgn, ignored_nodes).map do |node|
+          node.children.first
+        end.uniq.size
+      end
+
+      def ignored_nodes
+        [:or_asgn, :class, :module]
       end
     end
   end

--- a/lib/reek/smells/too_many_instance_variables.rb
+++ b/lib/reek/smells/too_many_instance_variables.rb
@@ -35,28 +35,14 @@ module Reek
       #
       def sniff(ctx)
         max_allowed_ivars = value(MAX_ALLOWED_IVARS_KEY, ctx)
-
-        count = count_instance_variables(ctx)
-
+        variables = ctx.local_nodes(:ivasgn, [:or_asgn]).map(&:name)
+        count = variables.uniq.size
         return [] if count <= max_allowed_ivars
-
         [smell_warning(
           context: ctx,
           lines: [ctx.exp.line],
           message: "has at least #{count} instance variables",
           parameters: { count: count })]
-      end
-
-      private
-
-      def count_instance_variables(ctx)
-        ctx.each_node(:ivasgn, ignored_nodes).map do |node|
-          node.children.first
-        end.uniq.size
-      end
-
-      def ignored_nodes
-        [:or_asgn, :class, :module]
       end
     end
   end

--- a/spec/reek/smells/too_many_instance_variables_spec.rb
+++ b/spec/reek/smells/too_many_instance_variables_spec.rb
@@ -13,12 +13,10 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
         end
       EOS
 
-      message = 'has at least 5 instance variables'
-
-      expect(src).to reek_of(:TooManyInstanceVariables,
+      expect(src).to reek_of(described_class,
                              lines: [1],
                              count: 5,
-                             message: message,
+                             message: 'has at least 5 instance variables',
                              context: 'Empty')
     end
   end
@@ -32,7 +30,7 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
           end
         end
       EOS
-      expect(src).not_to reek_of(:TooManyInstanceVariables)
+      expect(src).not_to reek_of(described_class)
     end
 
     it 'has a configurable maximum' do
@@ -45,7 +43,7 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
           end
         end
       EOS
-      expect(src).not_to reek_of(:TooManyInstanceVariables)
+      expect(src).not_to reek_of(described_class)
     end
 
     it 'counts each ivar only once' do
@@ -57,7 +55,7 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
           end
         end
       EOS
-      expect(src).not_to reek_of(:TooManyInstanceVariables)
+      expect(src).not_to reek_of(described_class)
     end
 
     it 'should not report memoized ivars' do
@@ -69,7 +67,7 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
           end
         end
       EOS
-      expect(src).not_to reek_of(:TooManyInstanceVariables)
+      expect(src).not_to reek_of(described_class)
     end
 
     it 'should not count ivars on inner classes altogether' do
@@ -88,7 +86,7 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
           end
         end
       EOS
-      expect(src).not_to reek_of(:TooManyInstanceVariables)
+      expect(src).not_to reek_of(described_class)
     end
 
     it 'should not count ivars on modules altogether' do
@@ -107,7 +105,7 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
           end
         end
       EOS
-      expect(src).not_to reek_of(:TooManyInstanceVariables)
+      expect(src).not_to reek_of(described_class)
     end
 
     it 'reports excessive ivars' do
@@ -119,7 +117,7 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
           end
         end
       EOS
-      expect(src).to reek_of(:TooManyInstanceVariables)
+      expect(src).to reek_of(described_class)
     end
 
     it 'reports excessive ivars even in different methods' do
@@ -134,7 +132,7 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
           end
         end
       EOS
-      expect(src).to reek_of(:TooManyInstanceVariables)
+      expect(src).to reek_of(described_class)
     end
 
     it 'should not report for ivars in 2 extensions' do
@@ -151,7 +149,7 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
           end
         end
       EOS
-      expect(src).not_to reek_of(:TooManyInstanceVariables)
+      expect(src).not_to reek_of(described_class)
     end
   end
 end


### PR DESCRIPTION
#807