### PR TITLE
Introduce rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-rspec
+
 AllCops:
   Exclude:
     - 'samples/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,49 @@ Metrics/LineLength:
 Metrics/ParameterLists:
   CountKeywordArgs: false
 
+# FIXME: Update specs to avoid offenses
+RSpec/AnyInstance:
+  Exclude:
+    - 'spec/reek/cli/application_spec.rb'
+
+# This file does not test a class
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/quality/reek_source_spec.rb'
+
+# Our examples are large because we have source literals in them
+RSpec/ExampleLength:
+  Enabled: false
+
+# FIXME: Split up files to avoid offenses
+RSpec/MultipleDescribes:
+  Exclude:
+    - 'spec/reek/ast/sexp_extensions_spec.rb'
+    - 'spec/reek/report/location_formatter_spec.rb'
+
+# FIXME: Update specs to avoid offenses
+RSpec/MultipleExpectations:
+  Exclude:
+    - 'spec/reek/cli/application_spec.rb'
+    - 'spec/reek/code_comment_spec.rb'
+    - 'spec/reek/configuration/app_configuration_spec.rb'
+    - 'spec/reek/context/module_context_spec.rb'
+    - 'spec/reek/context_builder_spec.rb'
+    - 'spec/reek/examiner_spec.rb'
+    - 'spec/reek/spec/should_reek_of_spec.rb'
+
+# FIXME: Update specs to avoid offenses
+RSpec/NestedGroups:
+  Exclude:
+    - 'spec/reek/cli/application_spec.rb'
+
+# FIXME: Update specs to avoid offenses
+RSpec/VerifiedDoubles:
+  Exclude:
+    - 'spec/reek/context/code_context_spec.rb'
+    - 'spec/reek/context/method_context_spec.rb'
+    - 'spec/reek/context/module_context_spec.rb'
+
 Style/AccessorMethodName:
   Exclude:
     - 'lib/reek/context/visibility_tracker.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development do
   gem 'rake',          '~> 11.1'
   gem 'rspec',         '~> 3.0'
   gem 'rubocop',       '~> 0.42.0'
+  gem 'rubocop-rspec', '~> 1.7'
   gem 'simplecov',     '~> 0.12.0'
   gem 'yard',          '~> 0.9.5'
   gem 'activesupport', '~> 4.2'

--- a/Gemfile
+++ b/Gemfile
@@ -10,11 +10,14 @@ group :development do
   gem 'mutant-rspec',  '~> 0.8.8'
   gem 'rake',          '~> 11.1'
   gem 'rspec',         '~> 3.0'
-  gem 'rubocop',       '~> 0.42.0'
-  gem 'rubocop-rspec', '~> 1.7'
   gem 'simplecov',     '~> 0.12.0'
   gem 'yard',          '~> 0.9.5'
   gem 'activesupport', '~> 4.2'
+
+  if RUBY_VERSION >= '2.3'
+    gem 'rubocop',       '~> 0.42.0'
+    gem 'rubocop-rspec', '~> 1.7'
+  end
 
   platforms :mri do
     gem 'redcarpet', '~> 3.3.1'

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -9,6 +9,8 @@ module Reek
     # code smell.
     #
     class ShouldReekOf
+      include RSpec::Matchers::Composable
+
       # Variant of Examiner that doesn't swallow exceptions
       class UnsafeExaminer < Examiner
         def run

--- a/spec/quality/reek_source_spec.rb
+++ b/spec/quality/reek_source_spec.rb
@@ -3,7 +3,7 @@ require_relative '../spec_helper'
 RSpec.describe 'Reek source code' do
   it 'has no smells' do
     Pathname.glob('lib/**/*.rb').each do |pathname|
-      expect(pathname).to_not reek
+      expect(pathname).not_to reek
     end
   end
 end

--- a/spec/reek/ast/object_refs_spec.rb
+++ b/spec/reek/ast/object_refs_spec.rb
@@ -2,57 +2,16 @@ require_relative '../../spec_helper'
 require_lib 'reek/ast/object_refs'
 
 RSpec.describe Reek::AST::ObjectRefs do
-  let(:refs) { Reek::AST::ObjectRefs.new }
+  let(:refs) { described_class.new }
 
   context 'when empty' do
-    it 'should report no refs to self' do
+    it 'reports no refs to self' do
       expect(refs.references_to(:self)).to be_empty
     end
   end
 
-  context 'with references to a, b, and a' do
-    context 'with no refs to self' do
-      before(:each) do
-        refs.record_reference(name: :a)
-        refs.record_reference(name: :b)
-        refs.record_reference(name: :a)
-      end
-
-      it 'should report no refs to self' do
-        expect(refs.references_to(:self)).to be_empty
-      end
-
-      it 'should report :a as the max' do
-        expect(refs.most_popular).to include(:a)
-      end
-
-      it 'should not report self as the max' do
-        expect(refs.self_is_max?).to eq(false)
-      end
-
-      context 'with one reference to self' do
-        before(:each) do
-          refs.record_reference(name: :self)
-        end
-
-        it 'should report 1 ref to self' do
-          expect(refs.references_to(:self).size).to eq(1)
-        end
-
-        it 'should not report self among the max' do
-          expect(refs.most_popular).to include(:a)
-          expect(refs.most_popular).not_to include(:self)
-        end
-
-        it 'should not report self as the max' do
-          expect(refs.self_is_max?).to eq(false)
-        end
-      end
-    end
-  end
-
   context 'with many refs to self' do
-    before(:each) do
+    before do
       refs.record_reference(name: :self)
       refs.record_reference(name: :self)
       refs.record_reference(name: :a)
@@ -62,21 +21,21 @@ RSpec.describe Reek::AST::ObjectRefs do
       refs.record_reference(name: :self)
     end
 
-    it 'should report all refs to self' do
+    it 'reports all refs to self' do
       expect(refs.references_to(:self).size).to eq(4)
     end
 
-    it 'should report self among the max' do
+    it 'reports self among the max' do
       expect(refs.most_popular).to include(:self)
     end
 
-    it 'should report self as the max' do
+    it 'reports self as the max' do
       expect(refs.self_is_max?).to eq(true)
     end
   end
 
   context 'when self is not the only max' do
-    before(:each) do
+    before do
       refs.record_reference(name: :a)
       refs.record_reference(name: :self)
       refs.record_reference(name: :self)
@@ -84,38 +43,40 @@ RSpec.describe Reek::AST::ObjectRefs do
       refs.record_reference(name: :a)
     end
 
-    it 'should report all refs to self' do
+    it 'reports all refs to self' do
       expect(refs.references_to(:self).size).to eq(2)
     end
 
-    it 'should report self among the max' do
-      expect(refs.most_popular).to include(:a)
+    it 'reports self among the max' do
       expect(refs.most_popular).to include(:self)
     end
 
-    it 'should report self as the max' do
+    it 'reports the other max among the max' do
+      expect(refs.most_popular).to include(:a)
+    end
+
+    it 'reports self as the max' do
       expect(refs.self_is_max?).to eq(true)
     end
   end
 
-  context 'when self is not among the max' do
-    before(:each) do
+  context 'when self is not recorded' do
+    before do
       refs.record_reference(name: :a)
       refs.record_reference(name: :b)
       refs.record_reference(name: :a)
       refs.record_reference(name: :b)
     end
 
-    it 'should report all refs to self' do
+    it 'reports no refs to self' do
       expect(refs.references_to(:self).size).to eq(0)
     end
 
-    it 'should not report self among the max' do
-      expect(refs.most_popular).to include(:a)
-      expect(refs.most_popular).to include(:b)
+    it 'does not report self among the max' do
+      expect(refs.most_popular).not_to include(:self)
     end
 
-    it 'should not report self as the max' do
+    it 'does not report self as the max' do
       expect(refs.self_is_max?).to eq(false)
     end
   end

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -402,60 +402,60 @@ end
 
 RSpec.describe Reek::AST::SexpExtensions::ModuleNode do
   context 'with a simple name' do
-    subject do
+    let(:exp) do
       Reek::Source::SourceCode.from('module Fred; end').syntax_tree
     end
 
     it 'has the correct #name' do
-      expect(subject.name).to eq 'Fred'
+      expect(exp.name).to eq 'Fred'
     end
 
     it 'has the correct #simple_name' do
-      expect(subject.simple_name).to eq 'Fred'
+      expect(exp.simple_name).to eq 'Fred'
     end
 
     it 'has a simple full_name' do
-      expect(subject.full_name('')).to eq 'Fred'
+      expect(exp.full_name('')).to eq 'Fred'
     end
 
     it 'has a fq full_name' do
-      expect(subject.full_name('Blimey::O::Reilly')).to eq 'Blimey::O::Reilly::Fred'
+      expect(exp.full_name('Blimey::O::Reilly')).to eq 'Blimey::O::Reilly::Fred'
     end
   end
 
   context 'with a scoped name' do
-    subject do
+    let(:exp) do
       Reek::Source::SourceCode.from('module Foo::Bar; end').syntax_tree
     end
 
     it 'has the correct #name' do
-      expect(subject.name).to eq 'Foo::Bar'
+      expect(exp.name).to eq 'Foo::Bar'
     end
 
     it 'has the correct #simple_name' do
-      expect(subject.simple_name).to eq 'Bar'
+      expect(exp.simple_name).to eq 'Bar'
     end
 
     it 'has a simple full_name' do
-      expect(subject.full_name('')).to eq 'Foo::Bar'
+      expect(exp.full_name('')).to eq 'Foo::Bar'
     end
 
-    it 'has a fq full_name' do
-      expect(subject.full_name('Blimey::O::Reilly')).to eq 'Blimey::O::Reilly::Foo::Bar'
+    it 'has a fully qualified full_name' do
+      expect(exp.full_name('Blimey::O::Reilly')).to eq 'Blimey::O::Reilly::Foo::Bar'
     end
   end
 
   context 'with a name scoped in a namespace that is not a constant' do
-    subject do
+    let(:exp) do
       Reek::Source::SourceCode.from('module foo::Bar; end').syntax_tree
     end
 
     it 'has the correct #name' do
-      expect(subject.name).to eq 'foo::Bar'
+      expect(exp.name).to eq 'foo::Bar'
     end
 
     it 'has the correct #simple_name' do
-      expect(subject.simple_name).to eq 'Bar'
+      expect(exp.simple_name).to eq 'Bar'
     end
   end
 end
@@ -463,12 +463,9 @@ end
 RSpec.describe Reek::AST::SexpExtensions::CasgnNode do
   describe '#defines_module?' do
     context 'with single assignment' do
-      subject do
-        sexp(:casgn, nil, :Foo)
-      end
-
       it 'does not define a module' do
-        expect(subject.defines_module?).to be_falsey
+        exp = sexp(:casgn, nil, :Foo)
+        expect(exp.defines_module?).to be_falsey
       end
     end
 

--- a/spec/reek/cli/application_spec.rb
+++ b/spec/reek/cli/application_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Reek::CLI::Application do
     it 'exits with default error code on invalid options' do
       call = lambda do
         Reek::CLI::Silencer.silently do
-          Reek::CLI::Application.new ['--foo']
+          described_class.new ['--foo']
         end
       end
       expect(call).to raise_error(SystemExit) do |error|
@@ -22,8 +22,8 @@ RSpec.describe Reek::CLI::Application do
   let(:configuration) { test_configuration_for(CONFIG_PATH.join('with_excluded_paths.reek')) }
 
   describe '#execute' do
-    let(:command) { double 'reek_command' }
-    let(:app) { Reek::CLI::Application.new [] }
+    let(:command) { instance_double 'Reek::CLI::Command::ReportCommand' }
+    let(:app) { described_class.new [] }
 
     before do
       allow(Reek::CLI::Command::ReportCommand).to receive(:new).and_return command
@@ -40,7 +40,7 @@ RSpec.describe Reek::CLI::Application do
           allow_any_instance_of(IO).to receive(:tty?).and_return(false)
         end
 
-        it 'should use source form pipe' do
+        it 'uses source form pipe' do
           app.execute
           expect(Reek::CLI::Command::ReportCommand).to have_received(:new).
             with(sources: [$stdin],
@@ -54,7 +54,7 @@ RSpec.describe Reek::CLI::Application do
           allow_any_instance_of(IO).to receive(:tty?).and_return(true)
         end
 
-        it 'should use working directory as source' do
+        it 'uses working directory as source' do
           expected_sources = Reek::Source::SourceLocator.new(['.']).sources
           app.execute
           expect(Reek::CLI::Command::ReportCommand).to have_received(:new).
@@ -64,7 +64,7 @@ RSpec.describe Reek::CLI::Application do
         end
 
         context 'when source files are excluded through configuration' do
-          let(:app) { Reek::CLI::Application.new ['--config', 'some_file.reek'] }
+          let(:app) { described_class.new ['--config', 'some_file.reek'] }
 
           before do
             allow(Reek::Configuration::AppConfiguration).
@@ -73,7 +73,7 @@ RSpec.describe Reek::CLI::Application do
               and_return configuration
           end
 
-          it 'should use configuration for excluded paths' do
+          it 'uses configuration for excluded paths' do
             expected_sources = Reek::Source::SourceLocator.
               new(['.'], configuration: configuration).sources
             expect(expected_sources).not_to include(path_excluded_in_configuration)
@@ -90,9 +90,9 @@ RSpec.describe Reek::CLI::Application do
     end
 
     context 'when source files given' do
-      let(:app) { Reek::CLI::Application.new ['.'] }
+      let(:app) { described_class.new ['.'] }
 
-      it 'should use sources from argv' do
+      it 'uses sources from argv' do
         expected_sources = Reek::Source::SourceLocator.new(['.']).sources
         app.execute
         expect(Reek::CLI::Command::ReportCommand).to have_received(:new).

--- a/spec/reek/cli/command/report_command_spec.rb
+++ b/spec/reek/cli/command/report_command_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Reek::CLI::Command::ReportCommand do
   describe '#execute' do
     let(:options) { Reek::CLI::Options.new [] }
 
-    let(:configuration) { double 'configuration' }
+    let(:configuration) { instance_double 'Reek::Configuration::AppConfiguration' }
     let(:sources) { [source_file] }
 
     let(:command) do

--- a/spec/reek/cli/command/todo_list_command_spec.rb
+++ b/spec/reek/cli/command/todo_list_command_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Reek::CLI::Command::TodoListCommand do
 
   describe '#execute' do
     let(:options) { Reek::CLI::Options.new [] }
-    let(:configuration) { double 'configuration' }
+    let(:configuration) { instance_double 'Reek::Configuration::AppConfiguration' }
 
     let(:command) do
       described_class.new(options: options,

--- a/spec/reek/cli/options_spec.rb
+++ b/spec/reek/cli/options_spec.rb
@@ -2,23 +2,25 @@ require_relative '../../spec_helper'
 require_lib 'reek/cli/options'
 
 RSpec.describe Reek::CLI::Options do
+  let(:options) { described_class.new }
+
   describe '#initialize' do
     it 'sets a valid default value for report_format' do
-      expect(subject.report_format).to eq :text
+      expect(options.report_format).to eq :text
     end
 
     it 'sets a valid default value for location_format' do
-      expect(subject.location_format).to eq :numbers
+      expect(options.location_format).to eq :numbers
     end
 
     it 'enables colors when stdout is a TTY' do
       allow($stdout).to receive_messages(tty?: false)
-      expect(subject.colored).to be false
+      expect(options.colored).to be false
     end
 
     it 'does not enable colors when stdout is not a TTY' do
       allow($stdout).to receive_messages(tty?: true)
-      expect(subject.colored).to be true
+      expect(options.colored).to be true
     end
   end
 
@@ -29,7 +31,7 @@ RSpec.describe Reek::CLI::Options do
     end
 
     it 'returns self' do
-      expect(subject.parse).to be_a(described_class)
+      expect(options.parse).to be_a(described_class)
     end
   end
 end

--- a/spec/reek/configuration/default_directive_spec.rb
+++ b/spec/reek/configuration/default_directive_spec.rb
@@ -3,11 +3,11 @@ require_lib 'reek/configuration/default_directive'
 
 RSpec.describe Reek::Configuration::DefaultDirective do
   describe '#add' do
-    subject { {}.extend(described_class) }
+    let(:directives) { {}.extend(described_class) }
 
     it 'adds a smell configuration' do
-      subject.add :UncommunicativeVariableName, enabled: false
-      expect(subject).to eq(Reek::Smells::UncommunicativeVariableName => { enabled: false })
+      directives.add :UncommunicativeVariableName, enabled: false
+      expect(directives).to eq(Reek::Smells::UncommunicativeVariableName => { enabled: false })
     end
   end
 end

--- a/spec/reek/configuration/directory_directives_spec.rb
+++ b/spec/reek/configuration/directory_directives_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
   describe '#directive_for' do
     let(:baz_config)  { { Reek::Smells::IrresponsibleModule => { enabled: false } } }
     let(:bang_config) { { Reek::Smells::Attribute => { enabled: true } } }
-    subject do
+    let(:directives) do
       {
         Pathname.new('foo/bar/baz')  => baz_config,
         Pathname.new('foo/bar/bang') => bang_config
@@ -15,19 +15,19 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
 
     context 'our source is in a directory for which we have a directive' do
       it 'returns the corresponding directive' do
-        expect(subject.directive_for(source_via)).to eq(bang_config)
+        expect(directives.directive_for(source_via)).to eq(bang_config)
       end
     end
 
     context 'our source is not in a directory for which we have a directive' do
       it 'returns nil' do
-        expect(subject.directive_for('does/not/exist')).to eq(nil)
+        expect(directives.directive_for('does/not/exist')).to eq(nil)
       end
     end
   end
 
   describe '#add' do
-    subject do
+    let(:directives) do
       {}.extend(described_class)
     end
 
@@ -36,14 +36,14 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
 
       it 'raises an error' do
         Reek::CLI::Silencer.silently do
-          expect { subject.add(file_as_path, {}) }.to raise_error(SystemExit)
+          expect { directives.add(file_as_path, {}) }.to raise_error(SystemExit)
         end
       end
     end
   end
 
   describe '#best_match_for' do
-    subject do
+    let(:directives) do
       {
         Pathname.new('foo/bar/baz')  => {},
         Pathname.new('foo/bar')      => {},
@@ -53,25 +53,25 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
 
     it 'returns the corresponding directory when source_base_dir is a leaf' do
       source_base_dir = 'foo/bar/baz/bang'
-      hit = subject.send :best_match_for, source_base_dir
+      hit = directives.send :best_match_for, source_base_dir
       expect(hit.to_s).to eq('foo/bar/baz')
     end
 
     it 'returns the corresponding directory when source_base_dir is in the middle of the tree' do
       source_base_dir = 'foo/bar'
-      hit = subject.send :best_match_for, source_base_dir
+      hit = directives.send :best_match_for, source_base_dir
       expect(hit.to_s).to eq('foo/bar')
     end
 
     it 'returns nil we are on top of the tree and all other directories are below' do
       source_base_dir = 'foo'
-      hit = subject.send :best_match_for, source_base_dir
+      hit = directives.send :best_match_for, source_base_dir
       expect(hit).to be_nil
     end
 
     it 'returns nil when source_base_dir is not part of any directory directive at all' do
       source_base_dir = 'non/existent'
-      hit = subject.send :best_match_for, source_base_dir
+      hit = directives.send :best_match_for, source_base_dir
       expect(hit).to be_nil
     end
   end

--- a/spec/reek/configuration/excluded_paths_spec.rb
+++ b/spec/reek/configuration/excluded_paths_spec.rb
@@ -3,7 +3,7 @@ require_lib 'reek/configuration/excluded_paths'
 
 RSpec.describe Reek::Configuration::ExcludedPaths do
   describe '#add' do
-    subject { [].extend(described_class) }
+    let(:exclusions) { [].extend(described_class) }
 
     context 'one of given paths is a file' do
       let(:file_as_path) { SAMPLES_PATH.join('inline.rb') }
@@ -11,7 +11,7 @@ RSpec.describe Reek::Configuration::ExcludedPaths do
 
       it 'raises an error if one of the given paths is a file' do
         Reek::CLI::Silencer.silently do
-          expect { subject.add(paths) }.to raise_error(SystemExit)
+          expect { exclusions.add(paths) }.to raise_error(SystemExit)
         end
       end
     end

--- a/spec/reek/context/code_context_spec.rb
+++ b/spec/reek/context/code_context_spec.rb
@@ -4,12 +4,12 @@ require_lib 'reek/context/module_context'
 
 RSpec.describe Reek::Context::CodeContext do
   context 'name recognition' do
-    let(:ctx)       { Reek::Context::CodeContext.new(nil, exp) }
+    let(:ctx)       { described_class.new(nil, exp) }
     let(:exp)       { double('exp') }
     let(:exp_name)  { 'random_name' }
     let(:full_name) { "::::::::::::::::::::#{exp_name}" }
 
-    before :each do
+    before do
       allow(exp).to receive(:name).and_return(exp_name)
       allow(exp).to receive(:full_name).and_return(full_name)
     end
@@ -43,11 +43,11 @@ RSpec.describe Reek::Context::CodeContext do
     end
 
     context 'when there is an outer' do
-      let(:ctx)        { Reek::Context::CodeContext.new(outer, exp) }
+      let(:ctx)        { described_class.new(outer, exp) }
       let(:outer_name) { 'another_random sting' }
-      let(:outer)      { Reek::Context::CodeContext.new(nil, double('exp1')) }
+      let(:outer)      { described_class.new(nil, double('exp1')) }
 
-      before :each do
+      before do
         ctx.register_with_parent outer
         allow(outer).to receive(:full_name).at_least(:once).and_return(outer_name)
       end
@@ -71,7 +71,7 @@ RSpec.describe Reek::Context::CodeContext do
       let(:ctx) do
         src = 'module Emptiness; end'
         ast = Reek::Source::SourceCode.from(src).syntax_tree
-        Reek::Context::CodeContext.new(nil, ast)
+        described_class.new(nil, ast)
       end
 
       it 'yields no calls' do
@@ -90,10 +90,8 @@ RSpec.describe Reek::Context::CodeContext do
         end
       end
 
-      context 'with no block' do
-        it 'returns an empty array of ifs' do
-          expect(ctx.each_node(:if, [])).to be_empty
-        end
+      it 'returns an empty array of ifs when no block is passed' do
+        expect(ctx.each_node(:if, [])).to be_empty
       end
     end
 
@@ -101,7 +99,7 @@ RSpec.describe Reek::Context::CodeContext do
       let(:ctx) do
         src = "module Loneliness; def calloo; puts('hello') end; end"
         ast = Reek::Source::SourceCode.from(src).syntax_tree
-        Reek::Context::CodeContext.new(nil, ast)
+        described_class.new(nil, ast)
       end
 
       it 'yields no ifs' do
@@ -129,10 +127,8 @@ RSpec.describe Reek::Context::CodeContext do
         ctx.each_node(:def, []) { |exp| expect(exp.children.first).to eq(:calloo) }
       end
 
-      context 'pruning the traversal' do
-        it 'ignores the call inside the method' do
-          expect(ctx.each_node(:send, [:def])).to be_empty
-        end
+      it 'ignores the call inside the method if the traversal is pruned' do
+        expect(ctx.each_node(:send, [:def])).to be_empty
       end
     end
 
@@ -153,7 +149,7 @@ RSpec.describe Reek::Context::CodeContext do
         end
       EOS
       ast = Reek::Source::SourceCode.from(src).syntax_tree
-      ctx = Reek::Context::CodeContext.new(nil, ast)
+      ctx = described_class.new(nil, ast)
       expect(ctx.each_node(:if, []).length).to eq(3)
     end
   end
@@ -170,10 +166,10 @@ RSpec.describe Reek::Context::CodeContext do
     end
     let(:expression) { Reek::Source::SourceCode.from(src).syntax_tree }
     let(:outer) { nil }
-    let(:context) { Reek::Context::CodeContext.new(outer, expression) }
+    let(:context) { described_class.new(outer, expression) }
     let(:sniffer) { double('sniffer') }
 
-    before :each do
+    before do
       context.register_with_parent(outer)
       allow(sniffer).to receive(:smell_type).and_return('DuplicateMethodCall')
     end
@@ -185,9 +181,9 @@ RSpec.describe Reek::Context::CodeContext do
     end
 
     context 'when there is an outer context' do
-      let(:outer) { Reek::Context::CodeContext.new(nil, double('exp1')) }
+      let(:outer) { described_class.new(nil, double('exp1')) }
 
-      before :each do
+      before do
         allow(outer).to receive(:config_for).with(sniffer).and_return(
           'max_calls' => 2)
       end
@@ -200,9 +196,9 @@ RSpec.describe Reek::Context::CodeContext do
   end
 
   describe '#register_with_parent' do
-    let(:context) { Reek::Context::CodeContext.new(nil, double('exp1')) }
-    let(:first_child) { Reek::Context::CodeContext.new(context, double('exp2')) }
-    let(:second_child) { Reek::Context::CodeContext.new(context, double('exp3')) }
+    let(:context) { described_class.new(nil, double('exp1')) }
+    let(:first_child) { described_class.new(context, double('exp2')) }
+    let(:second_child) { described_class.new(context, double('exp3')) }
 
     it "appends the element to the parent context's list of children" do
       first_child.register_with_parent context
@@ -213,9 +209,9 @@ RSpec.describe Reek::Context::CodeContext do
   end
 
   describe '#each' do
-    let(:context) { Reek::Context::CodeContext.new(nil, double('exp1')) }
-    let(:first_child) { Reek::Context::CodeContext.new(context, double('exp2')) }
-    let(:second_child) { Reek::Context::CodeContext.new(context, double('exp3')) }
+    let(:context) { described_class.new(nil, double('exp1')) }
+    let(:first_child) { described_class.new(context, double('exp2')) }
+    let(:second_child) { described_class.new(context, double('exp3')) }
 
     it 'yields each child' do
       first_child.register_with_parent context

--- a/spec/reek/context/ghost_context_spec.rb
+++ b/spec/reek/context/ghost_context_spec.rb
@@ -3,7 +3,7 @@ require_lib 'reek/context/code_context'
 require_lib 'reek/context/ghost_context'
 
 RSpec.describe Reek::Context::GhostContext do
-  let(:exp) { double('exp') }
+  let(:exp) { instance_double('Reek::AST::Node') }
   let(:parent) { Reek::Context::CodeContext.new(nil, exp) }
 
   describe '#register_with_parent' do

--- a/spec/reek/context/method_context_spec.rb
+++ b/spec/reek/context/method_context_spec.rb
@@ -2,22 +2,28 @@ require_relative '../../spec_helper'
 require_lib 'reek/context/method_context'
 
 RSpec.describe Reek::Context::MethodContext do
-  let(:method_context) { Reek::Context::MethodContext.new(nil, exp) }
+  let(:method_context) { described_class.new(nil, exp) }
 
   describe '#matches?' do
     let(:exp) { double('exp').as_null_object }
 
-    before :each do
-      expect(exp).to receive(:full_name).at_least(:once).and_return('mod')
+    before do
+      allow(exp).to receive(:full_name).at_least(:once).and_return('mod')
     end
 
-    it 'should recognise itself in a collection of names' do
+    it 'recognises itself in a collection of names' do
       expect(method_context.matches?(['banana', 'mod'])).to eq(true)
+    end
+
+    it 'does not recognise itself in a collection of names that does not include it' do
       expect(method_context.matches?(['banana'])).to eq(false)
     end
 
-    it 'should recognise itself in a collection of REs' do
+    it 'recognises itself in a collection of regular expressions' do
       expect(method_context.matches?([/banana/, /mod/])).to eq(true)
+    end
+
+    it 'does not recognise itself in a collection of regular expressions that do not match it' do
       expect(method_context.matches?([/banana/])).to eq(false)
     end
   end
@@ -54,8 +60,8 @@ RSpec.describe Reek::Context::MethodContext do
       end
 
       it 'returns both param-value pairs' do
-        expect(defaults[0]).to eq [:arga, sexp(:int, 123)]
-        expect(defaults[1]).to eq [:argb, sexp(:int, 456)]
+        expect(defaults).to eq [[:arga, sexp(:int, 123)],
+                                [:argb, sexp(:int, 456)]]
       end
 
       it 'returns nothing else' do

--- a/spec/reek/context/module_context_spec.rb
+++ b/spec/reek/context/module_context_spec.rb
@@ -3,7 +3,7 @@ require_lib 'reek/context/module_context'
 require_lib 'reek/context/root_context'
 
 RSpec.describe Reek::Context::ModuleContext do
-  it 'should report module name for smell in method' do
+  it 'reports module name for smell in method' do
     expect('
       module Fred
         def simple(x) x + 1; end
@@ -11,7 +11,7 @@ RSpec.describe Reek::Context::ModuleContext do
     ').to reek_of(:UncommunicativeParameterName, name: 'x')
   end
 
-  it 'should not report module with empty class' do
+  it 'does not report module with empty class' do
     expect('
       # module for test
       module Fred
@@ -19,7 +19,7 @@ RSpec.describe Reek::Context::ModuleContext do
         class Jim; end; end').not_to reek
   end
 
-  it 'should recognise global constant' do
+  it 'recognises global constant' do
     expect('
       # module for test
       module ::Global
@@ -28,7 +28,7 @@ RSpec.describe Reek::Context::ModuleContext do
   end
 
   describe '#track_visibility' do
-    let(:context) { Reek::Context::ModuleContext.new(nil, double('exp1')) }
+    let(:context) { described_class.new(nil, double('exp1')) }
     let(:first_child) { Reek::Context::MethodContext.new(context, double('exp2', type: :def, name: :foo)) }
     let(:second_child) { Reek::Context::MethodContext.new(context, double('exp3', type: :def)) }
 

--- a/spec/reek/context/root_context_spec.rb
+++ b/spec/reek/context/root_context_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reek::Context::RootContext do
   context 'full_name' do
     it 'reports full context' do
       ast = Reek::Source::SourceCode.from('foo = 1').syntax_tree
-      root = Reek::Context::RootContext.new(ast)
+      root = described_class.new(ast)
       expect(root.full_name).to eq('')
     end
   end

--- a/spec/reek/context_builder_spec.rb
+++ b/spec/reek/context_builder_spec.rb
@@ -2,46 +2,42 @@ require_relative '../spec_helper'
 require_lib 'reek/context_builder'
 
 RSpec.describe Reek::ContextBuilder do
-  describe '#initialize' do
-    describe 'the structure of the context_tree' do
-      let(:walker) do
-        code = 'class Car; def drive; end; end'
-        described_class.new(syntax_tree(code))
+  describe '#context_tree' do
+    let(:walker) do
+      code = 'class Car; def drive; end; end'
+      described_class.new(syntax_tree(code))
+    end
+    let(:context_tree) { walker.context_tree }
+    let(:module_context) { context_tree.children.first }
+    let(:method_context) { module_context.children.first }
+
+    it 'starts with a root node' do
+      expect(context_tree.type).to eq(:root)
+      expect(context_tree).to be_a(Reek::Context::RootContext)
+    end
+
+    it 'has one child' do
+      expect(context_tree.children.size).to eq(1)
+    end
+
+    describe 'the root node' do
+      it 'has one module_context' do
+        expect(module_context).to be_a(Reek::Context::ModuleContext)
       end
-      let(:context_tree) { walker.context_tree }
 
-      it 'starts with a root node' do
-        expect(context_tree.type).to eq(:root)
-        expect(context_tree).to be_a(Reek::Context::RootContext)
+      it 'holds a reference to the parent context' do
+        expect(module_context.parent).to eq(context_tree)
+      end
+    end
+
+    describe 'the module node' do
+      it 'has one method_context' do
+        expect(method_context).to be_a(Reek::Context::MethodContext)
+        expect(module_context.children.size).to eq(1)
       end
 
-      it 'has one child' do
-        expect(context_tree.children.size).to eq(1)
-      end
-
-      describe 'the root node' do
-        let(:module_context) { context_tree.children.first }
-
-        it 'has one module_context' do
-          expect(module_context).to be_a(Reek::Context::ModuleContext)
-        end
-
-        it 'holds a reference to the parent context' do
-          expect(module_context.parent).to eq(context_tree)
-        end
-
-        describe 'the module node' do
-          let(:method_context) { module_context.children.first }
-
-          it 'has one method_context' do
-            expect(method_context).to be_a(Reek::Context::MethodContext)
-            expect(module_context.children.size).to eq(1)
-          end
-
-          it 'holds a reference to the parent context' do
-            expect(method_context.parent).to eq(module_context)
-          end
-        end
+      it 'holds a reference to the parent context' do
+        expect(method_context.parent).to eq(module_context)
       end
     end
   end
@@ -368,7 +364,7 @@ RSpec.describe Reek::ContextBuilder do
       EOS
 
       syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
-      context_tree = Reek::ContextBuilder.new(syntax_tree).context_tree
+      context_tree = described_class.new(syntax_tree).context_tree
 
       class_node = context_tree.children.first
       start_method = class_node.children.first
@@ -390,7 +386,7 @@ RSpec.describe Reek::ContextBuilder do
       EOS
 
       syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
-      context_tree = Reek::ContextBuilder.new(syntax_tree).context_tree
+      context_tree = described_class.new(syntax_tree).context_tree
 
       class_context = context_tree.children.first
       method_context = class_context.children.first
@@ -410,7 +406,7 @@ RSpec.describe Reek::ContextBuilder do
       EOS
 
       syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
-      context_tree = Reek::ContextBuilder.new(syntax_tree).context_tree
+      context_tree = described_class.new(syntax_tree).context_tree
 
       class_context = context_tree.children.first
       foo_context = class_context.children.first
@@ -431,7 +427,7 @@ RSpec.describe Reek::ContextBuilder do
       EOS
 
       syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
-      context_tree = Reek::ContextBuilder.new(syntax_tree).context_tree
+      context_tree = described_class.new(syntax_tree).context_tree
 
       class_context = context_tree.children.first
       foo_context = class_context.children.first

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -110,40 +110,37 @@ RSpec.describe Reek::Examiner do
     context 'with an incomprehensible source that causes Reek to crash' do
       let(:source) { 'class C; def does_crash_reek; end; end' }
 
-      subject do
+      let(:examiner) do
         smell_repository = instance_double 'Reek::Smells::SmellRepository'
-        expect(smell_repository).to receive(:examine) do
+        allow(smell_repository).to receive(:examine) do
           raise ArgumentError, 'Looks like bad source'
         end
         class_double('Reek::Smells::SmellRepository').as_stubbed_const
         allow(Reek::Smells::SmellRepository).to receive(:eligible_smell_types)
-        expect(Reek::Smells::SmellRepository).to receive(:new) { smell_repository }
+        allow(Reek::Smells::SmellRepository).to receive(:new).and_return smell_repository
 
-        examiner = described_class.new source
-        examiner
+        described_class.new source
       end
 
-      it 'has no warnings' do
+      it 'returns no smell warnings' do
         Reek::CLI::Silencer.silently do
-          expect(subject.smells).to be_empty
+          expect(examiner.smells).to be_empty
         end
       end
 
-      describe 'message on STDERR' do
-        it 'contains the origin' do
-          origin = 'string'
-          expect { subject.smells }.to output(/#{origin}/).to_stderr
-        end
+      it 'outputs the origin to STDERR' do
+        origin = 'string'
+        expect { examiner.smells }.to output(/#{origin}/).to_stderr
+      end
 
-        it 'explains what to do' do
-          explanation = 'It would be great if you could report this back to the Reek team'
-          expect { subject.smells }.to output(/#{explanation}/).to_stderr
-        end
+      it 'explains what to do to STDERR' do
+        explanation = 'It would be great if you could report this back to the Reek team'
+        expect { examiner.smells }.to output(/#{explanation}/).to_stderr
+      end
 
-        it 'contains the original exception' do
-          original = '#<ArgumentError: Looks like bad source>'
-          expect { subject.smells }.to output(/#{original}/).to_stderr
-        end
+      it 'outputs the original exception to STDERR' do
+        original = '#<ArgumentError: Looks like bad source>'
+        expect { examiner.smells }.to output(/#{original}/).to_stderr
       end
     end
   end

--- a/spec/reek/rake/task_spec.rb
+++ b/spec/reek/rake/task_spec.rb
@@ -4,14 +4,14 @@ require_lib 'reek/rake/task'
 RSpec.describe Reek::Rake::Task do
   describe '#source_files' do
     it 'is set to "lib/**/*.rb" by default' do
-      task = Reek::Rake::Task.new
+      task = described_class.new
       expect(task.source_files).to eq FileList['lib/**/*.rb']
     end
   end
 
   describe '#source_files=' do
     it 'sets source_files to a FileList when passed a string' do
-      task = Reek::Rake::Task.new
+      task = described_class.new
       task.source_files = '*.rb'
       expect(task.source_files).to eq FileList['*.rb']
     end
@@ -19,7 +19,7 @@ RSpec.describe Reek::Rake::Task do
 
   # SMELL: Testing a private method
   describe '#command' do
-    let(:task) { Reek::Rake::Task.new }
+    let(:task) { described_class.new }
 
     it 'does not include a config file by default' do
       expect(task.send(:command)).not_to include '-c'

--- a/spec/reek/report/code_climate_formatter_spec.rb
+++ b/spec/reek/report/code_climate_formatter_spec.rb
@@ -1,45 +1,47 @@
 require_relative '../../spec_helper'
 require_lib 'reek/report/code_climate/code_climate_formatter'
 
-RSpec.describe Reek::Report::CodeClimateFormatter, '#render' do
-  let(:warning) do
-    FactoryGirl.build(:smell_warning,
-                      smell_detector: Reek::Smells::UtilityFunction.new,
-                      context:        'context foo',
-                      message:        'message bar',
-                      lines:          [1, 2],
-                      source:         'a/ruby/source/file.rb')
-  end
-  let(:rendered) { Reek::Report::CodeClimateFormatter.new(warning).render }
-  let(:json) { JSON.parse rendered.chop }
+RSpec.describe Reek::Report::CodeClimateFormatter do
+  describe '#render' do
+    let(:warning) do
+      FactoryGirl.build(:smell_warning,
+                        smell_detector: Reek::Smells::UtilityFunction.new,
+                        context:        'context foo',
+                        message:        'message bar',
+                        lines:          [1, 2],
+                        source:         'a/ruby/source/file.rb')
+    end
+    let(:rendered) { described_class.new(warning).render }
+    let(:json) { JSON.parse rendered.chop }
 
-  it "sets the type as 'issue'" do
-    expect(json['type']).to eq 'issue'
-  end
+    it "sets the type as 'issue'" do
+      expect(json['type']).to eq 'issue'
+    end
 
-  it 'sets the category' do
-    expect(json['categories']).to eq ['Complexity']
-  end
+    it 'sets the category' do
+      expect(json['categories']).to eq ['Complexity']
+    end
 
-  it 'constructs a description based on the context and message' do
-    expect(json['description']).to eq 'context foo message bar'
-  end
+    it 'constructs a description based on the context and message' do
+      expect(json['description']).to eq 'context foo message bar'
+    end
 
-  it 'sets a check name based on the smell detector' do
-    expect(json['check_name']).to eq 'UtilityFunction'
-  end
+    it 'sets a check name based on the smell detector' do
+      expect(json['check_name']).to eq 'UtilityFunction'
+    end
 
-  it 'sets the location' do
-    expect(json['location']).to eq('path' => 'a/ruby/source/file.rb',
-                                   'lines' => { 'begin' => 1, 'end' => 2 })
-  end
+    it 'sets the location' do
+      expect(json['location']).to eq('path' => 'a/ruby/source/file.rb',
+                                     'lines' => { 'begin' => 1, 'end' => 2 })
+    end
 
-  it 'sets a content based on the smell detector' do
-    expect(json['content']['body']).
-      to eq "A _Utility Function_ is any instance method that has no dependency on the state of the instance.\n"
-  end
+    it 'sets a content based on the smell detector' do
+      expect(json['content']['body']).
+        to eq "A _Utility Function_ is any instance method that has no dependency on the state of the instance.\n"
+    end
 
-  it 'sets remediation points based on the smell detector' do
-    expect(json['remediation_points']).to eq 250_000
+    it 'sets remediation points based on the smell detector' do
+      expect(json['remediation_points']).to eq 250_000
+    end
   end
 end

--- a/spec/reek/report/code_climate_report_spec.rb
+++ b/spec/reek/report/code_climate_report_spec.rb
@@ -8,7 +8,7 @@ require 'stringio'
 
 RSpec.describe Reek::Report::CodeClimateReport do
   let(:options) { {} }
-  let(:instance) { Reek::Report::CodeClimateReport.new(options) }
+  let(:instance) { described_class.new(options) }
   let(:examiner) { Reek::Examiner.new(source) }
 
   before do

--- a/spec/reek/report/html_report_spec.rb
+++ b/spec/reek/report/html_report_spec.rb
@@ -3,7 +3,7 @@ require_lib 'reek/examiner'
 require_lib 'reek/report/report'
 
 RSpec.describe Reek::Report::HTMLReport do
-  let(:instance) { Reek::Report::HTMLReport.new }
+  let(:instance) { described_class.new }
 
   context 'with an empty source' do
     let(:examiner) { Reek::Examiner.new('') }

--- a/spec/reek/report/json_report_spec.rb
+++ b/spec/reek/report/json_report_spec.rb
@@ -8,7 +8,7 @@ require 'stringio'
 
 RSpec.describe Reek::Report::JSONReport do
   let(:options) { {} }
-  let(:instance) { Reek::Report::JSONReport.new(options) }
+  let(:instance) { described_class.new(options) }
   let(:examiner) { Reek::Examiner.new(source) }
 
   before do

--- a/spec/reek/report/location_formatter_spec.rb
+++ b/spec/reek/report/location_formatter_spec.rb
@@ -1,30 +1,32 @@
 require_relative '../../spec_helper'
 require_lib 'reek/report/formatter'
 
-RSpec.describe 'location formatters' do
+RSpec.describe Reek::Report::BlankLocationFormatter do
   let(:warning) { build(:smell_warning, lines: [11, 9, 250, 100]) }
 
-  describe Reek::Report::BlankLocationFormatter do
-    describe '.format' do
-      it 'returns a blank String regardless of the warning' do
-        expect(described_class.format(warning)).to eq('')
-      end
+  describe '.format' do
+    it 'returns a blank String regardless of the warning' do
+      expect(described_class.format(warning)).to eq('')
     end
   end
+end
 
-  describe Reek::Report::DefaultLocationFormatter do
-    describe '.format' do
-      it 'returns a prefix with sorted line numbers' do
-        expect(described_class.format(warning)).to eq('[9, 11, 100, 250]:')
-      end
+RSpec.describe Reek::Report::DefaultLocationFormatter do
+  let(:warning) { build(:smell_warning, lines: [11, 9, 250, 100]) }
+
+  describe '.format' do
+    it 'returns a prefix with sorted line numbers' do
+      expect(described_class.format(warning)).to eq('[9, 11, 100, 250]:')
     end
   end
+end
 
-  describe Reek::Report::SingleLineLocationFormatter do
-    describe '.format' do
-      it 'returns the first line where the smell was found' do
-        expect(described_class.format(warning)).to eq('dummy_file:9: ')
-      end
+RSpec.describe Reek::Report::SingleLineLocationFormatter do
+  let(:warning) { build(:smell_warning, lines: [11, 9, 250, 100]) }
+
+  describe '.format' do
+    it 'returns the first line where the smell was found' do
+      expect(described_class.format(warning)).to eq('dummy_file:9: ')
     end
   end
 end

--- a/spec/reek/report/text_report_spec.rb
+++ b/spec/reek/report/text_report_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Reek::Report::TextReport do
       heading_formatter: Reek::Report::HeadingFormatter::Quiet
     }
   end
-  let(:instance) { Reek::Report::TextReport.new report_options }
+  let(:instance) { described_class.new report_options }
 
   context 'with a single empty source' do
     before do
@@ -21,7 +21,7 @@ RSpec.describe Reek::Report::TextReport do
     end
 
     it 'has an empty quiet_report' do
-      expect { instance.show }.to_not output.to_stdout
+      expect { instance.show }.not_to output.to_stdout
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe Reek::Report::TextReport do
     end
 
     context 'with colors disabled' do
-      before :each do
+      before do
         Rainbow.enabled = false
       end
 
@@ -42,7 +42,7 @@ RSpec.describe Reek::Report::TextReport do
     end
 
     context 'with colors enabled' do
-      before :each do
+      before do
         Rainbow.enabled = true
       end
 
@@ -67,9 +67,13 @@ RSpec.describe Reek::Report::TextReport do
         expect { instance.show }.to output(/string -- 2 warnings/).to_stdout
       end
 
-      it 'should mention every smell name' do
-        expect { instance.show }.to output(/UncommunicativeParameterName/).to_stdout
-        expect { instance.show }.to output(/UtilityFunction/).to_stdout
+      it 'mentions every smell name' do
+        matcher = match(/UncommunicativeParameterName/).and match(/UtilityFunction/)
+        expect { instance.show }.to output(matcher).to_stdout
+      end
+
+      it 'shows total number of warnings' do
+        expect { instance.show }.to output(/4 total warnings\n\Z/).to_stdout
       end
     end
 
@@ -83,7 +87,7 @@ RSpec.describe Reek::Report::TextReport do
           to output(/\A\e\[36mstring -- \e\[0m\e\[33m2 warning\e\[0m\e\[33ms\e\[0m/).to_stdout
       end
 
-      it 'has a footer in color' do
+      it 'shows total number of warnings in color' do
         expect { instance.show }.
           to output(/\e\[31m4 total warnings\n\e\[0m\Z/).to_stdout
       end

--- a/spec/reek/report/xml_report_spec.rb
+++ b/spec/reek/report/xml_report_spec.rb
@@ -3,7 +3,7 @@ require_lib 'reek/examiner'
 require_lib 'reek/report/report'
 
 RSpec.describe Reek::Report::XMLReport do
-  let(:xml_report) { Reek::Report::XMLReport.new }
+  let(:xml_report) { described_class.new }
 
   context 'empty source' do
     it 'prints empty checkstyle XML' do

--- a/spec/reek/report/yaml_report_spec.rb
+++ b/spec/reek/report/yaml_report_spec.rb
@@ -8,7 +8,7 @@ require 'stringio'
 
 RSpec.describe Reek::Report::YAMLReport do
   let(:options) { {} }
-  let(:instance) { Reek::Report::YAMLReport.new(options) }
+  let(:instance) { described_class.new(options) }
   let(:examiner) { Reek::Examiner.new(source) }
 
   before do

--- a/spec/reek/report_spec.rb
+++ b/spec/reek/report_spec.rb
@@ -4,25 +4,25 @@ require_lib 'reek/report'
 RSpec.describe Reek::Report do
   describe '.report_class' do
     it 'returns the correct class' do
-      expect(Reek::Report.report_class(:text)).to eq Reek::Report::TextReport
+      expect(described_class.report_class(:text)).to eq Reek::Report::TextReport
     end
   end
 
   describe '.location_formatter' do
     it 'returns the correct class' do
-      expect(Reek::Report.location_formatter(:plain)).to eq Reek::Report::BlankLocationFormatter
+      expect(described_class.location_formatter(:plain)).to eq Reek::Report::BlankLocationFormatter
     end
   end
 
   describe '.heading_formatter' do
     it 'returns the correct class' do
-      expect(Reek::Report.heading_formatter(:quiet)).to eq Reek::Report::HeadingFormatter::Quiet
+      expect(described_class.heading_formatter(:quiet)).to eq Reek::Report::HeadingFormatter::Quiet
     end
   end
 
   describe '.warning_formatter_class' do
     it 'returns the correct class' do
-      expect(Reek::Report.warning_formatter_class(:simple)).to eq Reek::Report::SimpleWarningFormatter
+      expect(described_class.warning_formatter_class(:simple)).to eq Reek::Report::SimpleWarningFormatter
     end
   end
 end

--- a/spec/reek/smells/attribute_spec.rb
+++ b/spec/reek/smells/attribute_spec.rb
@@ -23,12 +23,9 @@ RSpec.describe Reek::Smells::Attribute do
       end
     EOS
 
-    expect(src).to reek_of(:Attribute,
-                           lines:   [2],
-                           context: 'Alfa#bravo')
-    expect(src).to reek_of(:Attribute,
-                           lines:   [3],
-                           context: 'Alfa#charlie')
+    expect(src).
+      to reek_of(:Attribute, lines: [2], context: 'Alfa#bravo').
+      and reek_of(:Attribute, lines: [3], context: 'Alfa#charlie')
   end
 
   it 'records nothing with no attributes' do
@@ -37,7 +34,7 @@ RSpec.describe Reek::Smells::Attribute do
       end
     EOS
 
-    expect(src).to_not reek_of(:Attribute)
+    expect(src).not_to reek_of(:Attribute)
   end
 
   context 'with attributes' do
@@ -49,7 +46,7 @@ RSpec.describe Reek::Smells::Attribute do
         end
       EOS
 
-      expect(src).to_not reek_of(:Attribute)
+      expect(src).not_to reek_of(:Attribute)
     end
 
     it 'records writer attribute' do
@@ -115,7 +112,7 @@ RSpec.describe Reek::Smells::Attribute do
         end
       EOS
 
-      expect(src).to_not reek_of(:Attribute)
+      expect(src).not_to reek_of(:Attribute)
     end
 
     it "doesn't record private attributes" do
@@ -130,7 +127,7 @@ RSpec.describe Reek::Smells::Attribute do
         end
       EOS
 
-      expect(src).to_not reek_of(:Attribute)
+      expect(src).not_to reek_of(:Attribute)
     end
 
     it 'records attr_writer defined in public section' do

--- a/spec/reek/smells/boolean_parameter_spec.rb
+++ b/spec/reek/smells/boolean_parameter_spec.rb
@@ -22,14 +22,9 @@ RSpec.describe Reek::Smells::BooleanParameter do
       end
     EOS
 
-    expect(src).to reek_of(:BooleanParameter,
-                           lines:   [1],
-                           context: 'alfa',
-                           parameter: 'bravo')
-    expect(src).to reek_of(:BooleanParameter,
-                           lines:   [1],
-                           context: 'alfa',
-                           parameter: 'charlie')
+    expect(src).
+      to reek_of(:BooleanParameter, lines: [1], context: 'alfa', parameter: 'bravo').
+      and reek_of(:BooleanParameter, lines: [1], context: 'alfa', parameter: 'charlie')
   end
 
   context 'in a method' do
@@ -41,17 +36,17 @@ RSpec.describe Reek::Smells::BooleanParameter do
     it 'reports two parameters defaulted to booleans in a mixed parameter list' do
       src = 'def alfa(bravo, charlie = true, delta = false, &echo) end'
 
-      expect(src).to reek_of(:BooleanParameter, parameter: 'charlie')
-      expect(src).to reek_of(:BooleanParameter, parameter: 'delta')
-
-      expect(src).not_to reek_of(:BooleanParameter, parameter: 'bravo')
-      expect(src).not_to reek_of(:BooleanParameter, parameter: 'echo')
+      expect(src).to reek_of(:BooleanParameter, parameter: 'charlie').
+        and reek_of(:BooleanParameter, parameter: 'delta').
+        and not_reek_of(:BooleanParameter, parameter: 'bravo').
+        and not_reek_of(:BooleanParameter, parameter: 'echo')
     end
 
     it 'reports keyword parameters defaulted to booleans' do
       src = 'def alfa(bravo: true, charlie: false) end'
-      expect(src).to reek_of(:BooleanParameter, parameter: 'bravo')
-      expect(src).to reek_of(:BooleanParameter, parameter: 'charlie')
+      expect(src).
+        to reek_of(:BooleanParameter, parameter: 'bravo').
+        and reek_of(:BooleanParameter, parameter: 'charlie')
     end
 
     it 'does not report regular parameters' do
@@ -89,11 +84,10 @@ RSpec.describe Reek::Smells::BooleanParameter do
     it 'reports two parameters defaulted to booleans' do
       src = 'def self.alfa(bravo, charlie = true, delta = false, &echo) end'
 
-      expect(src).to reek_of(:BooleanParameter, parameter: 'charlie')
-      expect(src).to reek_of(:BooleanParameter, parameter: 'delta')
-
-      expect(src).not_to reek_of(:BooleanParameter, parameter: 'bravo')
-      expect(src).not_to reek_of(:BooleanParameter, parameter: 'echo')
+      expect(src).to reek_of(:BooleanParameter, parameter: 'charlie').
+        and reek_of(:BooleanParameter, parameter: 'delta').
+        and not_reek_of(:BooleanParameter, parameter: 'bravo').
+        and not_reek_of(:BooleanParameter, parameter: 'echo')
     end
   end
 end

--- a/spec/reek/smells/class_variable_spec.rb
+++ b/spec/reek/smells/class_variable_spec.rb
@@ -25,8 +25,9 @@ RSpec.describe Reek::Smells::ClassVariable do
       end
     EOS
 
-    expect(src).to reek_of(:ClassVariable, name: '@@bravo')
-    expect(src).to reek_of(:ClassVariable, name: '@@charlie')
+    expect(src).
+      to reek_of(:ClassVariable, name: '@@bravo').
+      and reek_of(:ClassVariable, name: '@@charlie')
   end
 
   it 'does not report class instance variables' do
@@ -36,7 +37,7 @@ RSpec.describe Reek::Smells::ClassVariable do
       end
     EOS
 
-    expect(src).to_not reek_of(:ClassVariable)
+    expect(src).not_to reek_of(:ClassVariable)
   end
 
   context 'with no class variables' do
@@ -47,7 +48,7 @@ RSpec.describe Reek::Smells::ClassVariable do
         end
       EOS
 
-      expect(src).to_not reek_of(:ClassVariable)
+      expect(src).not_to reek_of(:ClassVariable)
     end
 
     it 'records nothing in the module' do
@@ -57,7 +58,7 @@ RSpec.describe Reek::Smells::ClassVariable do
         end
       EOS
 
-      expect(src).to_not reek_of(:ClassVariable)
+      expect(src).not_to reek_of(:ClassVariable)
     end
   end
 

--- a/spec/reek/smells/control_parameter_spec.rb
+++ b/spec/reek/smells/control_parameter_spec.rb
@@ -25,8 +25,9 @@ RSpec.describe Reek::Smells::ControlParameter do
       end
     EOS
 
-    expect(src).to reek_of(:ControlParameter, lines: [2], argument: 'bravo')
-    expect(src).to reek_of(:ControlParameter, lines: [3], argument: 'charlie')
+    expect(src).
+      to reek_of(:ControlParameter, lines: [2], argument: 'bravo').
+      and reek_of(:ControlParameter, lines: [3], argument: 'charlie')
   end
 
   context 'parameter not used to determine code path' do

--- a/spec/reek/smells/data_clump_spec.rb
+++ b/spec/reek/smells/data_clump_spec.rb
@@ -33,12 +33,9 @@ RSpec.describe Reek::Smells::DataClump do
       end
     EOS
 
-    expect(src).to reek_of(:DataClump,
-                           lines:      [2, 3, 4],
-                           parameters: ['echo', 'foxtrot'])
-    expect(src).to reek_of(:DataClump,
-                           lines:      [6, 7, 8],
-                           parameters: ['juliett', 'kilo'])
+    expect(src).
+      to reek_of(:DataClump, lines: [2, 3, 4], parameters: ['echo', 'foxtrot']).
+      and reek_of(:DataClump, lines: [6, 7, 8], parameters: ['juliett', 'kilo'])
   end
 
   %w(class module).each do |scope|

--- a/spec/reek/smells/duplicate_method_call_spec.rb
+++ b/spec/reek/smells/duplicate_method_call_spec.rb
@@ -36,14 +36,9 @@ RSpec.describe Reek::Smells::DuplicateMethodCall do
       end
     EOS
 
-    expect(src).to reek_of(:DuplicateMethodCall,
-                           lines: [3, 4],
-                           name:  'charlie.delta',
-                           count: 2)
-    expect(src).to reek_of(:DuplicateMethodCall,
-                           lines: [8, 9],
-                           name:  'foxtrot.golf',
-                           count: 2)
+    expect(src).
+      to reek_of(:DuplicateMethodCall, lines: [3, 4], name:  'charlie.delta', count: 2).
+      and reek_of(:DuplicateMethodCall, lines: [8, 9], name:  'foxtrot.golf', count: 2)
   end
 
   context 'with repeated method calls' do
@@ -57,13 +52,14 @@ RSpec.describe Reek::Smells::DuplicateMethodCall do
       expect(src).to reek_of(:DuplicateMethodCall, name: '@bravo.charlie(2, 3)')
     end
 
-    it 'should report nested calls' do
+    it 'reports nested calls' do
       src = 'def alfa; @bravo.charlie.delta + @bravo.charlie.delta; end'
-      expect(src).to reek_of(:DuplicateMethodCall, name: '@bravo.charlie')
-      expect(src).to reek_of(:DuplicateMethodCall, name: '@bravo.charlie.delta')
+      expect(src).
+        to reek_of(:DuplicateMethodCall, name: '@bravo.charlie').
+        and reek_of(:DuplicateMethodCall, name: '@bravo.charlie.delta')
     end
 
-    it 'should ignore calls to new' do
+    it 'ignores calls to new' do
       src = 'def alfa; @bravo.new + @bravo.new; end'
       expect(src).not_to reek_of(:DuplicateMethodCall)
     end
@@ -155,12 +151,12 @@ RSpec.describe Reek::Smells::DuplicateMethodCall do
   end
 
   context 'non-repeated method calls' do
-    it 'should not report similar calls' do
+    it 'does not report similar calls' do
       src = 'def alfa(bravo) bravo.charlie == self.charlie end'
       expect(src).not_to reek_of(:DuplicateMethodCall)
     end
 
-    it 'should respect call parameters' do
+    it 'respects call parameters' do
       src = 'def alfa; @bravo.charlie(3) + @bravo.charlie(2) end'
       expect(src).not_to reek_of(:DuplicateMethodCall)
     end

--- a/spec/reek/smells/feature_envy_spec.rb
+++ b/spec/reek/smells/feature_envy_spec.rb
@@ -32,62 +32,69 @@ RSpec.describe Reek::Smells::FeatureEnvy do
       end
     EOS
 
-    expect(src).to reek_of(:FeatureEnvy,
-                           lines: [3, 3],
-                           name:  'charlie')
-    expect(src).to reek_of(:FeatureEnvy,
-                           lines: [7, 7],
-                           name:  'hotel')
+    expect(src).
+      to reek_of(:FeatureEnvy, lines: [3, 3], name:  'charlie').
+      and reek_of(:FeatureEnvy, lines: [7, 7], name:  'hotel')
   end
 
   it 'does not report use of self' do
-    expect('def alfa; self.to_s + self.to_i; end').not_to reek_of(:FeatureEnvy)
+    src = 'def alfa; self.to_s + self.to_i; end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'does not report vcall with no argument' do
-    expect('def alfa; bravo; end').not_to reek_of(:FeatureEnvy)
+    src = 'def alfa; bravo; end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'does not report single use' do
-    expect('def alfa(bravo); bravo.charlie(@delta); end').not_to reek_of(:FeatureEnvy)
+    src = 'def alfa(bravo); bravo.charlie(@delta); end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'does not report return value' do
-    expect('def alfa(bravo); bravo.charlie(@delta); bravo; end').not_to reek_of(:FeatureEnvy)
+    src = 'def alfa(bravo); bravo.charlie(@delta); bravo; end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'does ignore global variables' do
-    expect('def alfa; $bravo.to_a; $bravo[@charlie]; end').not_to reek_of(:FeatureEnvy)
+    src = 'def alfa; $bravo.to_a; $bravo[@charlie]; end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'does not report class methods' do
-    expect('def alfa; self.class.bravo(self); end').not_to reek_of(:FeatureEnvy)
+    src = 'def alfa; self.class.bravo(self); end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'does not report single use of an ivar' do
-    expect('def alfa; @bravo.to_a; end').not_to reek_of(:FeatureEnvy)
+    src = 'def alfa; @bravo.to_a; end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'does not report returning an ivar' do
-    expect('def alfa; @bravo.to_a; @bravo; end').not_to reek_of(:FeatureEnvy)
+    src = 'def alfa; @bravo.to_a; @bravo; end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'does not report ivar usage in a parameter' do
-    expect('def alfa; @bravo.charlie + delta(@bravo) - echo(@bravo) end').
-      not_to reek_of(:FeatureEnvy)
+    src = 'def alfa; @bravo.charlie + delta(@bravo) - echo(@bravo) end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'does not report single use of an lvar' do
-    expect('def alfa; bravo = @charlie; bravo.to_a; end').not_to reek_of(:FeatureEnvy)
+    src = 'def alfa; bravo = @charlie; bravo.to_a; end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'does not report returning an lvar' do
-    expect('def alfa; bravo = @charlie; bravo.to_a; lv end').not_to reek_of(:FeatureEnvy)
+    src = 'def alfa; bravo = @charlie; bravo.to_a; lv end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'ignores lvar usage in a parameter' do
-    expect('def alfa; bravo = @item; bravo.charlie + delta(bravo) - echo(bravo); end').
-      not_to reek_of(:FeatureEnvy)
+    src = 'def alfa; bravo = @item; bravo.charlie + delta(bravo) - echo(bravo); end'
+    expect(src).not_to reek_of(:FeatureEnvy)
   end
 
   it 'ignores multiple ivars' do
@@ -115,11 +122,12 @@ RSpec.describe Reek::Smells::FeatureEnvy do
       end
       EOS
 
-    expect(src).to reek_of(:FeatureEnvy, name: 'delta')
-    expect(src).not_to reek_of(:FeatureEnvy, name: 'bravo')
+    expect(src).
+      to reek_of(:FeatureEnvy, name: 'delta').
+      and not_reek_of(:FeatureEnvy, name: 'bravo')
   end
 
-  it 'should report multiple affinities' do
+  it 'reports multiple affinities' do
     src = <<-EOS
       def alfa
         bravo = @charlie
@@ -129,8 +137,9 @@ RSpec.describe Reek::Smells::FeatureEnvy do
       end
       EOS
 
-    expect(src).to reek_of(:FeatureEnvy, name: 'delta')
-    expect(src).to reek_of(:FeatureEnvy, name: 'bravo')
+    expect(src).
+      to reek_of(:FeatureEnvy, name: 'delta').
+      and reek_of(:FeatureEnvy, name: 'bravo')
   end
 
   it 'is not be fooled by duplication' do

--- a/spec/reek/smells/instance_variable_assumption_spec.rb
+++ b/spec/reek/smells/instance_variable_assumption_spec.rb
@@ -34,15 +34,12 @@ RSpec.describe Reek::Smells::InstanceVariableAssumption do
 
     EOS
 
-    expect(src).to reek_of(:InstanceVariableAssumption,
-                           lines: [1],
-                           assumption: '@charlie')
-    expect(src).to reek_of(:InstanceVariableAssumption,
-                           lines: [1],
-                           assumption: '@echo')
+    expect(src).
+      to reek_of(:InstanceVariableAssumption, lines: [1], assumption: '@charlie').
+      and reek_of(:InstanceVariableAssumption, lines: [1], assumption: '@echo')
   end
 
-  it 'should not report an empty class' do
+  it 'does not report an empty class' do
     src = <<-EOS
       class Alfa
       end

--- a/spec/reek/smells/irresponsible_module_spec.rb
+++ b/spec/reek/smells/irresponsible_module_spec.rb
@@ -25,12 +25,9 @@ RSpec.describe Reek::Smells::IrresponsibleModule do
       end
     EOS
 
-    expect(src).to reek_of(:IrresponsibleModule,
-                           lines:   [1],
-                           context: 'Alfa')
-    expect(src).to reek_of(:IrresponsibleModule,
-                           lines:   [4],
-                           context: 'Alfa::Charlie')
+    expect(src).
+      to reek_of(:IrresponsibleModule, lines: [1], context: 'Alfa').
+      and reek_of(:IrresponsibleModule, lines: [4], context: 'Alfa::Charlie')
   end
 
   %w(class module).each do |scope|

--- a/spec/reek/smells/long_parameter_list_spec.rb
+++ b/spec/reek/smells/long_parameter_list_spec.rb
@@ -29,16 +29,14 @@ RSpec.describe Reek::Smells::LongParameterList do
       end
     EOS
 
-    expect(src).to reek_of(:LongParameterList,
-                           lines:   [2],
-                           context: 'Alfa#bravo')
-    expect(src).to reek_of(:LongParameterList,
-                           lines:   [5],
-                           context: 'Alfa#golf')
+    expect(src).
+      to reek_of(:LongParameterList, lines: [2], context: 'Alfa#bravo').
+      and reek_of(:LongParameterList, lines: [5], context: 'Alfa#golf')
   end
 
   it 'reports nothing for 3 parameters' do
-    expect('def alfa(bravo, charlie, delta); end').not_to reek_of(:LongParameterList)
+    src = 'def alfa(bravo, charlie, delta); end'
+    expect(src).not_to reek_of(:LongParameterList)
   end
 
   it 'does not count an optional block' do

--- a/spec/reek/smells/long_yield_list_spec.rb
+++ b/spec/reek/smells/long_yield_list_spec.rb
@@ -32,12 +32,9 @@ RSpec.describe Reek::Smells::LongYieldList do
       end
     EOS
 
-    expect(src).to reek_of(:LongYieldList,
-                           lines:   [3],
-                           context: 'Alfa#bravo')
-    expect(src).to reek_of(:LongYieldList,
-                           lines:   [7],
-                           context: 'Alfa#golf')
+    expect(src).
+      to reek_of(:LongYieldList, lines: [3], context: 'Alfa#bravo').
+      and reek_of(:LongYieldList, lines: [7], context: 'Alfa#golf')
   end
 
   it 'does not report yield with 3 parameters' do

--- a/spec/reek/smells/manual_dispatch_spec.rb
+++ b/spec/reek/smells/manual_dispatch_spec.rb
@@ -31,12 +31,9 @@ RSpec.describe Reek::Smells::ManualDispatch do
       end
     EOS
 
-    expect(src).to reek_of(:ManualDispatch,
-                           lines:   [3],
-                           context: 'Alfa#bravo')
-    expect(src).to reek_of(:ManualDispatch,
-                           lines:   [7],
-                           context: 'Alfa#delta')
+    expect(src).
+      to reek_of(:ManualDispatch, lines: [3], context: 'Alfa#bravo').
+      and reek_of(:ManualDispatch, lines: [7], context: 'Alfa#delta')
   end
 
   it 'reports manual dispatch smell when using #respond_to? on implicit self' do

--- a/spec/reek/smells/nested_iterators_spec.rb
+++ b/spec/reek/smells/nested_iterators_spec.rb
@@ -34,8 +34,9 @@ RSpec.describe Reek::Smells::NestedIterators do
       end
     EOS
 
-    expect(src).to reek_of(:NestedIterators, lines: [3], depth: 2)
-    expect(src).to reek_of(:NestedIterators, lines: [8], depth: 3)
+    expect(src).
+      to reek_of(:NestedIterators, lines: [3], depth: 2).
+      and reek_of(:NestedIterators, lines: [8], depth: 3)
   end
 
   it 'reports no smells with no iterators' do
@@ -53,7 +54,7 @@ RSpec.describe Reek::Smells::NestedIterators do
     expect(src).not_to reek_of(:NestedIterators)
   end
 
-  it 'should not report nested iterators for Object#tap' do
+  it 'does not report nested iterators for Object#tap' do
     src = <<-EOS
       def alfa(bravo)
         bravo.tap do |charlie|
@@ -65,7 +66,7 @@ RSpec.describe Reek::Smells::NestedIterators do
     expect(src).not_to reek_of(:NestedIterators)
   end
 
-  it 'should not report method with successive iterators' do
+  it 'does not report method with successive iterators' do
     src = <<-EOS
       def alfa
         @bravo.each   { |charlie| charlie }
@@ -76,7 +77,7 @@ RSpec.describe Reek::Smells::NestedIterators do
     expect(src).not_to reek_of(:NestedIterators)
   end
 
-  it 'should not report method with chained iterators' do
+  it 'does not report method with chained iterators' do
     src = <<-EOS
       def alfa
         bravo.sort_by { |charlie| charlie }.each { |delta| delta }
@@ -123,8 +124,9 @@ RSpec.describe Reek::Smells::NestedIterators do
       end
     EOS
 
-    expect(src).not_to reek_of(:NestedIterators, depth: 2)
-    expect(src).to reek_of(:NestedIterators, depth: 3, lines: [4])
+    expect(src).
+      to not_reek_of(:NestedIterators, depth: 2).
+      and reek_of(:NestedIterators, depth: 3, lines: [4])
   end
 
   it 'reports all lines on which nested iterators occur' do
@@ -314,7 +316,7 @@ RSpec.describe Reek::Smells::NestedIterators do
       expect(src).to reek_of(:NestedIterators, depth: 2).with_config(config)
     end
 
-    it 'should report nested iterators with the ignored iterator between them' do
+    it 'reports nested iterators with the ignored iterator between them' do
       src = <<-EOS
         def alfa(bravo)
           bravo.each do |charlie|

--- a/spec/reek/smells/nil_check_spec.rb
+++ b/spec/reek/smells/nil_check_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Reek::Smells::NilCheck do
   end
 
   it 'reports nothing when scope includes no nil checks' do
-    expect('def alfa; end').not_to reek_of(:NilCheck)
+    src = 'def alfa; end'
+    expect(src).not_to reek_of(:NilCheck)
   end
 
   it 'reports when scope uses == nil' do

--- a/spec/reek/smells/prima_donna_method_spec.rb
+++ b/spec/reek/smells/prima_donna_method_spec.rb
@@ -29,15 +29,12 @@ RSpec.describe Reek::Smells::PrimaDonnaMethod do
       end
     EOS
 
-    expect(src).to reek_of(:PrimaDonnaMethod,
-                           lines: [1],
-                           name:  'bravo!')
-    expect(src).to reek_of(:PrimaDonnaMethod,
-                           lines: [1],
-                           name:  'charlie!')
+    expect(src).
+      to reek_of(:PrimaDonnaMethod, lines: [1], name: 'bravo!').
+      and reek_of(:PrimaDonnaMethod, lines: [1], name: 'charlie!')
   end
 
-  it 'should report nothing when method and bang counterpart exist' do
+  it 'reports nothing when method and bang counterpart exist' do
     src = <<-EOS
       class Alfa
         def bravo

--- a/spec/reek/smells/smell_configuration_spec.rb
+++ b/spec/reek/smells/smell_configuration_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Reek::Smells::SmellConfiguration do
       expect(updated).to eq(base_config)
     end
 
-    it 'should override single values' do
+    it 'overrides single values' do
       updated = smell_config.merge('enabled' => false)
       expect(updated).to eq('accept'  => ['_'],
                             'enabled' => false,
@@ -35,7 +35,7 @@ RSpec.describe Reek::Smells::SmellConfiguration do
                             'reject'  => [/^.$/, /[0-9]$/, /[A-Z]/])
     end
 
-    it 'should override arrays of values' do
+    it 'overrides arrays of values' do
       updated = smell_config.merge('reject' => [/^.$/, /[3-9]$/])
       expect(updated).to eq('accept'  => ['_'],
                             'enabled' => true,
@@ -43,7 +43,7 @@ RSpec.describe Reek::Smells::SmellConfiguration do
                             'reject'  => [/^.$/, /[3-9]$/])
     end
 
-    it 'should override multiple values' do
+    it 'overrides multiple values' do
       updated = smell_config.merge('accept' => [/[A-Z]$/], 'enabled' => false)
       expect(updated).to eq('accept'  => [/[A-Z]$/],
                             'enabled' => false,

--- a/spec/reek/smells/smell_repository_spec.rb
+++ b/spec/reek/smells/smell_repository_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe Reek::Smells::SmellRepository do
   describe '.smell_types' do
     let(:smell_types) { described_class.smell_types }
 
-    it 'should include existing smell_types' do
-      expect(smell_types).to include(Reek::Smells::IrresponsibleModule)
-      expect(smell_types).to include(Reek::Smells::TooManyStatements)
+    it 'includes existing smell_types' do
+      expect(smell_types).to include(Reek::Smells::IrresponsibleModule).
+        and include(Reek::Smells::TooManyStatements)
     end
 
-    it 'should exclude the smell detector base class' do
-      expect(smell_types).to_not include(Reek::Smells::SmellDetector)
+    it 'excludes the smell detector base class' do
+      expect(smell_types).not_to include(Reek::Smells::SmellDetector)
     end
 
-    it 'should return the smell types in alphabetic order' do
+    it 'returns the smell types in alphabetic order' do
       expect(smell_types).to eq(smell_types.sort_by(&:name))
     end
   end

--- a/spec/reek/smells/smell_warning_spec.rb
+++ b/spec/reek/smells/smell_warning_spec.rb
@@ -12,15 +12,17 @@ RSpec.describe Reek::Smells::SmellWarning do
       it 'hash differently' do
         expect(first.hash).not_to eq(second.hash)
       end
+
       it 'are not equal' do
         expect(first).not_to eq(second)
       end
+
       it 'sort correctly' do
         expect(first <=> second).to be < 0
       end
+
       it 'does not match using eql?' do
         expect(first).not_to eql(second)
-        expect(second).not_to eql(first)
       end
     end
 
@@ -99,48 +101,43 @@ RSpec.describe Reek::Smells::SmellWarning do
     let(:context_name) { 'Module::Class#method/block' }
     let(:lines) { [24, 513] }
     let(:message) { 'test message' }
+    let(:detector) { Reek::Smells::FeatureEnvy.new }
+    let(:parameters) { { 'one' => 34, 'two' => 'second' } }
+    let(:smell_type) { 'FeatureEnvy' }
+    let(:source) { 'a/ruby/source/file.rb' }
 
-    shared_examples_for 'common fields' do
-      it 'includes the smell type' do
-        expect(yaml['smell_type']).to eq 'FeatureEnvy'
-      end
-      it 'includes the context' do
-        expect(yaml['context']).to eq context_name
-      end
-      it 'includes the message' do
-        expect(yaml['message']).to eq message
-      end
-      it 'includes the line numbers' do
-        expect(yaml['lines']).to match_array lines
-      end
+    let(:yaml) do
+      warning = described_class.new(detector, source: source,
+                                              context: context_name,
+                                              lines: lines,
+                                              message: message,
+                                              parameters: parameters)
+      warning.yaml_hash
     end
 
-    context 'with all details specified' do
-      let(:detector) { Reek::Smells::FeatureEnvy.new }
-      let(:parameters) { { 'one' => 34, 'two' => 'second' } }
-      let(:smell_type) { 'FeatureEnvy' }
-      let(:source) { 'a/ruby/source/file.rb' }
-      let(:yaml) do
-        warning = Reek::Smells::SmellWarning.new(detector, source: source,
-                                                           context: context_name,
-                                                           lines: lines,
-                                                           message: message,
-                                                           parameters: parameters)
-        warning.yaml_hash
-      end
+    it 'includes the smell type' do
+      expect(yaml['smell_type']).to eq 'FeatureEnvy'
+    end
 
-      it_should_behave_like 'common fields'
+    it 'includes the context' do
+      expect(yaml['context']).to eq context_name
+    end
 
-      it 'includes the smell type' do
-        expect(yaml['smell_type']).to eq smell_type
-      end
-      it 'includes the source' do
-        expect(yaml['source']).to eq source
-      end
-      it 'includes the parameters' do
-        parameters.each do |key, value|
-          expect(yaml[key]).to eq value
-        end
+    it 'includes the message' do
+      expect(yaml['message']).to eq message
+    end
+
+    it 'includes the line numbers' do
+      expect(yaml['lines']).to match_array lines
+    end
+
+    it 'includes the source' do
+      expect(yaml['source']).to eq source
+    end
+
+    it 'includes the parameters' do
+      parameters.each do |key, value|
+        expect(yaml[key]).to eq value
       end
     end
   end

--- a/spec/reek/smells/subclassed_from_core_class_spec.rb
+++ b/spec/reek/smells/subclassed_from_core_class_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Reek::Smells::SubclassedFromCoreClass do
       end
     EOS
 
-    expect(src).to_not reek_of(:SubclassedFromCoreClass)
+    expect(src).not_to reek_of(:SubclassedFromCoreClass)
   end
 
   it 'does not report on coincidental core class names in other namespaces' do
@@ -42,7 +42,7 @@ RSpec.describe Reek::Smells::SubclassedFromCoreClass do
       end
     EOS
 
-    expect(src).to_not reek_of(:SubclassedFromCoreClass)
+    expect(src).not_to reek_of(:SubclassedFromCoreClass)
   end
 
   it 'reports if we inherit from a core class using Class#new' do
@@ -67,16 +67,16 @@ RSpec.describe Reek::Smells::SubclassedFromCoreClass do
 
   it 'does not report class which inherits from allowed class via Class.new' do
     src = 'Alfa = Class.new(StandardError)'
-    expect(src).to_not reek_of(:SubclassedFromCoreClass)
+    expect(src).not_to reek_of(:SubclassedFromCoreClass)
   end
 
   it 'does not report classes created with Struct.new' do
     src = "Alfa = Struct.new('Array')"
-    expect(src).to_not reek_of(:SubclassedFromCoreClass)
+    expect(src).not_to reek_of(:SubclassedFromCoreClass)
   end
 
   it 'does not report class created by another class constructor taking a core class as argument' do
     src = 'Charlie = Delta.new(Array)'
-    expect(src).to_not reek_of(:SubclassedFromCoreClass)
+    expect(src).not_to reek_of(:SubclassedFromCoreClass)
   end
 end

--- a/spec/reek/smells/too_many_constants_spec.rb
+++ b/spec/reek/smells/too_many_constants_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Reek::Smells::TooManyConstants do
                            count:   3).with_config(config)
   end
 
-  it 'should not report for non-excessive constants' do
+  it 'does not report for non-excessive constants' do
     src = <<-EOS
       class Alfa
         Bravo = Charlie = 1
@@ -31,7 +31,7 @@ RSpec.describe Reek::Smells::TooManyConstants do
     expect(src).not_to reek_of(:TooManyConstants).with_config(config)
   end
 
-  it 'should not report when increasing default' do
+  it 'does not report when increasing default' do
     src = <<-EOS
       # :reek:TooManyConstants: { max_constants: 3 }
       class Alfa
@@ -42,7 +42,7 @@ RSpec.describe Reek::Smells::TooManyConstants do
     expect(src).not_to reek_of(:TooManyConstants).with_config(config)
   end
 
-  it 'should not report when disabled' do
+  it 'does not report when disabled' do
     src = <<-EOS
       # :reek:TooManyConstants: { enabled: false }
       class Alfa
@@ -53,7 +53,7 @@ RSpec.describe Reek::Smells::TooManyConstants do
     expect(src).not_to reek_of(:TooManyConstants).with_config(config)
   end
 
-  it 'should not account class definition' do
+  it 'does not account class definition' do
     src = <<-EOS
       class Alfa
         Bravo = Charlie = 1
@@ -64,7 +64,7 @@ RSpec.describe Reek::Smells::TooManyConstants do
     expect(src).not_to reek_of(:TooManyConstants).with_config(config)
   end
 
-  it 'should not account struct definition' do
+  it 'does not account struct definition' do
     src = <<-EOS
       class Alfa
         Bravo = Charlie = 1
@@ -72,10 +72,10 @@ RSpec.describe Reek::Smells::TooManyConstants do
       end
     EOS
 
-    expect(src).to_not reek_of(:TooManyConstants).with_config(config)
+    expect(src).not_to reek_of(:TooManyConstants).with_config(config)
   end
 
-  it 'should count each constant only once' do
+  it 'counts each constant only once' do
     src = <<-EOS
       class Alfa
         Bravo = Charlie = 1
@@ -93,7 +93,7 @@ RSpec.describe Reek::Smells::TooManyConstants do
     expect(src).not_to reek_of(:TooManyConstants).with_config(config)
   end
 
-  it 'should not report outer module when inner module suppressed' do
+  it 'does not report outer module when inner module suppressed' do
     src = <<-EOS
       module Alfa
         # ignore :reek:TooManyConstants:
@@ -106,7 +106,7 @@ RSpec.describe Reek::Smells::TooManyConstants do
     expect(src).not_to reek_of(:TooManyConstants).with_config(config)
   end
 
-  it 'should count each constant only once for each namespace' do
+  it 'counts each constant only once for each namespace' do
     src = <<-EOS
       module Alfa
         Bravo = Charlie = 1
@@ -120,7 +120,7 @@ RSpec.describe Reek::Smells::TooManyConstants do
     expect(src).not_to reek_of(:TooManyConstants).with_config(config)
   end
 
-  it 'should report for excessive constants inside a module' do
+  it 'reports for excessive constants inside a module' do
     src = <<-EOS
       module Alfa
         Bravo = Charlie = Delta = 1

--- a/spec/reek/smells/too_many_instance_variables_spec.rb
+++ b/spec/reek/smells/too_many_instance_variables_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Reek::Smells::TooManyInstanceVariables do
                            count:   3).with_config(config)
   end
 
-  it 'should not report for non-excessive ivars' do
+  it 'does not report for non-excessive ivars' do
     src = <<-EOS
       class Alfa
         def bravo

--- a/spec/reek/smells/too_many_methods_spec.rb
+++ b/spec/reek/smells/too_many_methods_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Reek::Smells::TooManyMethods do
                            count:   4).with_config(config)
   end
 
-  it 'should not report if we stay below max_methods' do
+  it 'does not report if we stay below max_methods' do
     src = <<-EOS
       class Alfa
         def bravo; end

--- a/spec/reek/smells/too_many_statements_spec.rb
+++ b/spec/reek/smells/too_many_statements_spec.rb
@@ -42,12 +42,9 @@ RSpec.describe Reek::Smells::TooManyStatements do
       end
     EOS
 
-    expect(src).to reek_of(:TooManyStatements,
-                           lines:   [2],
-                           context: 'Alfa#bravo').with_config(config)
-    expect(src).to reek_of(:TooManyStatements,
-                           lines:   [8],
-                           context: 'Alfa#foxtrot').with_config(config)
+    expect(src).
+      to reek_of(:TooManyStatements, lines: [2], context: 'Alfa#bravo').with_config(config).
+      and reek_of(:TooManyStatements, lines: [8], context: 'Alfa#foxtrot').with_config(config)
   end
 
   it 'does not report short methods' do

--- a/spec/reek/smells/uncommunicative_method_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_method_name_spec.rb
@@ -17,15 +17,18 @@ RSpec.describe Reek::Smells::UncommunicativeMethodName do
 
   describe 'default configuration' do
     it 'reports one-word names' do
-      expect('def a; end').to reek_of(:UncommunicativeMethodName)
+      src = 'def a; end'
+      expect(src).to reek_of(:UncommunicativeMethodName)
     end
 
     it 'reports names ending with a digit' do
-      expect('def xyz1; end').to reek_of(:UncommunicativeMethodName)
+      src = 'def xyz1; end'
+      expect(src).to reek_of(:UncommunicativeMethodName)
     end
 
     it 'reports camelcased names' do
-      expect('def aBBa; end').to reek_of(:UncommunicativeMethodName)
+      src = 'def aBBa; end'
+      expect(src).to reek_of(:UncommunicativeMethodName)
     end
 
     it 'does not report one-letter special characters' do
@@ -40,7 +43,7 @@ RSpec.describe Reek::Smells::UncommunicativeMethodName do
 
     it 'make smelly names pass via regex / strings given by list / literal' do
       [[/x/], /x/, ['x'], 'x'].each do |pattern|
-        expect(source).to_not reek_of(:UncommunicativeMethodName).with_config('accept' => pattern)
+        expect(source).not_to reek_of(:UncommunicativeMethodName).with_config('accept' => pattern)
       end
     end
   end
@@ -56,7 +59,7 @@ RSpec.describe Reek::Smells::UncommunicativeMethodName do
   end
 
   describe '.default_config' do
-    it 'should merge in the default accept and reject patterns' do
+    it 'merges in the default accept and reject patterns' do
       expected = {
         'enabled' => true,
         'exclude' => [],
@@ -68,7 +71,7 @@ RSpec.describe Reek::Smells::UncommunicativeMethodName do
   end
 
   describe '.contexts' do
-    it 'should be scoped to classes and modules' do
+    it 'is scoped to classes and modules' do
       expect(described_class.contexts).to eq([:def, :defs])
     end
   end

--- a/spec/reek/smells/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_module_name_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Reek::Smells::UncommunicativeModuleName do
 
     it 'makes smelly names pass via regex / strings given by list / literal' do
       [[/lfa/], /lfa/, ['lfa'], 'lfa'].each do |pattern|
-        expect(source).to_not reek_of(:UncommunicativeModuleName).with_config('accept' => pattern)
+        expect(source).not_to reek_of(:UncommunicativeModuleName).with_config('accept' => pattern)
       end
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe Reek::Smells::UncommunicativeModuleName do
   end
 
   describe '.default_config' do
-    it 'should merge in the default accept and reject patterns' do
+    it 'merges in the default accept and reject patterns' do
       expected = {
         'enabled' => true,
         'exclude' => [],
@@ -69,7 +69,7 @@ RSpec.describe Reek::Smells::UncommunicativeModuleName do
   end
 
   describe '.contexts' do
-    it 'are scoped to classes and modules' do
+    it 'indicates that this smell is scoped to classes and modules' do
       expect(described_class.contexts).to eq([:module, :class])
     end
   end

--- a/spec/reek/smells/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_parameter_name_spec.rb
@@ -24,12 +24,9 @@ RSpec.describe Reek::Smells::UncommunicativeParameterName do
       end
     EOS
 
-    expect(src).to reek_of(:UncommunicativeParameterName,
-                           lines: [1],
-                           name:  'x')
-    expect(src).to reek_of(:UncommunicativeParameterName,
-                           lines: [1],
-                           name:  'y')
+    expect(src).
+      to reek_of(:UncommunicativeParameterName, lines: [1], name: 'x').
+      and reek_of(:UncommunicativeParameterName, lines: [1], name: 'y')
   end
 
   { 'alfa.' => 'with a receiver',
@@ -93,7 +90,7 @@ RSpec.describe Reek::Smells::UncommunicativeParameterName do
 
     it 'make smelly names pass via regex / strings given by list / literal' do
       [[/bar2/], /bar2/, ['bar2'], 'bar2'].each do |pattern|
-        expect(source).to_not reek_of(:UncommunicativeParameterName).with_config('accept' => pattern)
+        expect(source).not_to reek_of(:UncommunicativeParameterName).with_config('accept' => pattern)
       end
     end
   end
@@ -109,7 +106,7 @@ RSpec.describe Reek::Smells::UncommunicativeParameterName do
   end
 
   describe '.default_config' do
-    it 'should merge in the default accept and reject patterns' do
+    it 'merges in the default accept and reject patterns' do
       expected = {
         'enabled' => true,
         'exclude' => [],
@@ -122,7 +119,7 @@ RSpec.describe Reek::Smells::UncommunicativeParameterName do
   end
 
   describe '.contexts' do
-    it 'are scoped to classes and modules' do
+    it 'indicates that this smell is scoped to method definitions' do
       expect(described_class.contexts).to eq([:def, :defs])
     end
   end

--- a/spec/reek/smells/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smells/uncommunicative_variable_name_spec.rb
@@ -25,12 +25,8 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
       end
     EOS
 
-    expect(src).to reek_of(:UncommunicativeVariableName,
-                           lines: [2],
-                           name:  'x')
-    expect(src).to reek_of(:UncommunicativeVariableName,
-                           lines: [3],
-                           name:  'y')
+    expect(src).to reek_of(:UncommunicativeVariableName, lines: [2], name:  'x').
+      and reek_of(:UncommunicativeVariableName, lines: [3], name:  'y')
   end
 
   context 'instance variables' do
@@ -90,8 +86,8 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
         end
       EOS
 
-      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
-      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x').
+        and reek_of(:UncommunicativeVariableName, name: 'y')
     end
 
     it 'reports block parameters used outside of methods' do
@@ -121,8 +117,8 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
         end
       EOS
 
-      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
-      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x').
+        and reek_of(:UncommunicativeVariableName, name: 'y')
     end
 
     it 'reports splatted nested block parameters' do
@@ -132,8 +128,8 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
         end
       EOS
 
-      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
-      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x').
+        and reek_of(:UncommunicativeVariableName, name: 'y')
     end
 
     it 'reports deeply nested block parameters' do
@@ -143,9 +139,9 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
         end
       EOS
 
-      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
-      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
-      expect(src).to reek_of(:UncommunicativeVariableName, name: 'z')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x').
+        and reek_of(:UncommunicativeVariableName, name: 'y').
+        and reek_of(:UncommunicativeVariableName, name: 'z')
     end
 
     it 'reports shadowed block parameters' do
@@ -155,19 +151,19 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
         end
       EOS
 
-      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x')
-      expect(src).to reek_of(:UncommunicativeVariableName, name: 'y')
+      expect(src).to reek_of(:UncommunicativeVariableName, name: 'x').
+        and reek_of(:UncommunicativeVariableName, name: 'y')
     end
   end
 
   describe '`accept` patterns' do
     let(:src) { 'def alfa; bravo2 = 42; end' }
 
+    # FIXME: Move the loop out of the it?
     it 'make smelly names pass via regex / strings given by list / literal' do
-      expect(src).to reek_of(:UncommunicativeVariableName)
-
       [[/bravo2/], /bravo2/, ['bravo2'], 'bravo2'].each do |pattern|
-        expect(src).to_not reek_of(:UncommunicativeVariableName).with_config('accept' => pattern)
+        expect(src).to reek_of(:UncommunicativeVariableName).
+          and not_reek_of(:UncommunicativeVariableName).with_config('accept' => pattern)
       end
     end
   end
@@ -175,17 +171,17 @@ RSpec.describe Reek::Smells::UncommunicativeVariableName do
   describe '`reject` patterns' do
     let(:src) { 'def alfa; foobar = 42; end' }
 
+    # FIXME: Move the loop out of the it?
     it 'reject smelly names via regex / strings given by list / literal' do
-      expect(src).not_to reek_of(:UncommunicativeVariableName)
-
       [[/foobar/], /foobar/, ['foobar'], 'foobar'].each do |pattern|
-        expect(src).to reek_of(:UncommunicativeVariableName).with_config('reject' => pattern)
+        expect(src).to not_reek_of(:UncommunicativeVariableName).
+          and reek_of(:UncommunicativeVariableName).with_config('reject' => pattern)
       end
     end
   end
 
   describe '.default_config' do
-    it 'should merge in the default accept and reject patterns' do
+    it 'merges in the default accept and reject patterns' do
       expected = {
         'enabled' => true,
         'exclude' => [],

--- a/spec/reek/smells/unused_parameters_spec.rb
+++ b/spec/reek/smells/unused_parameters_spec.rb
@@ -22,82 +22,93 @@ RSpec.describe Reek::Smells::UnusedParameters do
       end
     EOS
 
-    expect(src).to reek_of(:UnusedParameters,
-                           lines: [1],
-                           name:  'bravo')
-    expect(src).to reek_of(:UnusedParameters,
-                           lines: [1],
-                           name:  'charlie')
+    expect(src).
+      to reek_of(:UnusedParameters, lines: [1], name: 'bravo').
+      and reek_of(:UnusedParameters, lines: [1], name:  'charlie')
   end
 
   it 'reports nothing for no parameters' do
-    expect('def alfa; end').not_to reek_of(:UnusedParameters)
+    src = 'def alfa; end'
+    expect(src).not_to reek_of(:UnusedParameters)
   end
 
   it 'reports nothing for used parameter' do
-    expect('def alfa(bravo); bravo; end').not_to reek_of(:UnusedParameters)
+    src = 'def alfa(bravo); bravo; end'
+    expect(src).not_to reek_of(:UnusedParameters)
   end
 
   it 'reports for 1 used and 2 unused parameter' do
     src = 'def alfa(bravo, charlie, delta); bravo end'
 
-    expect(src).not_to reek_of(:UnusedParameters, name: 'bravo')
-    expect(src).to reek_of(:UnusedParameters, name: 'charlie')
-    expect(src).to reek_of(:UnusedParameters, name: 'delta')
+    expect(src).
+      to not_reek_of(:UnusedParameters, name: 'bravo').
+      and reek_of(:UnusedParameters, name: 'charlie').
+      and reek_of(:UnusedParameters, name: 'delta')
   end
 
   it 'reports nothing for named parameters prefixed with _' do
-    expect('def alfa(_bravo); end').not_to reek_of(:UnusedParameters)
+    src = 'def alfa(_bravo); end'
+    expect(src).not_to reek_of(:UnusedParameters)
   end
 
   it 'reports nothing when using a parameter via self assignment' do
-    expect('def alfa(bravo); bravo += 1; end').not_to reek_of(:UnusedParameters)
+    src = 'def alfa(bravo); bravo += 1; end'
+    expect(src).not_to reek_of(:UnusedParameters)
   end
 
   it 'reports nothing when using a parameter on a rescue' do
-    expect('def alfa(bravo = 3); puts "nothing"; rescue; retry if bravo -= 1 > 0; raise; end').
-      not_to reek_of(:UnusedParameters)
+    src = 'def alfa(bravo = 3); puts "nothing"; rescue; retry if bravo -= 1 > 0; raise; end'
+    expect(src).not_to reek_of(:UnusedParameters)
   end
 
   context 'using super' do
     it 'reports nothing with implicit arguments' do
-      expect('def alfa(*bravo); super; end').not_to reek_of(:UnusedParameters)
+      src = 'def alfa(*bravo); super; end'
+      expect(src).not_to reek_of(:UnusedParameters)
     end
 
     it 'reports something when explicitely passing no arguments' do
-      expect('def alfa(*bravo); super(); end').to reek_of(:UnusedParameters)
+      src = 'def alfa(*bravo); super(); end'
+      expect(src).to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing when explicitely passing all arguments' do
-      expect('def alfa(*bravo); super(*bravo); end').not_to reek_of(:UnusedParameters)
+      src = 'def alfa(*bravo); super(*bravo); end'
+      expect(src).not_to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing in a nested context' do
-      expect('def alfa(*bravo); charlie(super); end').not_to reek_of(:UnusedParameters)
+      src = 'def alfa(*bravo); charlie(super); end'
+      expect(src).not_to reek_of(:UnusedParameters)
     end
   end
 
   context 'anonymous parameters' do
     it 'reports nothing for unused anonymous parameter' do
-      expect('def alfa(_); end').not_to reek_of(:UnusedParameters)
+      src = 'def alfa(_); end'
+      expect(src).not_to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing for unused anonymous splatted parameter' do
-      expect('def alfa(*); end').not_to reek_of(:UnusedParameters)
+      src = 'def alfa(*); end'
+      expect(src).not_to reek_of(:UnusedParameters)
     end
   end
 
   context 'splatted parameters' do
     it 'reports nothing for used splatted parameter' do
-      expect('def alfa(*bravo); bravo; end').not_to reek_of(:UnusedParameters)
+      src = 'def alfa(*bravo); bravo; end'
+      expect(src).not_to reek_of(:UnusedParameters)
     end
 
     it 'reports something when not using a keyword argument with splat' do
-      expect('def alfa(**bravo); end').to reek_of(:UnusedParameters)
+      src = 'def alfa(**bravo); end'
+      expect(src).to reek_of(:UnusedParameters)
     end
 
     it 'reports nothing when using a keyword argument with splat' do
-      expect('def alfa(**bravo); bravo; end').not_to reek_of(:UnusedParameters)
+      src = 'def alfa(**bravo); bravo; end'
+      expect(src).not_to reek_of(:UnusedParameters)
     end
   end
 end

--- a/spec/reek/smells/unused_private_method_spec.rb
+++ b/spec/reek/smells/unused_private_method_spec.rb
@@ -33,12 +33,9 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
       end
     EOS
 
-    expect(src).to reek_of(:UnusedPrivateMethod,
-                           lines: [4],
-                           name:  'charlie')
-    expect(src).to reek_of(:UnusedPrivateMethod,
-                           lines: [7],
-                           name:  'charlie')
+    expect(src).
+      to reek_of(:UnusedPrivateMethod, lines: [4], name: 'charlie').
+      and reek_of(:UnusedPrivateMethod, lines: [7], name: 'charlie')
   end
 
   context 'unused private methods' do
@@ -51,8 +48,9 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
         end
       EOF
 
-      expect(source).to reek_of(:UnusedPrivateMethod, name: 'bravo')
-      expect(source).to reek_of(:UnusedPrivateMethod, name: 'charlie')
+      expect(source).
+        to reek_of(:UnusedPrivateMethod, name: 'bravo').
+        and reek_of(:UnusedPrivateMethod, name: 'charlie')
     end
 
     it 'reports instance methods in the correct class' do
@@ -65,12 +63,9 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
         end
       EOF
 
-      expect(source).to reek_of(:UnusedPrivateMethod,
-                                context: 'Alfa::Bravo',
-                                name: 'charlie')
-      expect(source).not_to reek_of(:UnusedPrivateMethod,
-                                    context: 'Alfa',
-                                    name: 'charlie')
+      expect(source).
+        to reek_of(:UnusedPrivateMethod, context: 'Alfa::Bravo', name: 'charlie').
+        and not_reek_of(:UnusedPrivateMethod, context: 'Alfa', name: 'charlie')
     end
 
     it 'discounts calls to identically named methods in nested classes' do
@@ -90,12 +85,9 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
         end
       EOF
 
-      expect(source).not_to reek_of(:UnusedPrivateMethod,
-                                    context: 'Alfa::Bravo',
-                                    name: 'charlie')
-      expect(source).to reek_of(:UnusedPrivateMethod,
-                                context: 'Alfa',
-                                name: 'charlie')
+      expect(source).
+        to reek_of(:UnusedPrivateMethod, context: 'Alfa', name: 'charlie').
+        and not_reek_of(:UnusedPrivateMethod, context: 'Alfo::Bravo', name: 'charlie')
     end
 
     it 'creates warnings correctly' do
@@ -107,12 +99,9 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
         end
       EOF
 
-      expect(source).to reek_of(:UnusedPrivateMethod,
-                                name: 'bravo',
-                                lines: [3])
-      expect(source).to reek_of(:UnusedPrivateMethod,
-                                name: 'charlie',
-                                lines: [4])
+      expect(source).
+        to reek_of(:UnusedPrivateMethod, name: 'bravo', lines: [3]).
+        and reek_of(:UnusedPrivateMethod, name: 'charlie', lines: [4])
     end
   end
 
@@ -127,8 +116,9 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
         end
       EOF
 
-      expect(source).to reek_of(:UnusedPrivateMethod, name: 'charlie')
-      expect(source).not_to reek_of(:UnusedPrivateMethod, name: 'bravo')
+      expect(source).
+        to reek_of(:UnusedPrivateMethod, name: 'charlie').
+        and not_reek_of(:UnusedPrivateMethod, name: 'bravo')
     end
   end
 
@@ -188,15 +178,17 @@ RSpec.describe Reek::Smells::UnusedPrivateMethod do
     it 'excludes them via direct match in the app configuration' do
       config = { Reek::Smells::SmellDetector::EXCLUDE_KEY => ['Alfa#charlie'] }
 
-      expect(source).to reek_of(:UnusedPrivateMethod, name: 'bravo').with_config(config)
-      expect(source).not_to reek_of(:UnusedPrivateMethod, name: 'charlie').with_config(config)
+      expect(source).
+        to reek_of(:UnusedPrivateMethod, name: 'bravo').with_config(config).
+        and not_reek_of(:UnusedPrivateMethod, name: 'charlie').with_config(config)
     end
 
     it 'excludes them via regex in the app configuration' do
       config = { Reek::Smells::SmellDetector::EXCLUDE_KEY => [/charlie/] }
 
-      expect(source).to reek_of(:UnusedPrivateMethod, name: 'bravo').with_config(config)
-      expect(source).not_to reek_of(:UnusedPrivateMethod, name: 'charlie').with_config(config)
+      expect(source).
+        to reek_of(:UnusedPrivateMethod, name: 'bravo').with_config(config).
+        and not_reek_of(:UnusedPrivateMethod, name: 'charlie').with_config(config)
     end
   end
 end

--- a/spec/reek/smells/utility_function_spec.rb
+++ b/spec/reek/smells/utility_function_spec.rb
@@ -17,31 +17,37 @@ RSpec.describe Reek::Smells::UtilityFunction do
   end
 
   it 'counts a local call in a param initializer' do
-    expect('def alfa(bravo = charlie) bravo.to_s end').not_to reek_of(:UtilityFunction)
+    src = 'def alfa(bravo = charlie) bravo.to_s end'
+    expect(src).not_to reek_of(:UtilityFunction)
   end
 
   it 'counts usages of self' do
-    expect('def alfa(bravo); alfa.bravo(self); end').not_to reek_of(:UtilityFunction)
+    src = 'def alfa(bravo); alfa.bravo(self); end'
+    expect(src).not_to reek_of(:UtilityFunction)
   end
 
   it 'counts self reference within a dstr' do
-    expect('def alfa(bravo); "#{self} #{bravo}"; end').not_to reek_of(:UtilityFunction)
+    src = 'def alfa(bravo); "#{self} #{bravo}"; end'
+    expect(src).not_to reek_of(:UtilityFunction)
   end
 
   it 'counts calls to self within a dstr' do
-    expect('def alfa(bravo); "#{self.gsub(/charlie/, /delta/)}"; end').
+    src = 'def alfa(bravo); "#{self.gsub(/charlie/, /delta/)}"; end'
+    expect(src).
       not_to reek_of(:UtilityFunction)
   end
 
   it 'does not report a method that calls super' do
-    expect('def alfa(bravo) super; bravo.to_s; end').not_to reek_of(:UtilityFunction)
+    src = 'def alfa(bravo) super; bravo.to_s; end'
+    expect(src).not_to reek_of(:UtilityFunction)
   end
 
   it 'does not report a method that calls super with arguments' do
-    expect('def alfa(bravo) super(bravo); bravo.to_s; end').not_to reek_of(:UtilityFunction)
+    src = 'def alfa(bravo) super(bravo); bravo.to_s; end'
+    expect(src).not_to reek_of(:UtilityFunction)
   end
 
-  it 'should recognise a deep call' do
+  it 'recognises a deep call' do
     src = <<-EOS
         class Alfa
           def bravo(charlie)
@@ -58,31 +64,38 @@ RSpec.describe Reek::Smells::UtilityFunction do
   end
 
   it 'does not report empty method' do
-    expect('def alfa(bravo); end').not_to reek_of(:UtilityFunction)
+    src = 'def alfa(bravo); end'
+    expect(src).not_to reek_of(:UtilityFunction)
   end
 
   it 'does not report literal' do
-    expect('def alfa; 3; end').not_to reek_of(:UtilityFunction)
+    src = 'def alfa; 3; end'
+    expect(src).not_to reek_of(:UtilityFunction)
   end
 
   it 'does not report instance variable reference' do
-    expect('def alfa; @bravo; end').not_to reek_of(:UtilityFunction)
+    src = 'def alfa; @bravo; end'
+    expect(src).not_to reek_of(:UtilityFunction)
   end
 
   it 'does not report vcall' do
-    expect('def alfa; bravo; end').not_to reek_of(:UtilityFunction)
+    src = 'def alfa; bravo; end'
+    expect(src).not_to reek_of(:UtilityFunction)
   end
 
   it 'does not report references to self' do
-    expect('def alfa; self; end').not_to reek_of(:UtilityFunction)
+    src = 'def alfa; self; end'
+    expect(src).not_to reek_of(:UtilityFunction)
   end
 
   it 'recognises an ivar reference within a block' do
-    expect('def alfa(bravo) bravo.each { @charlie = 3} end').not_to reek_of(:UtilityFunction)
+    src = 'def alfa(bravo) bravo.each { @charlie = 3} end'
+    expect(src).not_to reek_of(:UtilityFunction)
   end
 
   it 'reports a call to a constant' do
-    expect('def simple(arga) FIELDS[arga] end').to reek_of(:UtilityFunction, context: 'simple')
+    src = 'def simple(arga) FIELDS[arga] end'
+    expect(src).to reek_of(:UtilityFunction, context: 'simple')
   end
 
   context 'Singleton methods' do

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe Reek::Source::SourceCode do
   describe '#syntax_tree' do
     it 'associates comments with the AST' do
       source = "# this is\n# a comment\ndef foo; end"
-      source_code = Reek::Source::SourceCode.new(code: source, origin: '(string)')
+      source_code = described_class.new(code: source, origin: '(string)')
       result = source_code.syntax_tree
       expect(result.leading_comment).to eq "# this is\n# a comment"
     end
 
     it 'cleanly processes empty source' do
-      source_code = Reek::Source::SourceCode.new(code: '', origin: '(string)')
+      source_code = described_class.new(code: '', origin: '(string)')
       result = source_code.syntax_tree
       expect(result).to be_nil
     end
 
     it 'cleanly processes empty source with comments' do
       source = "# this is\n# a comment\n"
-      source_code = Reek::Source::SourceCode.new(code: source, origin: '(string)')
+      source_code = described_class.new(code: source, origin: '(string)')
       result = source_code.syntax_tree
       expect(result).to be_nil
     end
@@ -29,8 +29,8 @@ RSpec.describe Reek::Source::SourceCode do
     let(:catcher) { StringIO.new }
     let(:source_name) { 'Test source' }
     let(:error_message) { 'Error message' }
-    let(:parser) { double('parser') }
-    let(:src) { Reek::Source::SourceCode.new(code: '', origin: source_name, parser: parser) }
+    let(:parser) { class_double(Parser::Ruby23) }
+    let(:src) { described_class.new(code: '', origin: source_name, parser: parser) }
 
     before { $stderr = catcher }
 
@@ -61,7 +61,7 @@ RSpec.describe Reek::Source::SourceCode do
 
     context 'with a Parser::SyntaxError' do
       let(:error_class) { Parser::SyntaxError }
-      let(:diagnostic) { double('diagnostic', message: error_message) }
+      let(:diagnostic) { instance_double('Parser::Diagnostic', message: error_message) }
 
       before do
         allow(parser).to receive(:parse_with_comments).

--- a/spec/reek/spec/should_reek_of_spec.rb
+++ b/spec/reek/spec/should_reek_of_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
   describe 'different sources of input' do
     context 'checking code in a string' do
       let(:clean_code) { 'def good() true; end' }
-      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, name: 'y') }
+      let(:matcher) { described_class.new(:UncommunicativeVariableName, name: 'y') }
       let(:smelly_code) { 'def x() y = 4; end' }
 
       it 'matches a smelly String' do
@@ -42,7 +42,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
     end
 
     context 'checking code in a File' do
-      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeMethodName, name: 'x') }
+      let(:matcher) { described_class.new(:UncommunicativeMethodName, name: 'x') }
 
       it 'matches a smelly file' do
         expect(matcher.matches?(SMELLY_FILE)).to be_truthy
@@ -56,7 +56,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
 
   describe 'smell types and smell details' do
     context 'passing in smell_details with unknown parameter name' do
-      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, foo: 'y') }
+      let(:matcher) { described_class.new(:UncommunicativeVariableName, foo: 'y') }
       let(:smelly_code) { 'def x() y = 4; end' }
 
       it 'raises ArgumentError' do
@@ -65,7 +65,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
     end
 
     context 'both are matching' do
-      let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, name: 'y') }
+      let(:matcher) { described_class.new(:UncommunicativeVariableName, name: 'y') }
       let(:smelly_code) { 'def x() y = 4; end' }
 
       it 'is truthy' do
@@ -76,8 +76,8 @@ RSpec.describe Reek::Spec::ShouldReekOf do
     context 'no smell_type is matching' do
       let(:smelly_code) { 'def dummy() y = 4; end' }
 
-      let(:falsey_matcher) { Reek::Spec::ShouldReekOf.new(:FeatureEnvy, name: 'y') }
-      let(:truthy_matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName, name: 'y') }
+      let(:falsey_matcher) { described_class.new(:FeatureEnvy, name: 'y') }
+      let(:truthy_matcher) { described_class.new(:UncommunicativeVariableName, name: 'y') }
 
       it 'is falsey' do
         expect(falsey_matcher.matches?(smelly_code)).to be_falsey
@@ -100,7 +100,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
 
     context 'smell type is matching but smell details are not' do
       let(:smelly_code) { 'def double_thing() @other.thing.foo + @other.thing.foo end' }
-      let(:matcher) { Reek::Spec::ShouldReekOf.new(:DuplicateMethodCall, name: 'foo', count: 15) }
+      let(:matcher) { described_class.new(:DuplicateMethodCall, name: 'foo', count: 15) }
 
       it 'is falsey' do
         expect(matcher.matches?(smelly_code)).to be_falsey
@@ -130,15 +130,20 @@ RSpec.describe Reek::Spec::ShouldReekOf do
     end
   end
 
-  it 'enables the smell detector to match automatically' do
-    default_config = Reek::Smells::UnusedPrivateMethod.default_config
-    expect(default_config[Reek::Smells::SmellConfiguration::ENABLED_KEY]).to be_falsy
+  context 'for a smell that is disabled by default' do
+    before do
+      default_config = Reek::Smells::UnusedPrivateMethod.default_config
+      expect(default_config[Reek::Smells::SmellConfiguration::ENABLED_KEY]).to be_falsy
+    end
 
-    expect('class C; private; def foo; end; end').to reek_of(:UnusedPrivateMethod)
+    it 'enables the smell detector to match automatically' do
+      src = 'class C; private; def foo; end; end'
+      expect(src).to reek_of(:UnusedPrivateMethod)
+    end
   end
 
   describe '#with_config' do
-    let(:matcher) { Reek::Spec::ShouldReekOf.new(:UncommunicativeVariableName) }
+    let(:matcher) { described_class.new(:UncommunicativeVariableName) }
     let(:configured_matcher) { matcher.with_config('accept' => 'x') }
 
     it 'uses the passed-in configuration for matching' do

--- a/spec/reek/spec/should_reek_only_of_spec.rb
+++ b/spec/reek/spec/should_reek_only_of_spec.rb
@@ -2,14 +2,14 @@ require_relative '../../spec_helper'
 require_lib 'reek/spec'
 
 RSpec.describe Reek::Spec::ShouldReekOnlyOf do
-  let(:examiner) { double('examiner').as_null_object }
+  let(:examiner) { instance_double('Reek::Examiner').as_null_object }
   let(:expected_context_name) { 'SmellyClass#big_method' }
   let(:expected_smell_type) { :NestedIterators }
-  let(:matcher) { Reek::Spec::ShouldReekOnlyOf.new(expected_smell_type) }
+  let(:matcher) { described_class.new(expected_smell_type) }
   let(:matcher_matches) { matcher.matches_examiner?(examiner) }
 
   before do
-    expect(examiner).to receive(:smells) { smells }
+    allow(examiner).to receive(:smells) { smells }
     matcher_matches
   end
 
@@ -21,7 +21,7 @@ RSpec.describe Reek::Spec::ShouldReekOnlyOf do
     context 'when a match was expected' do
       let(:source) { 'the_path/to_a/source_file.rb' }
 
-      before { expect(examiner).to receive(:description).and_return(source) }
+      before { allow(examiner).to receive(:description).and_return(source) }
 
       it 'reports the source' do
         expect(matcher.failure_message).to match(source)
@@ -91,7 +91,7 @@ RSpec.describe Reek::Spec::ShouldReekOnlyOf do
 
     it 'reports the source when no match was expected' do
       source = 'the_path/to_a/source_file.rb'
-      expect(examiner).to receive(:description).and_return(source)
+      allow(examiner).to receive(:description).and_return(source)
       expect(matcher.failure_message_when_negated).to match(source)
     end
   end

--- a/spec/reek/spec/should_reek_spec.rb
+++ b/spec/reek/spec/should_reek_spec.rb
@@ -3,7 +3,7 @@ require_lib 'reek/spec'
 
 RSpec.describe Reek::Spec::ShouldReek do
   describe 'checking code in a string' do
-    let(:matcher) { Reek::Spec::ShouldReek.new }
+    let(:matcher) { described_class.new }
     let(:clean_code) { 'def good() true; end' }
     let(:smelly_code) { 'def x() y = 4; end' }
 
@@ -23,7 +23,7 @@ RSpec.describe Reek::Spec::ShouldReek do
 
   describe 'checking code in a File' do
     context 'matcher without masking' do
-      let(:matcher) { Reek::Spec::ShouldReek.new }
+      let(:matcher) { described_class.new }
 
       it 'matches a smelly File' do
         expect(matcher.matches?(SMELLY_FILE)).to be_truthy
@@ -42,7 +42,7 @@ RSpec.describe Reek::Spec::ShouldReek do
     context 'matcher without masking' do
       let(:path) { CONFIG_PATH.join('full_mask.reek') }
       let(:configuration) { test_configuration_for(path) }
-      let(:matcher) { Reek::Spec::ShouldReek.new(configuration: configuration) }
+      let(:matcher) { described_class.new(configuration: configuration) }
 
       it 'masks smells using the relevant configuration' do
         expect(matcher.matches?(SMELLY_FILE)).to be_falsey

--- a/spec/reek/tree_dresser_spec.rb
+++ b/spec/reek/tree_dresser_spec.rb
@@ -33,13 +33,15 @@ RSpec.describe Reek::TreeDresser do
     end
 
     it 'dresses `def` nodes properly' do
-      expect(def_node).to be_a Reek::AST::SexpExtensions::DefNode
-      expect(def_node).to be_a Reek::AST::SexpExtensions::MethodNodeBase
+      expect(def_node).
+        to be_a(Reek::AST::SexpExtensions::DefNode).
+        and be_a(Reek::AST::SexpExtensions::MethodNodeBase)
     end
 
     it 'dresses `args` nodes properly' do
-      expect(args_node).to be_a Reek::AST::SexpExtensions::ArgsNode
-      expect(args_node).to be_a Reek::AST::SexpExtensions::NestedAssignables
+      expect(args_node).
+        to be_a(Reek::AST::SexpExtensions::ArgsNode).
+        and be_a(Reek::AST::SexpExtensions::NestedAssignables)
     end
 
     it 'dresses `send` nodes properly' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,6 +81,7 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
+    mocks.verify_doubled_constant_names = true
   end
 
   # Avoid infinitely running tests. This is mainly useful when running mutant.
@@ -92,6 +93,8 @@ RSpec.configure do |config|
     end
   end
 end
+
+RSpec::Matchers.define_negated_matcher :not_reek_of, :reek_of
 
 private
 

--- a/tasks/rubocop.rake
+++ b/tasks/rubocop.rake
@@ -1,5 +1,11 @@
-require 'rubocop/rake_task'
+begin
+  require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new do |task|
-  task.options << '--display-cop-names'
+  RuboCop::RakeTask.new do |task|
+    task.options << '--display-cop-names'
+  end
+rescue LoadError
+  task :rubocop do
+    puts 'Install rubocop to run its rake tasks'
+  end
 end


### PR DESCRIPTION
Implements #1036 based on #1037.

Because #1035 will introduce a lot of changes, this PR is based on that one. For now I have only touched the files that have been changed in #1035. This already gives a good feel for what settings and fixes to our specs are needed.

Some highlights:
* I had to increase the maximum for RSpec/ExampleLength significantly because of our multi-line source literals.
* To fix RSpec/MultipleExpectations, I used RSpec's [compound expectations](http://www.relishapp.com/rspec/rspec-expectations/v/3-5/docs/compound-expectations), in one case with a [negated matcher](http://www.relishapp.com/rspec/rspec-expectations/v/3-5/docs/define-negated-matcher).

I'll rebase this once #1035 is done.


