### PR TITLE
Add `#lines` to smell warning identity

### DIFF
--- a/features/samples.feature
+++ b/features/samples.feature
@@ -63,7 +63,7 @@ Feature: Basic smell detection
       UncommunicativeVariableName: Inline::C#module_name has the variable name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
       UncommunicativeVariableName: Inline::C#parse_signature has the variable name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
       UtilityFunction: Inline::C#strip_comments doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/master/docs/Utility-Function.md]
-    optparse.rb -- 126 warnings:
+    optparse.rb -- 130 warnings:
       Attribute: OptionParser#banner is a writable attribute [https://github.com/troessner/reek/blob/master/docs/Attribute.md]
       Attribute: OptionParser#default_argv is a writable attribute [https://github.com/troessner/reek/blob/master/docs/Attribute.md]
       Attribute: OptionParser#program_name is a writable attribute [https://github.com/troessner/reek/blob/master/docs/Attribute.md]
@@ -127,6 +127,10 @@ Feature: Basic smell detection
       LongParameterList: OptionParser::Switch#initialize has 7 parameters [https://github.com/troessner/reek/blob/master/docs/Long-Parameter-List.md]
       LongParameterList: OptionParser::Switch#summarize has 5 parameters [https://github.com/troessner/reek/blob/master/docs/Long-Parameter-List.md]
       ManualDispatch: OptionParser#make_switch manually dispatches method call [https://github.com/troessner/reek/blob/master/docs/Manual-Dispatch.md]
+      ManualDispatch: OptionParser#make_switch manually dispatches method call [https://github.com/troessner/reek/blob/master/docs/Manual-Dispatch.md]
+      ManualDispatch: OptionParser#make_switch manually dispatches method call [https://github.com/troessner/reek/blob/master/docs/Manual-Dispatch.md]
+      ManualDispatch: OptionParser::List#accept manually dispatches method call [https://github.com/troessner/reek/blob/master/docs/Manual-Dispatch.md]
+      ManualDispatch: OptionParser::List#accept manually dispatches method call [https://github.com/troessner/reek/blob/master/docs/Manual-Dispatch.md]
       ManualDispatch: OptionParser::List#accept manually dispatches method call [https://github.com/troessner/reek/blob/master/docs/Manual-Dispatch.md]
       ManualDispatch: OptionParser::List#add_banner manually dispatches method call [https://github.com/troessner/reek/blob/master/docs/Manual-Dispatch.md]
       ManualDispatch: OptionParser::List#summarize manually dispatches method call [https://github.com/troessner/reek/blob/master/docs/Manual-Dispatch.md]
@@ -190,7 +194,7 @@ Feature: Basic smell detection
       UnusedParameters: OptionParser::Completion#convert has unused parameter 'opt' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
       UnusedParameters: OptionParser::Switch::NoArgument#parse has unused parameter 'argv' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
       UnusedParameters: OptionParser::Switch::OptionalArgument#parse has unused parameter 'argv' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
-    redcloth.rb -- 110 warnings:
+    redcloth.rb -- 111 warnings:
       Attribute: RedCloth#filter_html is a writable attribute [https://github.com/troessner/reek/blob/master/docs/Attribute.md]
       Attribute: RedCloth#filter_styles is a writable attribute [https://github.com/troessner/reek/blob/master/docs/Attribute.md]
       Attribute: RedCloth#hard_breaks is a writable attribute [https://github.com/troessner/reek/blob/master/docs/Attribute.md]
@@ -233,6 +237,7 @@ Feature: Basic smell detection
       LongParameterList: RedCloth#textile_bq has 4 parameters [https://github.com/troessner/reek/blob/master/docs/Long-Parameter-List.md]
       LongParameterList: RedCloth#textile_fn_ has 5 parameters [https://github.com/troessner/reek/blob/master/docs/Long-Parameter-List.md]
       LongParameterList: RedCloth#textile_p has 4 parameters [https://github.com/troessner/reek/blob/master/docs/Long-Parameter-List.md]
+      ManualDispatch: RedCloth#block_textile_prefix manually dispatches method call [https://github.com/troessner/reek/blob/master/docs/Manual-Dispatch.md]
       ManualDispatch: RedCloth#block_textile_prefix manually dispatches method call [https://github.com/troessner/reek/blob/master/docs/Manual-Dispatch.md]
       NestedIterators: RedCloth#block_textile_lists contains iterators nested 3 deep [https://github.com/troessner/reek/blob/master/docs/Nested-Iterators.md]
       NestedIterators: RedCloth#block_textile_table contains iterators nested 2 deep [https://github.com/troessner/reek/blob/master/docs/Nested-Iterators.md]
@@ -301,5 +306,5 @@ Feature: Basic smell detection
       UtilityFunction: RedCloth#lT doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/master/docs/Utility-Function.md]
       UtilityFunction: RedCloth#no_textile doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/master/docs/Utility-Function.md]
       UtilityFunction: RedCloth#v_align doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/master/docs/Utility-Function.md]
-    287 total warnings
+    292 total warnings
     """

--- a/lib/reek/smells/smell_warning.rb
+++ b/lib/reek/smells/smell_warning.rb
@@ -67,7 +67,7 @@ module Reek
       protected
 
       def sort_key
-        [smell_type, context, message]
+        [smell_type, context, message, lines]
       end
 
       private

--- a/lib/reek/smells/smell_warning.rb
+++ b/lib/reek/smells/smell_warning.rb
@@ -35,12 +35,12 @@ module Reek
 
       # @public
       def hash
-        sort_key.hash
+        identifying_values.hash
       end
 
       # @public
       def <=>(other)
-        sort_key <=> other.sort_key
+        identifying_values <=> other.identifying_values
       end
 
       # @public
@@ -66,7 +66,7 @@ module Reek
 
       protected
 
-      def sort_key
+      def identifying_values
         [smell_type, context, message, lines]
       end
 

--- a/lib/reek/smells/smell_warning.rb
+++ b/lib/reek/smells/smell_warning.rb
@@ -31,6 +31,8 @@ module Reek
         @lines          = lines
         @message        = message
         @parameters     = parameters
+
+        freeze
       end
 
       # @public

--- a/spec/reek/smells/smell_warning_spec.rb
+++ b/spec/reek/smells/smell_warning_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe Reek::Smells::SmellWarning do
       it_should_behave_like 'first sorts ahead of second'
     end
 
+    context 'smells differing only by lines' do
+      let(:first) { build(:smell_warning, smell_detector: feature_envy_detector, lines: [2]) }
+      let(:second) { build(:smell_warning, smell_detector: feature_envy_detector, lines: [3]) }
+
+      it_should_behave_like 'first sorts ahead of second'
+    end
+
     context 'smells differing only by context' do
       let(:first) { build(:smell_warning, smell_detector: duplication_detector, context: 'first') }
       let(:second) do


### PR DESCRIPTION
This is related to #1044 but I don't want to close that issue because I think it also revealed that the smell's message should be improved.

I've broken this PR into three commits:

1. Adding `#lines` to the `#sort_key` method for `SmellWarning`. If two smells share the same type, context, and message but are on different lines then I think reek should treat these as being different smells.

2. `SmallWarning` seems like a value  object to me so I renamed `#sort_keys` to `#identifying_values` because that seems to better convey the very important role that method is playing.

3. Freezing `SmellWarning` on initialization. This doesn't break any specs or public API and, if you agree that `SmellWarning` is a Value then it should forbid mutating its state. 

These are certainly opinionated changes so I wont be offended if you disagree with one or more of the commits.