### PR TITLE
Make our CodeComment regex more lenient.

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ end
 You can even pass in smell specific configuration settings:
 
 ```Ruby
-# :reek:NestedIterators: { max_allowed_nesting: 2 }
+# :reek:NestedIterators { max_allowed_nesting: 2 }
 def smelly_method foo
   foo.each {|bar| bar.each {|baz| baz.qux}}
 end

--- a/docs/Smell-Suppression.md
+++ b/docs/Smell-Suppression.md
@@ -51,10 +51,10 @@ def many_parameters_it_has foo, bar, baz, qux
 end
 ```
 
-It is also possible to specify options for a particular smell detector, like so:
+It is also possible to specify options for a particular smell detector in hash-style:
 
 ```ruby
-# :reek:LongParameterList: { max_params: 4 }
+# :reek:LongParameterList { max_params: 4 }
 def many_parameters_it_has foo, bar, baz, qux
   # ...
 end
@@ -66,17 +66,17 @@ also use via comment.
 E.g.:
 
 ```ruby
-# :reek:TooManyStatements: { max_statements: 6 }
+# :reek:TooManyStatements { max_statements: 6 }
 def too_many
   # ...
 end
 
-# :reek:NestedIterators: { max_allowed_nesting: 2 }
+# :reek:NestedIterators { max_allowed_nesting: 2 }
 def quax
   foo.each {|bar| bar.each {|baz| baz.qux(qux)}}
 end
 
-# :reek:DuplicateMethodCall: { max_calls: 3 }
+# :reek:DuplicateMethodCall { max_calls: 3 }
 def quax
   foo.to_i + foo.to_i + foo.to_i
 end
@@ -86,7 +86,7 @@ Keep in mind that there are also smell detectors that operate on a class or
 module level, e.g.:
 
 ```ruby
-# :reek:TooManyInstanceVariables: { max_instance_variables: 8 }
+# :reek:TooManyInstanceVariables { max_instance_variables: 8 }
 class Klass
   # ...
 end

--- a/docs/Unused-Private-Method.md
+++ b/docs/Unused-Private-Method.md
@@ -37,7 +37,7 @@ configuration option (which is part of the [Basic Smell Options](Basic-Smell-Opt
 for instance like this (an example from Reek's own codebase):
 
 ```Ruby
-# :reek:UnusedPrivateMethod: { exclude: [ !ruby/regexp /process_/ ] }
+# :reek:UnusedPrivateMethod { exclude: [ !ruby/regexp /process_/ ] }
 class ContextBuilder
   def process_begin
     # ....

--- a/spec/reek/code_comment_spec.rb
+++ b/spec/reek/code_comment_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe Reek::CodeComment do
 
   context 'comment config' do
     it 'parses hashed options' do
+      comment = '# :reek:Duplication { enabled: false }'
+      config = described_class.new(comment).config
+      expect(config).to include('Duplication')
+      expect(config['Duplication']).to include('enabled')
+      expect(config['Duplication']['enabled']).to be_falsey
+    end
+
+    it "supports hashed options with the legacy separator ':' after the smell detector" do
       comment = '# :reek:Duplication: { enabled: false }'
       config = described_class.new(comment).config
       expect(config).to include('Duplication')
@@ -39,8 +47,8 @@ RSpec.describe Reek::CodeComment do
 
     it 'parses multiple hashed options' do
       config = described_class.new('
-        # :reek:Duplication: { enabled: false }
-        # :reek:NestedIterators: { enabled: true }
+        # :reek:Duplication { enabled: false }
+        # :reek:NestedIterators { enabled: true }
       ').config
       expect(config).to include('Duplication', 'NestedIterators')
       expect(config['Duplication']).to include('enabled')
@@ -51,7 +59,7 @@ RSpec.describe Reek::CodeComment do
 
     it 'parses multiple hashed options on the same line' do
       config = described_class.new('
-        #:reek:Duplication: { enabled: false } and :reek:NestedIterators: { enabled: true }
+        #:reek:Duplication { enabled: false } and :reek:NestedIterators { enabled: true }
       ').config
       expect(config).to include('Duplication', 'NestedIterators')
       expect(config['Duplication']).to include('enabled')
@@ -85,8 +93,8 @@ RSpec.describe Reek::CodeComment do
     it 'removes the configuration options from the comment' do
       subject = described_class.new('
         # Actual
-        # :reek:Duplication: { enabled: false }
-        # :reek:NestedIterators: { enabled: true }
+        # :reek:Duplication { enabled: false }
+        # :reek:NestedIterators { enabled: true }
         # comment
       ')
       expect(subject.send(:sanitized_comment)).to eq('Actual comment')


### PR DESCRIPTION
Fixes #1054 
This PR makes the ":" at the end of ":reek:UncommunicativeMethodName:" optional with 1 max

I'd consider the ":" at the end unnecessary and confusing syntax that a lot of users will get wrong.
Not to mention that a lot, a lot of people will forget about this when you go from the optionless form to the form with options like [we did ourselves](https://github.com/troessner/reek/blob/master/lib/reek/ast/node.rb#L89).
