### PR TITLE
Remove ControlCouple as detector from docs.

### DIFF
--- a/docs/Basic-Smell-Options.md
+++ b/docs/Basic-Smell-Options.md
@@ -19,7 +19,7 @@ exclusions for each smell.
 To stop Reek reporting smells in any method called `write` you might create a configuration file containing this:
 
 ```yaml
-ControlCouple: 
+DuplicateMethodCall:
   exclude:
   - write
 ```
@@ -27,7 +27,7 @@ ControlCouple:
 Or a little more sophisticated using a Ruby regex like this:
 
 ```yaml
-ControlCouple: 
+DuplicateMethodCall:
   exclude:
   - !ruby/regexp /write/
 ```

--- a/docs/YAML-Reports.md
+++ b/docs/YAML-Reports.md
@@ -91,21 +91,3 @@ Duplication:
   status:
     is_active: true
 </pre>
-
-[Control Couple](Control-Couple.md):
-
-<pre>
-- !ruby/object:Reek::SmellWarning 
-  location: 
-    source: $stdin
-    lines: 
-    - 2
-    context: Turn#fred
-  smell: 
-    class: ControlCouple
-    subclass: BooleanParameter
-    parameter: arg
-    message: has boolean parameter 'arg'
-  status:
-    is_active: true
-</pre>


### PR DESCRIPTION
Leftover from when it was still possible to use SmellCategories.