### PR TITLE
Add a progress formatter to the text report

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ Reek will report the following code smells in this file:
 
 ```
 $ reek demo.rb
+Inspecting 1 file(s):
+S
+
 demo.rb -- 2 warnings:
   [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
   [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]

--- a/features/command_line_interface/basic_usage.feature
+++ b/features/command_line_interface/basic_usage.feature
@@ -9,6 +9,9 @@ Feature: The Reek CLI maintains backwards compatibility
     Then the exit status indicates smells
     And it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     smelly.rb -- 2 warnings:
       [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
       [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -61,6 +61,7 @@ Feature: Reek can be controlled using command-line options
           -U, --[no-]wiki-links            Show link to related wiki page for each smell (default: true)
           -n, --[no-]line-numbers          Show line numbers in the output (default: true)
           -s, --single-line                Show location in editor-compatible single-line-per-smell format
+          -P, --[no-]progress              Show progress of each source as it is examined (default: true)
               --sort-by SORTING            Sort reported files by the given criterium:
                                              smelliness ("smelliest" files first)
                                              none (default - output in processing order)

--- a/features/command_line_interface/show_progress.feature
+++ b/features/command_line_interface/show_progress.feature
@@ -1,0 +1,31 @@
+Feature: Show progress
+  In order to see the progress of the examiners
+  As a developer
+  I want to be able to selectively activate progress reporting
+
+  Scenario: shows progress output on mixed files by default
+    Given a directory called 'mixed_files' containing some clean and smelly files
+    When I run reek mixed_files
+    Then the exit status indicates smells
+    And it reports:
+      """
+      Inspecting 2 file(s):
+      .S
+
+      mixed_files/dirty.rb -- 2 warnings:
+        [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+        [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
+      2 total warnings
+      """
+
+  Scenario: --no-progress disables progress output
+    Given a directory called 'mixed_files' containing some clean and smelly files
+    When I run reek --no-progress mixed_files
+    Then the exit status indicates smells
+    And it reports:
+      """
+      mixed_files/dirty.rb -- 2 warnings:
+        [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
+        [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
+      2 total warnings
+      """

--- a/features/command_line_interface/smell_selection.feature
+++ b/features/command_line_interface/smell_selection.feature
@@ -10,6 +10,9 @@ Feature: Smell selection
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 1 warning:
         UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
       """

--- a/features/command_line_interface/smells_count.feature
+++ b/features/command_line_interface/smells_count.feature
@@ -8,6 +8,9 @@ Feature: Reports total number of code smells
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -19,6 +22,9 @@ Feature: Reports total number of code smells
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 2 file(s):
+      SS
+
       smelly/dirty_one.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -34,5 +40,8 @@ Feature: Reports total number of code smells
     Then it succeeds
     And it reports:
       """
+      Inspecting 2 file(s):
+      ..
+
       0 total warnings
       """

--- a/features/command_line_interface/stdin.feature
+++ b/features/command_line_interface/stdin.feature
@@ -18,6 +18,9 @@ Feature: Reek reads from $stdin when no files are given
     Then it succeeds
     And it reports:
       """
+      Inspecting 1 file(s):
+      .
+
       STDIN -- 0 warnings
       """
 

--- a/features/configuration_files/accept_setting.feature
+++ b/features/configuration_files/accept_setting.feature
@@ -33,6 +33,9 @@ Feature: `accept` configuration setting
     When I run `reek -c config.reek smelly.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     smelly.rb -- 2 warnings:
       [8]:UncommunicativeMethodName: C1#m3 has the name 'm3' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
       [8]:UncommunicativeParameterName: C1#m3 has the parameter name 'a3' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md]
@@ -64,6 +67,9 @@ Feature: `accept` configuration setting
     When I run `reek -c config.reek smelly.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     smelly.rb -- 2 warnings:
       [6]:UncommunicativeMethodName: Classy1#m2 has the name 'm2' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
       [6]:UncommunicativeParameterName: Classy1#m2 has the parameter name 'a2' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md]

--- a/features/configuration_files/directory_specific_directives.feature
+++ b/features/configuration_files/directory_specific_directives.feature
@@ -49,6 +49,9 @@ Feature: Directory directives
     When I run `reek -c web_app/config.reek web_app/`
     Then it reports:
     """
+    Inspecting 3 file(s):
+    S.S
+
     web_app/app/controllers/users_controller.rb -- 1 warning:
       [1]:InstanceVariableAssumption: UsersController assumes too much for instance variable '@user' [https://github.com/troessner/reek/blob/master/docs/Instance-Variable-Assumption.md]
     web_app/app/models/user.rb -- 2 warnings:
@@ -73,7 +76,12 @@ Feature: Directory directives
       end
       """
     When I run `reek -c web_app/config.reek controllers`
-    Then it reports nothing
+    Then it reports:
+    """
+    Inspecting 1 file(s):
+    .
+
+    """
 
   Scenario: Partially mask smells in different directories
     Given a file named "web_app/config.reek" with:
@@ -120,6 +128,9 @@ Feature: Directory directives
     When I run `reek -c web_app/config.reek web_app/`
     Then it reports:
     """
+    Inspecting 3 file(s):
+    S.S
+
     web_app/app/controllers/users_controller.rb -- 3 warnings:
       [1]:InstanceVariableAssumption: UsersController assumes too much for instance variable '@user' [https://github.com/troessner/reek/blob/master/docs/Instance-Variable-Assumption.md]
       [1]:IrresponsibleModule: UsersController has no descriptive comment [https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md]
@@ -166,6 +177,9 @@ Feature: Directory directives
     When I run `reek -c config.reek other/ web_app/`
     Then it reports:
     """
+    Inspecting 2 file(s):
+    SS
+
     other/projects_controller.rb -- 2 warnings:
       [1]:InstanceVariableAssumption: ProjectController assumes too much for instance variable '@project' [https://github.com/troessner/reek/blob/master/docs/Instance-Variable-Assumption.md]
       [4]:NestedIterators: ProjectController#show contains iterators nested 2 deep [https://github.com/troessner/reek/blob/master/docs/Nested-Iterators.md]
@@ -261,6 +275,9 @@ Feature: Directory directives
     When I run `reek -c config.reek foo/`
     Then it reports:
     """
+    Inspecting 2 file(s):
+    SS
+
     foo/bar/baz/klass.rb -- 1 warning:
       [4]:NestedIterators: Klass#meth contains iterators nested 2 deep [https://github.com/troessner/reek/blob/master/docs/Nested-Iterators.md]
     foo/bar/klazz.rb -- 1 warning:

--- a/features/configuration_files/exclude_directives.feature
+++ b/features/configuration_files/exclude_directives.feature
@@ -28,6 +28,9 @@ Feature: Exclude directives
     When I run `reek -c config.reek smelly.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     smelly.rb -- 2 warnings:
       [1]:IrresponsibleModule: Smelly has no descriptive comment [https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md]
       [3]:UnusedParameters: Smelly#foo has unused parameter 'arg' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]

--- a/features/configuration_files/masking_smells.feature
+++ b/features/configuration_files/masking_smells.feature
@@ -20,7 +20,12 @@ Feature: Masking smells using config files
     And a configuration file 'full_mask.reek'
     When I run reek -c full_mask.reek smelly.rb
     Then it succeeds
-    And it reports nothing
+    And it reports:
+      """
+      Inspecting 1 file(s):
+      .
+
+      """
 
   Scenario: allow masking some calls for duplication smell
     Given the smelly file 'smelly.rb'
@@ -29,6 +34,9 @@ Feature: Masking smells using config files
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 1 warning:
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
       """
@@ -38,7 +46,12 @@ Feature: Masking smells using config files
     And a configuration file 'partial_mask.reek'
     When I run reek -c partial_mask.reek smelly_with_inline_mask.rb
     Then it succeeds
-    And it reports nothing
+    And it reports:
+    """
+    Inspecting 1 file(s):
+    .
+
+    """
 
   Scenario: empty config file outputs normally
     Given the smelly file 'smelly.rb'
@@ -47,11 +60,13 @@ Feature: Masking smells using config files
     Then the exit status indicates smells
     And it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     smelly.rb -- 2 warnings:
       [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
       [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
     """
-
 
   Scenario: Disable UtilityFunction for non-public methods
     Given the smelly file 'smelly_with_modifiers.rb'
@@ -60,6 +75,9 @@ Feature: Masking smells using config files
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly_with_modifiers.rb -- 1 warning:
         [7]:UtilityFunction: Klass#public_method doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/master/docs/Utility-Function.md]
       """

--- a/features/configuration_files/mix_accept_reject_setting.feature
+++ b/features/configuration_files/mix_accept_reject_setting.feature
@@ -25,6 +25,9 @@ Feature: Mix `accept` and `reject` configuration settings
     When I run `reek -c config.reek smelly.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     smelly.rb -- 2 warnings:
       [4]:UncommunicativeMethodName: awesome_helper has the name 'awesome_helper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
       [3]:UncommunicativeMethodName: foobar has the name 'foobar' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
@@ -52,6 +55,9 @@ Feature: Mix `accept` and `reject` configuration settings
     When I run `reek -c config.reek smelly.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     smelly.rb -- 1 warning:
       [3]:UncommunicativeModuleName: BaseHelper has the name 'BaseHelper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Module-Name.md]
     """
@@ -76,6 +82,9 @@ Feature: Mix `accept` and `reject` configuration settings
     When I run `reek -c config.reek smelly.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     smelly.rb -- 1 warning:
       [3]:UncommunicativeParameterName: omg has the parameter name 'foobar' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md]
     """

--- a/features/configuration_files/reject_setting.feature
+++ b/features/configuration_files/reject_setting.feature
@@ -33,6 +33,9 @@ Feature: `reject` configuration setting
     When I run `reek -c config.reek smelly.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     smelly.rb -- 5 warnings:
       [4]:UncommunicativeMethodName: Dummy#awesome_helper has the name 'awesome_helper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
       [6]:UncommunicativeMethodName: Dummy#little_helper has the name 'little_helper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
@@ -69,6 +72,9 @@ Feature: `reject` configuration setting
     When I run `reek -c config.reek smelly.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     smelly.rb -- 5 warnings:
       [4]:UncommunicativeMethodName: Dummy#awesome_helper has the name 'awesome_helper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
       [6]:UncommunicativeMethodName: Dummy#little_helper has the name 'little_helper' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]

--- a/features/configuration_files/unused_private_method.feature
+++ b/features/configuration_files/unused_private_method.feature
@@ -30,6 +30,9 @@ Feature: Unused Private Method detector
     When I run `reek -c config.reek sample.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     sample.rb -- 1 warning:
       [4]:UnusedPrivateMethod: Outer::Smelly has the unused private instance method 'foobar' [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
     """
@@ -61,6 +64,9 @@ Feature: Unused Private Method detector
     When I run `reek -c config.reek sample.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     sample.rb -- 1 warning:
       [4]:UnusedPrivateMethod: Outer::Smelly has the unused private instance method 'foobar' [https://github.com/troessner/reek/blob/master/docs/Unused-Private-Method.md]
     """

--- a/features/configuration_loading.feature
+++ b/features/configuration_loading.feature
@@ -16,6 +16,9 @@ Feature: Offer different ways how to load configuration
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -43,6 +46,9 @@ Feature: Offer different ways how to load configuration
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 1 warning:
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
       """

--- a/features/configuration_via_source_comments/erroneous_source_comments.feature
+++ b/features/configuration_via_source_comments/erroneous_source_comments.feature
@@ -32,6 +32,9 @@ Feature: Erroneous source comments are handled properly
     And the exit status indicates smells
     And it reports:
       """
+      Inspecting 2 file(s):
+      .S
+
       smelly.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]

--- a/features/configuration_via_source_comments/well_formed_source_comments.feature
+++ b/features/configuration_via_source_comments/well_formed_source_comments.feature
@@ -15,7 +15,12 @@ Feature: Well formed source comments are handled properly
       """
     When I run reek disable_detector_implicitly.rb
     Then it succeeds
-    And it reports nothing
+    And it reports:
+      """
+      Inspecting 1 file(s):
+      .
+
+      """
 
   Scenario: Disable smell detector explicitly
     Given a file named "disable_detector_explicitly.rb" with:
@@ -30,7 +35,12 @@ Feature: Well formed source comments are handled properly
       """
     When I run reek disable_detector_explicitly.rb
     Then it succeeds
-    And it reports nothing
+    And it reports:
+      """
+      Inspecting 1 file(s):
+      .
+
+      """
 
   Scenario: Enable smell detector explicitly
     Given a file named "enable_detector_explicitly.rb" with:
@@ -47,6 +57,9 @@ Feature: Well formed source comments are handled properly
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       enable_detector_explicitly.rb -- 1 warning:
         [3]:TooManyInstanceVariables: Alfa has at least 5 instance variables [https://github.com/troessner/reek/blob/master/docs/Too-Many-Instance-Variables.md]
       """
@@ -64,7 +77,12 @@ Feature: Well formed source comments are handled properly
       """
     When I run reek configure_exclude_option.rb
     Then it succeeds
-    And it reports nothing
+    And it reports:
+      """
+      Inspecting 1 file(s):
+      .
+
+      """
 
   Scenario: Configure smell detector with the basic exclude option as regex
     Given a file named "configure_exclude_option.rb" with:
@@ -79,7 +97,12 @@ Feature: Well formed source comments are handled properly
       """
     When I run reek configure_exclude_option.rb
     Then it succeeds
-    And it reports nothing
+    And it reports:
+      """
+      Inspecting 1 file(s):
+      .
+
+      """
 
   Scenario: Configure smell detector with a detector specific option that silences it
     Given a file named "configure_detector_specific_option.rb" with:
@@ -94,7 +117,12 @@ Feature: Well formed source comments are handled properly
       """
     When I run reek configure_detector_specific_option.rb
     Then it succeeds
-    And it reports nothing
+    And it reports:
+      """
+      Inspecting 1 file(s):
+      .
+
+      """
 
   Scenario: Configure smell detector with a detector specific option that makes it report again
     Given a file named "configure_detector_specific_option.rb" with:
@@ -111,6 +139,9 @@ Feature: Well formed source comments are handled properly
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       configure_detector_specific_option.rb -- 1 warning:
         [3]:TooManyInstanceVariables: Alfa has at least 3 instance variables [https://github.com/troessner/reek/blob/master/docs/Too-Many-Instance-Variables.md]
       """

--- a/features/rake_task/rake_task.feature
+++ b/features/rake_task/rake_task.feature
@@ -14,6 +14,9 @@ Feature: Reek can be driven through its Task
     Then the exit status indicates an error
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -31,6 +34,9 @@ Feature: Reek can be driven through its Task
     Then the exit status indicates an error
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -48,6 +54,9 @@ Feature: Reek can be driven through its Task
     Then the exit status indicates an error
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -79,6 +88,9 @@ Feature: Reek can be driven through its Task
     And it succeeds
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -95,4 +107,9 @@ Feature: Reek can be driven through its Task
       end
       """
     Then it succeeds
-    And it reports nothing
+    And it reports:
+      """
+      Inspecting 1 file(s):
+      .
+
+      """

--- a/features/reports/reports.feature
+++ b/features/reports/reports.feature
@@ -9,6 +9,9 @@ Feature: Correctly formatted reports
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 2 file(s):
+      SS
+
       smelly/dirty_one.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -29,6 +32,9 @@ Feature: Correctly formatted reports
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 2 file(s):
+      SS
+
       smelly/dirty_one.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -50,6 +56,9 @@ Feature: Correctly formatted reports
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 2 file(s):
+      SS
+
       smelly/dirty_two.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -70,6 +79,9 @@ Feature: Correctly formatted reports
     Then it succeeds
     And it reports:
       """
+      Inspecting 2 file(s):
+      ..
+
       0 total warnings
       """
 
@@ -79,6 +91,9 @@ Feature: Correctly formatted reports
     Then it succeeds
     And it reports:
       """
+      Inspecting 2 file(s):
+      ..
+
       clean/clean_one.rb -- 0 warnings
       clean/clean_two.rb -- 0 warnings
       0 total warnings
@@ -95,6 +110,9 @@ Feature: Correctly formatted reports
     Then it succeeds
     And it reports:
       """
+      Inspecting 2 file(s):
+      ..
+
       0 total warnings
       """
 
@@ -109,6 +127,9 @@ Feature: Correctly formatted reports
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -126,6 +147,9 @@ Feature: Correctly formatted reports
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -143,6 +167,9 @@ Feature: Correctly formatted reports
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         smelly.rb:4: UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         smelly.rb:5: UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -161,6 +188,9 @@ Feature: Correctly formatted reports
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 2 file(s):
+      SS
+
       smelly/dirty_one.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -181,6 +211,9 @@ Feature: Correctly formatted reports
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
@@ -197,6 +230,9 @@ Feature: Correctly formatted reports
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x'
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y'
@@ -208,6 +244,9 @@ Feature: Correctly formatted reports
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]

--- a/features/samples.feature
+++ b/features/samples.feature
@@ -11,6 +11,9 @@ Feature: Basic smell detection
     Then the exit status indicates smells
     And it reports:
     """
+    Inspecting 3 file(s):
+    SSS
+
     inline.rb -- 51 warnings:
       BooleanParameter: Inline::C#parse_signature has boolean parameter 'raw' [https://github.com/troessner/reek/blob/master/docs/Boolean-Parameter.md]
       ClassVariable: Inline declares the class variable '@@directory' [https://github.com/troessner/reek/blob/master/docs/Class-Variable.md]

--- a/features/smells/subclassed_from_core_class.feature
+++ b/features/smells/subclassed_from_core_class.feature
@@ -9,6 +9,9 @@ Feature: Smell - SubclassedFromCoreClass
     When I run `reek my_hash.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     my_hash.rb -- 1 warning:
       [2]:SubclassedFromCoreClass: MyHash inherits from core class 'Hash' [https://github.com/troessner/reek/blob/master/docs/Subclassed-From-Core-Class.md]
     """

--- a/features/smells/too_many_constants.feature
+++ b/features/smells/too_many_constants.feature
@@ -14,6 +14,9 @@ Feature: Smell - TooManyConstants
     When I run `reek my_class.rb`
     Then it reports:
     """
+    Inspecting 1 file(s):
+    S
+
     my_class.rb -- 1 warning:
       [1]:TooManyConstants: MyClass has 6 constants [https://github.com/troessner/reek/blob/master/docs/Too-Many-Constants.md]
     """

--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -15,6 +15,11 @@ Given(/^a directory called 'clean' containing two clean files$/) do
   write_file('clean/clean_two.rb', contents)
 end
 
+Given(/^a directory called 'mixed_files' containing some clean and smelly files$/) do
+  write_file('mixed_files/clean.rb', CLEAN_FILE.read)
+  write_file('mixed_files/dirty.rb', SMELLY_FILE.read)
+end
+
 Given(/^a directory called 'smelly' containing two smelly files$/) do
   contents = SMELLY_FILE.read
 

--- a/features/todo_list.feature
+++ b/features/todo_list.feature
@@ -15,6 +15,9 @@ Feature:
     Then the exit status indicates smells
     And it reports:
       """
+      Inspecting 1 file(s):
+      S
+
       smelly.rb -- 2 warnings:
         [4]:UncommunicativeMethodName: Smelly#x has the name 'x' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md]
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]

--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -54,6 +54,7 @@ module Reek
       def sources
         if no_source_files_given?
           if input_was_piped?
+            disable_progress_output_unless_verbose
             source_from_pipe
           else
             working_directory_as_source
@@ -88,6 +89,10 @@ module Reek
 
       def source_from_pipe
         [$stdin]
+      end
+
+      def disable_progress_output_unless_verbose
+        options.progress_format = :quiet unless options.show_empty
       end
     end
   end

--- a/lib/reek/cli/command/report_command.rb
+++ b/lib/reek/cli/command/report_command.rb
@@ -37,7 +37,8 @@ module Reek
               warning_formatter: warning_formatter,
               report_formatter: Report::Formatter,
               sort_by_issue_count: sort_by_issue_count,
-              heading_formatter: heading_formatter)
+              heading_formatter: heading_formatter,
+              progress_formatter: progress_formatter.new(sources.length))
         end
 
         def report_class
@@ -58,6 +59,10 @@ module Reek
 
         def heading_formatter
           Report.heading_formatter(options.show_empty ? :verbose : :quiet)
+        end
+
+        def progress_formatter
+          Report.progress_formatter(options.progress_format)
         end
 
         def sort_by_issue_count

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -10,7 +10,8 @@ module Reek
     #
     # See {file:docs/Command-Line-Options.md} for details.
     #
-    # :reek:TooManyInstanceVariables: { max_instance_variables: 10 }
+    # :reek:TooManyInstanceVariables: { max_instance_variables: 11 }
+    # :reek:TooManyMethods: { max_methods: 17 }
     # :reek:Attribute: { enabled: false }
     #
     class Options
@@ -22,6 +23,7 @@ module Reek
       attr_accessor :colored,
                     :config_file,
                     :location_format,
+                    :progress_format,
                     :report_format,
                     :show_empty,
                     :show_links,
@@ -35,6 +37,7 @@ module Reek
         @parser             = OptionParser.new
         @report_format      = :text
         @location_format    = :numbers
+        @progress_format    = :dots
         @show_links         = true
         @smells_to_detect   = []
         @colored            = color_support?
@@ -113,11 +116,13 @@ module Reek
         end
       end
 
+      # :reek:TooManyStatements: { max_statements: 6 }
       def set_report_formatting_options
         parser.separator "\nText format options:"
         set_up_color_option
         set_up_verbosity_options
         set_up_location_formatting_options
+        set_up_progress_formatting_options
         set_up_sorting_option
       end
 
@@ -146,6 +151,13 @@ module Reek
         parser.on('-s', '--single-line',
                   'Show location in editor-compatible single-line-per-smell format') do
           self.location_format = :single_line
+        end
+      end
+
+      def set_up_progress_formatting_options
+        parser.on('-P', '--[no-]progress',
+                  'Show progress of each source as it is examined (default: true)') do |show_progress|
+          self.progress_format = show_progress ? :dots : :quiet
         end
       end
 

--- a/lib/reek/report.rb
+++ b/lib/reek/report.rb
@@ -2,6 +2,7 @@
 require_relative 'report/report'
 require_relative 'report/formatter'
 require_relative 'report/heading_formatter'
+require_relative 'report/progress_formatter'
 
 module Reek
   # Reek reporting functionality.
@@ -24,6 +25,11 @@ module Reek
     HEADING_FORMATTERS = {
       verbose: HeadingFormatter::Verbose,
       quiet: HeadingFormatter::Quiet
+    }.freeze
+
+    PROGRESS_FORMATTERS = {
+      dots: ProgressFormatter::Dots,
+      quiet: ProgressFormatter::Quiet
     }.freeze
 
     WARNING_FORMATTER_CLASSES = {
@@ -59,6 +65,16 @@ module Reek
     #
     def self.heading_formatter(heading_format)
       HEADING_FORMATTERS.fetch(heading_format)
+    end
+
+    # Map progress format symbol to a report class.
+    #
+    # @param [Symbol] progress_format The format to map
+    #
+    # @return The mapped progress class
+    #
+    def self.progress_formatter(progress_format)
+      PROGRESS_FORMATTERS.fetch(progress_format)
     end
 
     # Map warning format symbol to a report class.

--- a/lib/reek/report/progress_formatter.rb
+++ b/lib/reek/report/progress_formatter.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+module Reek
+  module Report
+    module ProgressFormatter
+      #
+      # Base class for progress formatters.
+      # Is responsible for formatting the progress emitted for each examiner
+      #
+      # @abstract Override {#header, #progress, #footer} to implement a progress formatter.
+      class Base
+        attr_reader :sources_count
+
+        def initialize(sources_count)
+          @sources_count = sources_count
+        end
+
+        def header
+          raise NotImplementedError
+        end
+
+        def progress(_examiner)
+          raise NotImplementedError
+        end
+
+        def footer
+          raise NotImplementedError
+        end
+      end
+
+      #
+      # Shows the status of each source as either a dot (.) or an S
+      #
+      class Dots < Base
+        NO_WARNINGS_COLOR = :green
+        WARNINGS_COLOR = :red
+
+        def header
+          print "Inspecting #{sources_count} file(s):\n"
+        end
+
+        def progress(examiner)
+          print examiner.smelly? ? display_smelly : display_clean
+        end
+
+        def footer
+          print "\n\n"
+        end
+
+        private
+
+        def display_clean
+          Rainbow('.').color(NO_WARNINGS_COLOR)
+        end
+
+        def display_smelly
+          Rainbow('S').color(WARNINGS_COLOR)
+        end
+      end
+
+      #
+      # Does not show progress
+      #
+      class Quiet < Base
+        def header
+          ''
+        end
+
+        def progress(_examiner)
+          ''
+        end
+
+        def footer
+          ''
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a revision of #983 that includes a progress formatter that can be extended in the future. As part of the work to get the specs to pass, there a few things I found irritating about the other implementation. 

Submitting this as a hopeful for being able to finally merge this in and close out the issue.