### PR TITLE
Introduce CodeCommentValidator.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,7 @@ RSpec/MultipleDescribes:
   Exclude:
     - 'spec/reek/ast/sexp_extensions_spec.rb'
     - 'spec/reek/report/location_formatter_spec.rb'
+    - 'spec/reek/code_comment_spec.rb'
 
 # FIXME: Update specs to avoid offenses
 RSpec/MultipleExpectations:

--- a/lib/reek/errors/bad_detector_in_comment_error.rb
+++ b/lib/reek/errors/bad_detector_in_comment_error.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module Errors
     # Gets raised when trying to configure a detector which is unknown to us.
@@ -21,9 +22,9 @@ module Reek
 
       EOS
 
-      def initialize(detector:, source:, line:, original_comment:)
+      def initialize(detector_name:, source:, line:, original_comment:)
         message = format(UNKNOWN_SMELL_DETECTOR_MESSAGE,
-                         detector,
+                         detector_name,
                          source,
                          line,
                          original_comment)

--- a/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
+++ b/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+
 module Reek
   module Errors
     # Gets raised when trying to use a configuration for a detector
     # that can't be parsed into a hash.
-    class BadDetectorConfigurationInCommentError < RuntimeError
+    class GarbageDetectorConfigurationInCommentError < RuntimeError
       BAD_DETECTOR_CONFIGURATION_MESSAGE = <<-EOS.freeze
 
         Error: You are trying to configure the smell detector '%s'.
@@ -20,9 +21,9 @@ module Reek
 
       EOS
 
-      def initialize(detector:, source:, line:, original_comment:)
+      def initialize(detector_name:, source:, line:, original_comment:)
         message = format(BAD_DETECTOR_CONFIGURATION_MESSAGE,
-                         detector,
+                         detector_name,
                          source,
                          line,
                          original_comment)

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 require_relative 'context_builder'
-require_relative 'source/source_code'
 require_relative 'errors/bad_detector_in_comment_error'
-require_relative 'errors/bad_detector_configuration_in_comment_error'
+require_relative 'errors/garbage_detector_configuration_in_comment_error'
 require_relative 'smell_detectors/detector_repository'
+require_relative 'source/source_code'
 
 module Reek
   #
@@ -121,7 +121,7 @@ module Reek
       begin
         examine_tree
       rescue Errors::BadDetectorInCommentError,
-             Errors::BadDetectorConfigurationInCommentError => exception
+             Errors::GarbageDetectorConfigurationInCommentError => exception
         warn exception
         []
       rescue StandardError => exception

--- a/spec/reek/code_comment_spec.rb
+++ b/spec/reek/code_comment_spec.rb
@@ -1,7 +1,5 @@
 require_relative '../spec_helper'
 require_lib 'reek/code_comment'
-require_lib 'reek/errors/bad_detector_configuration_in_comment_error'
-require_lib 'reek/errors/bad_detector_in_comment_error'
 
 RSpec.describe Reek::CodeComment do
   context 'with an empty comment' do
@@ -124,20 +122,24 @@ RSpec.describe Reek::CodeComment do
       expect(comment.send(:sanitized_comment)).to eq('Actual comment')
     end
   end
+end
 
-  context 'bad comment config' do
-    it 'raises BadDetectorInCommentError on unknown detector in comment config' do
+RSpec.describe Reek::CodeComment::CodeCommentValidator do
+  context 'bad detector' do
+    it 'raises BadDetectorInCommentError' do
       expect do
         FactoryGirl.build(:code_comment,
                           comment: '# :reek:DoesNotExist')
       end.to raise_error(Reek::Errors::BadDetectorInCommentError)
     end
+  end
 
-    it 'raises BadDetectorConfigurationInComment on garbage in comment config' do
+  context 'unparsable detector configuration' do
+    it 'raises GarbageDetectorConfigurationInCommentError' do
       expect do
         comment = '# :reek:UncommunicativeMethodName { thats: a: bad: config }'
         FactoryGirl.build(:code_comment, comment: comment)
-      end.to raise_error(Reek::Errors::BadDetectorConfigurationInCommentError)
+      end.to raise_error(Reek::Errors::GarbageDetectorConfigurationInCommentError)
     end
   end
 end


### PR DESCRIPTION
PR nr. 3 hash-tag long-flight ;)

A typical configuration via code comment looks like this:

  :reek:DuplicateMethodCall { enabled: false }

There are a lot of ways a user can introduce some errors here:

1.) Unknown smell detector
2.) Garbage in the detector configuration like { thats: a: bad: config }
3.) Unknown configuration keys (e.g. by doing a simple typo: "exclude" vs. "exlude" )
4.) Bad data types given as values for those keys
This class validates [1] and [2] at the moment but will also validate [3]
and [4] in the future.

This is basically a refactoring of the already working [1] and [2] to mitigate working on [3] and [4].
Contributes to #1102 