### PR TITLE
Emit fingerprints in Code Climate reporter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,7 @@ RSpec/VerifiedDoubles:
 # rubocop-rspec expects a CodeClimate namespace to go with the code_climate directory.
 RSpec/FilePath:
   Exclude:
+    - 'spec/reek/report/code_climate/code_climate_fingerprint_spec.rb'
     - 'spec/reek/report/code_climate/code_climate_formatter_spec.rb'
     - 'spec/reek/report/code_climate/code_climate_report_spec.rb'
 

--- a/lib/reek/report/code_climate.rb
+++ b/lib/reek/report/code_climate.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+require_relative 'code_climate/code_climate_fingerprint'
 require_relative 'code_climate/code_climate_formatter'
 require_relative 'code_climate/code_climate_report'

--- a/lib/reek/report/code_climate/code_climate_fingerprint.rb
+++ b/lib/reek/report/code_climate/code_climate_fingerprint.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+module Reek
+  module Report
+    # Generates a string to uniquely identify a smell
+    class CodeClimateFingerprint
+      NON_IDENTIFYING_PARAMETERS = [:count, :depth].freeze
+
+      def initialize(warning)
+        @warning = warning
+      end
+
+      def compute
+        return unless warning_uniquely_identifiable?
+
+        identify_warning
+
+        identifying_aspects.hexdigest
+      end
+
+      private
+
+      attr_reader :warning
+
+      def identify_warning
+        identifying_aspects << warning.source
+        identifying_aspects << warning.smell_type
+        identifying_aspects << warning.context
+        identifying_aspects << parameters
+      end
+
+      def identifying_aspects
+        @identifying_aspects ||= Digest::MD5.new
+      end
+
+      def parameters
+        warning.parameters.except(*NON_IDENTIFYING_PARAMETERS).sort.to_s
+      end
+
+      def warning_uniquely_identifiable?
+        # These could be identifiable if they had parameters
+        ![
+          'ManualDispatch',
+          'NilCheck'
+        ].include?(warning.smell_type)
+      end
+    end
+  end
+end

--- a/lib/reek/report/code_climate/code_climate_formatter.rb
+++ b/lib/reek/report/code_climate/code_climate_formatter.rb
@@ -15,6 +15,7 @@ module Reek
                             categories: categories,
                             location: location,
                             remediation_points: remediation_points,
+                            fingerprint: fingerprint,
                             content: content).render
       end
 
@@ -43,6 +44,10 @@ module Reek
 
       def remediation_points
         configuration[warning.smell_type].fetch('remediation_points')
+      end
+
+      def fingerprint
+        CodeClimateFingerprint.new(warning).compute
       end
 
       def content

--- a/spec/reek/report/code_climate/code_climate_fingerprint_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_fingerprint_spec.rb
@@ -1,0 +1,122 @@
+require_relative '../../../spec_helper'
+require_lib 'reek/report/code_climate/code_climate_fingerprint'
+
+RSpec.describe Reek::Report::CodeClimateFingerprint do
+  describe '#compute' do
+    let(:computed) { described_class.new(warning).compute }
+
+    shared_examples_for 'computes a fingerprint with no parameters' do
+      let(:expected_fingerprint) { 'e68badd29db51c92363a7c6a2438d722' }
+      let(:warning) do
+        FactoryGirl.build(:smell_warning,
+                          smell_detector: Reek::SmellDetectors::UtilityFunction.new,
+                          context:        'alfa',
+                          message:        "doesn't depend on instance state (maybe move it to another class?)",
+                          lines:          lines,
+                          source:         'a/ruby/source/file.rb')
+      end
+
+      it 'it computes the fingerprint' do
+        expect(computed).to eq expected_fingerprint
+      end
+    end
+
+    context 'with code at a specific location' do
+      let(:lines) { [1] }
+      it_should_behave_like 'computes a fingerprint with no parameters'
+    end
+
+    context 'with code at a different location' do
+      let(:lines) { [5] }
+      it_should_behave_like 'computes a fingerprint with no parameters'
+    end
+
+    context 'when the fingerprint should not be computed' do
+      let(:warning) do
+        FactoryGirl.build(:smell_warning,
+                          smell_detector: Reek::SmellDetectors::ManualDispatch.new,
+                          context:        'Alfa#bravo',
+                          message:        'manually dispatches method call',
+                          lines:          [4],
+                          source:         'a/ruby/source/file.rb')
+      end
+
+      it 'it returns nil' do
+        expect(computed).to be_nil
+      end
+    end
+
+    shared_examples_for 'computes a fingerprint with identifying parameters' do
+      let(:warning) do
+        FactoryGirl.build(:smell_warning,
+                          smell_detector: Reek::SmellDetectors::ClassVariable.new,
+                          context:        'Alfa',
+                          message:        "declares the class variable '@@#{name}'",
+                          lines:          [4],
+                          parameters:     { name: "@@#{name}" },
+                          source:         'a/ruby/source/file.rb')
+      end
+
+      it 'computes the fingerprint' do
+        expect(computed).to eq expected_fingerprint
+      end
+    end
+
+    context 'when the name is one thing it has one fingerprint' do
+      let(:name) { 'bravo' }
+      let(:expected_fingerprint) { '9c3fd378178118a67e9509f87cae24f9' }
+
+      it_should_behave_like 'computes a fingerprint with identifying parameters'
+    end
+
+    context 'when the name is another thing it has another fingerprint' do
+      let(:name) { 'echo' }
+      let(:expected_fingerprint) { 'd2a6d2703ce04cca65e7300b7de4b89f' }
+
+      it_should_behave_like 'computes a fingerprint with identifying parameters'
+    end
+
+    shared_examples_for 'computes a fingerprint with identifying and non-identifying parameters' do
+      let(:warning) do
+        FactoryGirl.build(:smell_warning,
+                          smell_detector: Reek::SmellDetectors::DuplicateMethodCall.new,
+                          context:        "Alfa##{name}",
+                          message:        "calls '#{name}' #{count} times",
+                          lines:          lines,
+                          parameters:     { name: "@@#{name}", count: count },
+                          source:         'a/ruby/source/file.rb')
+      end
+
+      it 'computes the fingerprint' do
+        expect(computed).to eq expected_fingerprint
+      end
+    end
+
+    context 'when the parameters are provided' do
+      let(:name) { 'bravo' }
+      let(:count) { 5 }
+      let(:lines) { [1, 7, 10, 13, 15] }
+      let(:expected_fingerprint) { '238733f4f51ba5473dcbe94a43ec5400' }
+
+      it_should_behave_like 'computes a fingerprint with identifying and non-identifying parameters'
+    end
+
+    context 'when the non-identifying parameters change, it computes the same fingerprint' do
+      let(:name) { 'bravo' }
+      let(:count) { 9 }
+      let(:lines) { [1, 7, 10, 13, 15, 17, 19, 20, 25] }
+      let(:expected_fingerprint) { '238733f4f51ba5473dcbe94a43ec5400' }
+
+      it_should_behave_like 'computes a fingerprint with identifying and non-identifying parameters'
+    end
+
+    context 'but when the identifying parameters change, it computes a different fingerprint' do
+      let(:name) { 'echo' }
+      let(:count) { 5 }
+      let(:lines) { [1, 7, 10, 13, 15] }
+      let(:expected_fingerprint) { 'e0c35e9223cc19bdb9a04fb3e60573e1' }
+
+      it_should_behave_like 'computes a fingerprint with identifying and non-identifying parameters'
+    end
+  end
+end

--- a/spec/reek/report/code_climate/code_climate_formatter_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_formatter_spec.rb
@@ -43,5 +43,9 @@ RSpec.describe Reek::Report::CodeClimateFormatter do
     it 'sets remediation points based on the smell detector' do
       expect(json['remediation_points']).to eq 250_000
     end
+
+    it 'sets fingerprint based on warning context' do
+      expect(json['fingerprint']).to eq '70c530e45999af129d520f1f579f967f'
+    end
   end
 end

--- a/spec/reek/report/code_climate/code_climate_report_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_report_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Reek::Report::CodeClimateReport do
  doesn't communicate its intent well enough.\\n\\nPoor names make it hard for the reader
  to build a mental picture of what's going on in the code. They can also be
  mis-interpreted; and they hurt the flow of reading, because the reader must slow down
- to interpret the names.\\n\"}}\u0000
+ to interpret the names.\\n\"},
+\"fingerprint\":\"09970037d92b5a628bf682a3e2bb126d\"}\u0000
 {\"type\":\"issue\",
 \"check_name\":\"UtilityFunction\",
 \"description\":\"simple doesn't depend on instance state (maybe move it to another class?)\",
@@ -45,8 +46,10 @@ RSpec.describe Reek::Report::CodeClimateReport do
 \"location\":{\"path\":\"string\",\"lines\":{\"begin\":1,\"end\":1}},
 \"remediation_points\":250000,
 \"content\":{\"body\":\"A _Utility Function_ is any instance method that has no
- dependency on the state of the instance.\\n\"}}\u0000
+ dependency on the state of the instance.\\n\"},
+\"fingerprint\":\"db456db7cb344bb5a98b8fc54a2f382e\"}\u0000
       EOS
+
       expect { instance.show }.to output(expected).to_stdout
     end
   end


### PR DESCRIPTION
Hi! Jumping in for @wfleming. This should close #1115.

This enables Code Climate to more accurately identify whether an issue
is new, as opposed to changed.

I chose to look at the `warning.parameters` value rather than the
`warning.message` value, because the message (for some smell types) will
change over time. For example:

If you have this code:

```ruby
class Alfa
  Bravo = Charlie = Delta = 1
end
```

You will have a warning with message "Alfa has 3 constants".

Later, when you add a 4th constant, it will change to "Alfa has 4
constants".

Ideally, this would be flagged as the same Code Climate issue, but with
a greater remediation points value, so we can flag it as getting worse.
For now, I think it's good to simply treat it as the same issue.

The way this is accomplished is by CodeClimateFingerprint maintaining a
list of parameters to ignore (:count and :depth, currently). I think
this is a good light-weight approach, but am open to the idea of moving
it somewhere else if you're concerend that may fall out-of-sync over
time.

There are two smell types which don't seem to be identifiable based on
smell_type + context + parameters, which are ManualDispatch and
NilCheck. I believe those could become identifiable if they had
parameters, but haven't done that.

What do you think?