### PR TITLE
Require digest for code climate reporter

### DIFF
--- a/lib/reek/report/code_climate/code_climate_fingerprint.rb
+++ b/lib/reek/report/code_climate/code_climate_fingerprint.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'digest'
+
 module Reek
   module Report
     # Generates a string to uniquely identify a smell
@@ -14,7 +16,7 @@ module Reek
 
         identify_warning
 
-        identifying_aspects.hexdigest
+        identifying_aspects.hexdigest.freeze
       end
 
       private


### PR DESCRIPTION
This is a follow-up to https://github.com/troessner/reek/pull/1125

Started testing this upgrade in our canary and realized that the
context where this is running, `Digest` isn't defined 😞.

While I'm here, I took the suggestion to freeze the digest from Drenmi
in the last PR. Seems sensible to me.