### PR TITLE
Remove dependency on activesupport's Hash#except

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,7 @@ RSpec/VerifiedDoubles:
 # rubocop-rspec expects a CodeClimate namespace to go with the code_climate directory.
 RSpec/FilePath:
   Exclude:
+    - 'spec/reek/report/code_climate/code_climate_configuration_spec.rb'
     - 'spec/reek/report/code_climate/code_climate_fingerprint_spec.rb'
     - 'spec/reek/report/code_climate/code_climate_formatter_spec.rb'
     - 'spec/reek/report/code_climate/code_climate_report_spec.rb'

--- a/lib/reek/report/code_climate/code_climate_configuration.rb
+++ b/lib/reek/report/code_climate/code_climate_configuration.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Reek
+  module Report
+    # loads the smell type metadata to present in Code Climate
+    module CodeClimateConfiguration
+      def self.load
+        config_file = File.expand_path('../code_climate_configuration.yml', __FILE__)
+        YAML.load_file config_file
+      end
+    end
+  end
+end

--- a/lib/reek/report/code_climate/code_climate_configuration.yml
+++ b/lib/reek/report/code_climate/code_climate_configuration.yml
@@ -222,6 +222,135 @@ FeatureEnvy:
     ```
 
     belongs to the Item class, not the Warehouse.
+InstanceVariableAssumption:
+  remediation_points: 350_000
+  content: |
+    Classes should not assume that instance variables are set or present outside of the current class definition.
+
+    Good:
+
+    ```Ruby
+    class Foo
+      def initialize
+        @bar = :foo
+      end
+
+      def foo?
+        @bar == :foo
+      end
+    end
+    ```
+
+    Good as well:
+
+    ```Ruby
+    class Foo
+      def foo?
+        bar == :foo
+      end
+
+      def bar
+        @bar ||= :foo
+      end
+    end
+    ```
+
+    Bad:
+
+    ```Ruby
+    class Foo
+      def go_foo!
+        @bar = :foo
+      end
+
+      def foo?
+        @bar == :foo
+      end
+    end
+    ```
+
+    ## Example
+
+    Running Reek on:
+
+    ```Ruby
+    class Dummy
+      def test
+        @ivar
+      end
+    end
+    ```
+
+    would report:
+
+    ```Bash
+      [1]:InstanceVariableAssumption: Dummy assumes too much for instance variable @ivar [https://github.com/troessner/reek/blob/master/docs/Instance-Variable-Assumption.md]
+    ```
+
+    Note that this example would trigger this smell warning as well:
+
+    ```Ruby
+    class Parent
+      def initialize(omg)
+        @omg = omg
+      end
+    end
+
+    class Child < Parent
+      def foo
+        @omg
+      end
+    end
+    ```
+
+    The way to address the smell warning is that you should create an `attr_reader` to use `@omg` in the subclass and not access `@omg` directly like this:
+
+    ```Ruby
+    class Parent
+      attr_reader :omg
+
+      def initialize(omg)
+        @omg = omg
+      end
+    end
+
+    class Child < Parent
+      def foo
+        omg
+      end
+    end
+    ```
+
+    Directly accessing instance variables is considered a smell because it [breaks encapsulation](http://designisrefactoring.com/2015/03/29/organizing-data-self-encapsulation/) and makes it harder to reason about code.
+
+    If you don't want to expose those methods as public API just make them private like this:
+
+    ```Ruby
+    class Parent
+      def initialize(omg)
+        @omg = omg
+      end
+
+      private
+      attr_reader :omg
+    end
+
+    class Child < Parent
+      def foo
+        omg
+      end
+    end
+    ```
+
+
+    ## Current Support in Reek
+
+    An instance variable must:
+
+    * be set in the constructor
+    * or be accessed through a method with lazy initialization / memoization.
+
+    If not, _Instance Variable Assumption_ will be reported.
 IrresponsibleModule:
   remediation_points: 350_000
   content: |
@@ -300,6 +429,33 @@ LongYieldList:
     ```
 
     A common solution to this problem would be the introduction of parameter objects.
+ManualDispatch:
+  remediation_points: 350_000
+  content: |
+    Reek reports a _Manual Dispatch_ smell if it finds source code that manually checks whether an object responds to a method before that method is called. Manual dispatch is a type of [Simulated Polymorphism](Simulated-Polymorphism.md) which leads to code that is harder to reason about, debug, and refactor.
+
+    ## Example
+
+    ```Ruby
+    class MyManualDispatcher
+      attr_reader :foo
+
+      def initialize(foo)
+        @foo = foo
+      end
+
+      def call
+        foo.bar if foo.respond_to?(:bar)
+      end
+    end
+    ```
+
+    Reek would emit the following warning:
+
+    ```
+    test.rb -- 1 warning:
+      [9]: MyManualDispatcher manually dispatches method call (ManualDispatch)
+    ```
 ModuleInitialize:
   remediation_points: 350_000
   content: |

--- a/lib/reek/report/code_climate/code_climate_fingerprint.rb
+++ b/lib/reek/report/code_climate/code_climate_fingerprint.rb
@@ -35,7 +35,7 @@ module Reek
       end
 
       def parameters
-        warning.parameters.except(*NON_IDENTIFYING_PARAMETERS).sort.to_s
+        warning.parameters.reject { |key, _| NON_IDENTIFYING_PARAMETERS.include?(key) }.sort.to_s
       end
 
       def warning_uniquely_identifiable?

--- a/lib/reek/report/code_climate/code_climate_formatter.rb
+++ b/lib/reek/report/code_climate/code_climate_formatter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'codeclimate_engine'
+require_relative 'code_climate_configuration'
 
 module Reek
   module Report
@@ -56,8 +57,7 @@ module Reek
 
       def configuration
         @configuration ||= begin
-          config_file = File.expand_path('../code_climate_configuration.yml', __FILE__)
-          YAML.load_file config_file
+          CodeClimateConfiguration.load
         end
       end
     end

--- a/spec/reek/report/code_climate/code_climate_configuration_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_configuration_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../../../spec_helper'
+require_lib 'reek/report/code_climate/code_climate_configuration'
+
+RSpec.describe Reek::Report::CodeClimateConfiguration do
+  yml = described_class.load
+  smell_types = Reek::SmellDetectors::BaseDetector.descendants.map do |descendant|
+    descendant.name.demodulize
+  end
+
+  smell_types.each do |name|
+    config = yml.fetch(name)
+    it "provides remediation_points for #{name}" do
+      expect(config['remediation_points']).to be_a Fixnum
+    end
+
+    it "provides content for #{name}" do
+      expect(config['content']).to be_a String
+    end
+  end
+
+  it 'does not include extraneous configuration' do
+    expect(smell_types).to match_array(yml.keys)
+  end
+end


### PR DESCRIPTION
Sigh, one more (I think/hope). I forgot this was added by ActiveSupport.
It's required somewhere in the specs, so it's available outside of the
specs too, but not in the non-spec-context.