### PR TITLE
Add comment spec for ModuleInitialize.

### DIFF
--- a/spec/reek/smell_detectors/module_initialize_spec.rb
+++ b/spec/reek/smell_detectors/module_initialize_spec.rb
@@ -49,4 +49,15 @@ RSpec.describe Reek::SmellDetectors::ModuleInitialize do
 
     expect(src).not_to reek_of(:ModuleInitialize)
   end
+
+  it 'can be disabled via comment' do
+    src = <<-EOS
+      # :reek:ModuleInitialize
+      module Alfa
+        def initialize; end
+      end
+    EOS
+
+    expect(src).not_to reek_of(:ModuleInitialize)
+  end
 end


### PR DESCRIPTION
Looking into #1137 I thought we should make this explicit also in our specs.