### PR TITLE
Fix gem requirements on v2.2.1 to make it compatible with ruby 1.9.3

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'parser',   '~> 2.2'
   s.add_runtime_dependency 'rainbow',  '~> 2.0'
-  s.add_runtime_dependency 'unparser', '~> 0.2.2'
+  s.add_runtime_dependency 'unparser', '~> 0.1.16'
 
   s.add_development_dependency 'activesupport', '~> 4.2'
   s.add_development_dependency 'aruba',         '~> 0.6.2'


### PR DESCRIPTION
The problem:
On rubygems.org version 2.2.1 has required ruby version >= 1.9.3, but the unparser gem required ruby 2.1.

The solution:
Use unparser version 0.1.16 which is the last one compatible with ruby 1.9.3.