### PR TITLE
Stop reporting FeatureEnvy with super and arguments

### DIFF
--- a/lib/reek/context_builder.rb
+++ b/lib/reek/context_builder.rb
@@ -19,7 +19,7 @@ module Reek
   # counting. Ideally `ContextBuilder` would only build up the context tree and leave the
   # statement and reference counting to the contexts.
   #
-  # :reek:TooManyMethods: { max_methods: 30 }
+  # :reek:TooManyMethods: { max_methods: 31 }
   # :reek:UnusedPrivateMethod: { exclude: [ !ruby/regexp /process_/ ] }
   class ContextBuilder
     attr_reader :context_tree
@@ -225,6 +225,30 @@ module Reek
     # We record one reference to `self`.
     #
     def process_zsuper(_)
+      current_context.record_use_of_self
+    end
+
+    # Handles `super` nodes a.k.a. calls to `super` with arguments
+    #
+    # An input example that would trigger this method would be:
+    #
+    #   def call_me; super(); end
+    #
+    # or
+    #
+    #   def call_me; super(bar); end
+    #
+    # but not
+    #
+    #   def call_me; super; end
+    #
+    # and not
+    #
+    #   def call_me; super do end; end
+    #
+    # We record one reference to `self`.
+    #
+    def process_super(_)
       current_context.record_use_of_self
     end
 

--- a/spec/reek/smell_detectors/feature_envy_spec.rb
+++ b/spec/reek/smell_detectors/feature_envy_spec.rb
@@ -97,6 +97,11 @@ RSpec.describe Reek::SmellDetectors::FeatureEnvy do
     expect(src).not_to reek_of(:FeatureEnvy)
   end
 
+  it 'does not report parameter method called with super ' do
+    src = 'def alfa(bravo) super(bravo.to_s); end'
+    expect(src).not_to reek_of(:FeatureEnvy)
+  end
+
   it 'ignores multiple ivars' do
     src = <<-EOS
       def func


### PR DESCRIPTION
I honestly don't know why this fixes the problem. Based on my inspection of the code, it seems like this may ensure that super is added to the context when the code is parsed so that it can be counted by the `Reek::AST::ReferenceCollector`. 

I didn't see any tests for the `CodeContext` that tested things like this so I didn't add one, but it seems like it would make sense to test these out a little bit.

It would be helpful if someone could explain what's going on here. 😄 

Per #1150