### PR TITLE
Update rubocop-rspec and fix offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,6 +65,7 @@ RSpec/MultipleExpectations:
 
 # FIXME: Update specs to avoid offenses
 RSpec/NestedGroups:
+  MaxNesting: 3
   Exclude:
     - 'spec/reek/cli/application_spec.rb'
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development do
 
   if RUBY_VERSION >= '2.3'
     gem 'rubocop',       '~> 0.46.0'
-    gem 'rubocop-rspec', '~> 1.8.0'
+    gem 'rubocop-rspec', '~> 1.9.0'
   end
 
   platforms :mri do

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :development do
 
   if RUBY_VERSION >= '2.3'
     gem 'rubocop',       '~> 0.46.0'
-    gem 'rubocop-rspec', '~> 1.7'
+    gem 'rubocop-rspec', '~> 1.8.0'
   end
 
   platforms :mri do

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development do
   end
 
   platforms :mri do
-    gem 'redcarpet', '~> 3.3.1'
+    gem 'redcarpet', '~> 3.4.0'
   end
 end
 

--- a/lib/reek/ast/reference_collector.rb
+++ b/lib/reek/ast/reference_collector.rb
@@ -6,8 +6,6 @@ module Reek
     # of an abstract syntax tree.
     #
     class ReferenceCollector
-      STOP_NODES = [:class, :module, :def, :defs].freeze
-
       def initialize(ast)
         @ast = ast
       end
@@ -22,12 +20,12 @@ module Reek
 
       def explicit_self_calls
         [:self, :super, :zsuper, :ivar, :ivasgn].flat_map do |node_type|
-          ast.each_node(node_type, STOP_NODES)
+          ast.each_node(node_type)
         end
       end
 
       def implicit_self_calls
-        ast.each_node(:send, STOP_NODES).reject(&:receiver)
+        ast.each_node(:send).reject(&:receiver)
       end
     end
   end

--- a/spec/reek/ast/reference_collector_spec.rb
+++ b/spec/reek/ast/reference_collector_spec.rb
@@ -43,22 +43,5 @@ RSpec.describe Reek::AST::ReferenceCollector do
     it 'ignores global variables' do
       expect(refs_to_self('def no_envy(arga) $s2.to_a; $s2[arga] end')).to eq(0)
     end
-
-    it 'ignores global variables' do
-      src = <<-EOS
-        def accept(t, pat = /.*/nm, &block)
-          if pat
-            pat.respond_to?(:match) or raise TypeError, "has no `match'"
-          else
-            pat = t if t.respond_to?(:match)
-          end
-          unless block
-            block = pat.method(:convert).to_proc if pat.respond_to?(:convert)
-          end
-          @atype[t] = [pat, block]
-        end
-      EOS
-      expect(refs_to_self(src)).to eq(2)
-    end
   end
 end


### PR DESCRIPTION
* Fixes config for MaxNesting offense
* Removes misleading spec
* Removes needless STOP_NODES
* Also updates RedCarpet.