### PR TITLE
Allow regular expressions in code comment configuration

### DIFF
--- a/lib/reek/code_comment.rb
+++ b/lib/reek/code_comment.rb
@@ -46,7 +46,8 @@ module Reek
                                  line:             line,
                                  source:           source,
                                  options:          options).validate
-        @config.merge! detector_name => YAML.safe_load(options || DISABLE_DETECTOR_CONFIGURATION)
+        @config.merge! detector_name => YAML.safe_load(options || DISABLE_DETECTOR_CONFIGURATION,
+                                                       [Regexp])
       end
     end
 
@@ -130,7 +131,8 @@ module Reek
       end
 
       def escalate_bad_detector_configuration
-        @parsed_options = YAML.safe_load(options || CodeComment::DISABLE_DETECTOR_CONFIGURATION)
+        @parsed_options = YAML.safe_load(options || CodeComment::DISABLE_DETECTOR_CONFIGURATION,
+                                         [Regexp])
       rescue Psych::SyntaxError
         raise Errors::GarbageDetectorConfigurationInCommentError, detector_name: detector_name,
                                                                   original_comment: original_comment,

--- a/spec/reek/code_comment_spec.rb
+++ b/spec/reek/code_comment_spec.rb
@@ -161,6 +161,13 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
           FactoryGirl.build(:code_comment, comment: comment)
         end.not_to raise_error
       end
+
+      it 'does not raise on regexps' do
+        expect do
+          comment = '# :reek:UncommunicativeMethodName { exclude: !ruby/regexp /alfa/ }'
+          FactoryGirl.build(:code_comment, comment: comment)
+        end.not_to raise_error
+      end
     end
 
     context 'unknown custom options' do


### PR DESCRIPTION
Silences warning message in our own `test:quality` rake task.