### PR TITLE
Make each check for smells a separate spec

### DIFF
--- a/spec/quality/reek_source_spec.rb
+++ b/spec/quality/reek_source_spec.rb
@@ -1,9 +1,11 @@
 require_relative '../spec_helper'
 
 RSpec.describe 'Reek source code' do
-  it 'has no smells' do
-    Pathname.glob('lib/**/*.rb').each do |pathname|
-      expect(pathname).not_to reek
+  Pathname.glob('lib/**/*.rb').each do |pathname|
+    describe pathname do
+      it 'has no smells' do
+        expect(pathname).not_to reek
+      end
     end
   end
 end


### PR DESCRIPTION
This has three effects:
- Feedback is much nicer, since RSpec will print the offending file name as part of the spec description.
- Every file will be checked, regardless of earlier failures in other files.
- Each spec takes a lot less time individually, so there's less chance of hitting the 5 second spec timeout.