### PR TITLE
Ensure arguments of a :super node are processed

### DIFF
--- a/lib/reek/context_builder.rb
+++ b/lib/reek/context_builder.rb
@@ -248,8 +248,9 @@ module Reek
     #
     # We record one reference to `self`.
     #
-    def process_super(_)
+    def process_super(exp)
       current_context.record_use_of_self
+      process(exp)
     end
 
     # Handles `block` nodes.

--- a/spec/reek/smell_detectors/feature_envy_spec.rb
+++ b/spec/reek/smell_detectors/feature_envy_spec.rb
@@ -97,9 +97,14 @@ RSpec.describe Reek::SmellDetectors::FeatureEnvy do
     expect(src).not_to reek_of(:FeatureEnvy)
   end
 
-  it 'does not report parameter method called with super ' do
+  it 'does not report parameter method called with super' do
     src = 'def alfa(bravo) super(bravo.to_s); end'
     expect(src).not_to reek_of(:FeatureEnvy)
+  end
+
+  it 'reports parameter method called with super and elsewhere' do
+    src = 'def alfa(bravo) bravo.charley; super(bravo.to_s); end'
+    expect(src).to reek_of(:FeatureEnvy)
   end
 
   it 'ignores multiple ivars' do


### PR DESCRIPTION
#1156.

Handling of the block is fine as it happens outside the the (z)super node.