### PR TITLE
Raise exceptions from the API

### DIFF
--- a/lib/reek/cli/command/report_command.rb
+++ b/lib/reek/cli/command/report_command.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative 'base_command'
 require_relative '../../examiner'
+require_relative '../../logging_error_handler'
 require_relative '../../report'
 
 module Reek
@@ -23,7 +24,8 @@ module Reek
           sources.each do |source|
             reporter.add_examiner Examiner.new(source,
                                                filter_by_smells: smell_names,
-                                               configuration: configuration)
+                                               configuration: configuration,
+                                               error_handler: LoggingErrorHandler.new)
           end
         end
 

--- a/lib/reek/errors/bad_detector_configuration_key_in_comment_error.rb
+++ b/lib/reek/errors/bad_detector_configuration_key_in_comment_error.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
+require_relative 'base_error'
 
 module Reek
   module Errors
     # Gets raised when trying to configure a detector with an option
     # which is unknown to it.
-    class BadDetectorConfigurationKeyInCommentError < RuntimeError
+    class BadDetectorConfigurationKeyInCommentError < BaseError
       UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-EOS.freeze
 
         Error: You are trying to configure the smell detector '%s'

--- a/lib/reek/errors/bad_detector_in_comment_error.rb
+++ b/lib/reek/errors/bad_detector_in_comment_error.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
+require_relative 'base_error'
 
 module Reek
   module Errors
     # Gets raised when trying to configure a detector which is unknown to us.
     # This might happen for multiple reasons. The users might have a typo in
     # his comment or he might use a detector that does not exist anymore.
-    class BadDetectorInCommentError < RuntimeError
+    class BadDetectorInCommentError < BaseError
       UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-EOS.freeze
 
         Error: You are trying to configure an unknown smell detector '%s' in one

--- a/lib/reek/errors/base_error.rb
+++ b/lib/reek/errors/base_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Reek
+  module Errors
+    # Base class for all runtime Reek errors
+    class BaseError < ::RuntimeError
+    end
+  end
+end

--- a/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
+++ b/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
+require_relative 'base_error'
 
 module Reek
   module Errors
     # Gets raised when trying to use a configuration for a detector
     # that can't be parsed into a hash.
-    class GarbageDetectorConfigurationInCommentError < RuntimeError
+    class GarbageDetectorConfigurationInCommentError < BaseError
       BAD_DETECTOR_CONFIGURATION_MESSAGE = <<-EOS.freeze
 
         Error: You are trying to configure the smell detector '%s'.

--- a/lib/reek/errors/incomprehensible_source_error.rb
+++ b/lib/reek/errors/incomprehensible_source_error.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Reek
+  module Errors
+    # Gets raised when ...
+    class IncomprehensibleSourceError < RuntimeError
+      INCOMPREHENSIBLE_SOURCE_TEMPLATE = <<-EOS.freeze
+        !!!
+        Source %s can not be processed by Reek.
+
+        This is most likely either a bug in your Reek configuration (config file or
+        source code comments) or a Reek bug.
+
+        Please double check your Reek configuration taking the original exception
+        below into account -  you might have misspelled a smell detector for instance.
+        (In the future Reek will handle configuration errors more gracefully, something
+        we are working on already).
+
+        If you feel that this is not a problem with your Reek configuration but with
+        Reek itself it would be great if you could report this back to the Reek
+        team by opening up a corresponding issue at https://github.com/troessner/reek/issues.
+
+        Please make sure to include the source in question, the Reek version
+        and the original exception below.
+
+        Exception message:
+
+        %s
+
+        Original exception:
+
+        %s
+
+        !!!
+      EOS
+
+      def initialize(origin:, original_exception:)
+        message = format(INCOMPREHENSIBLE_SOURCE_TEMPLATE,
+                         origin,
+                         original_exception.message,
+                         original_exception.backtrace.join("\n\t"))
+        super message
+      end
+    end
+  end
+end

--- a/lib/reek/errors/incomprehensible_source_error.rb
+++ b/lib/reek/errors/incomprehensible_source_error.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
+require_relative 'base_error'
 
 module Reek
   module Errors
-    # Gets raised when ...
-    class IncomprehensibleSourceError < RuntimeError
+    # Gets raised when Reek is unable to process the source
+    class IncomprehensibleSourceError < BaseError
       INCOMPREHENSIBLE_SOURCE_TEMPLATE = <<-EOS.freeze
         !!!
         Source %s can not be processed by Reek.

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 require_relative 'context_builder'
-require_relative 'errors/bad_detector_in_comment_error'
-require_relative 'errors/garbage_detector_configuration_in_comment_error'
 require_relative 'detector_repository'
+require_relative 'errors/incomprehensible_source_error'
 require_relative 'source/source_code'
+require_relative 'logging_error_handler'
 
 module Reek
   #
@@ -11,35 +11,13 @@ module Reek
   #
   # @public
   class Examiner
-    INCOMPREHENSIBLE_SOURCE_TEMPLATE = <<-EOS.freeze
-      !!!
-      Source %s can not be processed by Reek.
+    # Handles no errors
+    class NullHandler
+      def handle(_exception)
+        false
+      end
+    end
 
-      This is most likely either a bug in your Reek configuration (config file or
-      source code comments) or a Reek bug.
-
-      Please double check your Reek configuration taking the original exception
-      below into account -  you might have misspelled a smell detector for instance.
-      (In the future Reek will handle configuration errors more gracefully, something
-      we are working on already).
-
-      If you feel that this is not a problem with your Reek configuration but with
-      Reek itself it would be great if you could report this back to the Reek
-      team by opening up a corresponding issue at https://github.com/troessner/reek/issues.
-
-      Please make sure to include the source in question, the Reek version
-      and the original exception below.
-
-      Exception message:
-
-      %s
-
-      Original exception:
-
-      %s
-
-      !!!
-    EOS
     #
     # Creates an Examiner which scans the given +source+ for code smells.
     #
@@ -57,11 +35,13 @@ module Reek
     def initialize(source,
                    filter_by_smells: [],
                    configuration: Configuration::AppConfiguration.default,
-                   detector_repository_class: DetectorRepository)
+                   detector_repository_class: DetectorRepository,
+                   error_handler: LoggingErrorHandler.new)
       @source              = Source::SourceCode.from(source)
       @smell_types         = detector_repository_class.eligible_smell_types(filter_by_smells)
       @detector_repository = detector_repository_class.new(smell_types: @smell_types,
                                                            configuration: configuration.directive_for(description))
+      @error_handler       = error_handler
     end
 
     # @return [String] origin of the source being analysed
@@ -120,16 +100,9 @@ module Reek
       return [] unless syntax_tree
       begin
         examine_tree
-      rescue Errors::BadDetectorInCommentError,
-             Errors::GarbageDetectorConfigurationInCommentError,
-             Errors::BadDetectorConfigurationKeyInCommentError => exception
-        warn exception
-        []
+      # TODO: Rescue a common Reek error superclass
       rescue StandardError => exception
-        warn format(INCOMPREHENSIBLE_SOURCE_TEMPLATE,
-                    origin,
-                    exception.message,
-                    exception.backtrace.join("\n\t"))
+        raise unless @error_handler.handle exception
         []
       end
     end
@@ -142,6 +115,8 @@ module Reek
       ContextBuilder.new(syntax_tree).context_tree.flat_map do |element|
         detector_repository.examine(element)
       end
+    rescue StandardError => exception
+      raise Errors::IncomprehensibleSourceError, origin: origin, original_exception: exception
     end
   end
 end

--- a/lib/reek/logging_error_handler.rb
+++ b/lib/reek/logging_error_handler.rb
@@ -1,0 +1,22 @@
+require_relative 'errors/bad_detector_configuration_key_in_comment_error'
+require_relative 'errors/bad_detector_in_comment_error'
+require_relative 'errors/garbage_detector_configuration_in_comment_error'
+require_relative 'errors/incomprehensible_source_error'
+
+module Reek
+  # Handles selected errors by logging to stderr
+  class LoggingErrorHandler
+    def handle(exception)
+      case exception
+      when Errors::BadDetectorInCommentError,
+        Errors::GarbageDetectorConfigurationInCommentError,
+        Errors::BadDetectorConfigurationKeyInCommentError,
+        Errors::IncomprehensibleSourceError
+        warn exception
+        true
+      else
+        false
+      end
+    end
+  end
+end

--- a/lib/reek/logging_error_handler.rb
+++ b/lib/reek/logging_error_handler.rb
@@ -1,22 +1,15 @@
+# frozen_string_literal: true
 require_relative 'errors/bad_detector_configuration_key_in_comment_error'
 require_relative 'errors/bad_detector_in_comment_error'
 require_relative 'errors/garbage_detector_configuration_in_comment_error'
 require_relative 'errors/incomprehensible_source_error'
 
 module Reek
-  # Handles selected errors by logging to stderr
+  # Handles errors by logging to stderr
   class LoggingErrorHandler
     def handle(exception)
-      case exception
-      when Errors::BadDetectorInCommentError,
-        Errors::GarbageDetectorConfigurationInCommentError,
-        Errors::BadDetectorConfigurationKeyInCommentError,
-        Errors::IncomprehensibleSourceError
-        warn exception
-        true
-      else
-        false
-      end
+      warn exception
+      true
     end
   end
 end

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -122,30 +122,29 @@ RSpec.describe Reek::Examiner do
         described_class.new source
       end
 
-      it 'returns no smell warnings' do
-        Reek::CLI::Silencer.silently do
-          expect(examiner.smells).to be_empty
-        end
+      it 'raises an incomprehensible source error' do
+        expect { examiner.smells }.to raise_error Reek::Errors::IncomprehensibleSourceError
       end
 
-      it 'prints the origin' do
+      it 'explains the origin of the error' do
         origin = 'string'
-        expect { examiner.smells }.to output(/#{origin}/).to_stderr
+        expect { examiner.smells }.to raise_error.with_message(/#{origin}/)
       end
 
       it 'explains what to do' do
         explanation = 'Please double check your Reek configuration'
-        expect { examiner.smells }.to output(/#{explanation}/).to_stderr
+        expect { examiner.smells }.to raise_error.with_message(/#{explanation}/)
       end
 
-      it 'contains a message' do
+      it 'contains the original error message' do
         original = 'Looks like bad source'
-        expect { examiner.smells }.to output(/#{original}/).to_stderr
+        expect { examiner.smells }.to raise_error.with_message(/#{original}/)
       end
     end
   end
 
   describe 'bad comment config' do
+    let(:examiner) { described_class.new(source) }
     context 'unknown smell detector' do
       let(:source) do
         <<-EOS
@@ -154,21 +153,21 @@ RSpec.describe Reek::Examiner do
         EOS
       end
 
-      it 'prints out a proper message' do
-        expected_output = "You are trying to configure an unknown smell detector 'DoesNotExist'"
-
-        expect do
-          described_class.new(source).smells
-        end.to output(/#{expected_output}/).to_stderr
+      it 'raises a bad detector name error' do
+        expect { examiner.smells }.to raise_error Reek::Errors::BadDetectorInCommentError
       end
 
-      it 'prints out a line and a source' do
-        expected_output = "The source is 'string' and the comment belongs "\
-                          'to the expression starting in line 2.'
+      it 'explains the reason for the error' do
+        message = "You are trying to configure an unknown smell detector 'DoesNotExist'"
 
-        expect do
-          described_class.new(source).smells
-        end.to output(/#{expected_output}/).to_stderr
+        expect { examiner.smells }.to raise_error.with_message(/#{message}/)
+      end
+
+      it 'explains the origin of the error' do
+        details = "The source is 'string' and the comment belongs "\
+                  'to the expression starting in line 2.'
+
+        expect { examiner.smells }.to raise_error.with_message(/#{details}/)
       end
     end
 
@@ -180,21 +179,21 @@ RSpec.describe Reek::Examiner do
         EOS
       end
 
-      it 'prints out a proper message' do
-        expected_output = "Error: You are trying to configure the smell detector 'UncommunicativeMethodName'"
-
-        expect do
-          described_class.new(source).smells
-        end.to output(/#{expected_output}/).to_stderr
+      it 'raises a garbarge configuration error' do
+        expect { examiner.smells }.to raise_error Reek::Errors::GarbageDetectorConfigurationInCommentError
       end
 
-      it 'prints out a line and a source' do
-        expected_output = "The source is 'string' and "\
-                          'the comment belongs to the expression starting in line 2'
+      it 'explains the reason for the error' do
+        message = "Error: You are trying to configure the smell detector 'UncommunicativeMethodName'"
 
-        expect do
-          described_class.new(source).smells
-        end.to output(/#{expected_output}/).to_stderr
+        expect { examiner.smells }.to raise_error.with_message(/#{message}/)
+      end
+
+      it 'explains the origin of the error' do
+        details = "The source is 'string' and the comment belongs "\
+                  'to the expression starting in line 2.'
+
+        expect { examiner.smells }.to raise_error.with_message(/#{details}/)
       end
     end
   end

--- a/spec/reek/logging_error_handler_spec.rb
+++ b/spec/reek/logging_error_handler_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../spec_helper'
+require_lib 'reek/logging_error_handler'
+
+RSpec.describe Reek::LoggingErrorHandler do
+  describe '#handle' do
+    let(:exception) { RuntimeError.new('some message') }
+    let(:handler) { described_class.new }
+
+    it "outputs the exception's message to stderr" do
+      expect { handler.handle(exception) }.
+        to output(/some message/).to_stderr
+    end
+
+    it 'indicates the exception has been appropriately handled' do
+      result = false
+
+      Reek::CLI::Silencer.silently do
+        result = handler.handle(exception)
+      end
+
+      expect(result).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
This was inspired by the problem fixed by #1171: That particular problem did not result in a build failure because there was only some output during the `test:quality` task, but spec itself passed.

So, what does this do? Instead of always logging exceptions in `Examiner`, we can pass in a handler object. By default, the handler doesn't handle any exceptions so they are all re-raised. However, in the configuration used when we actually run Reek, a logging handler gets passed that handles the exception by logging it, so they exceptions are not re-raised, resulting in the original behavior in that case.