### PR TITLE
Re-raise parse errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,7 +53,6 @@ RSpec/ExampleLength:
 RSpec/ExpectOutput:
   Exclude:
     - 'spec/reek/cli/command/todo_list_command_spec.rb'
-    - 'spec/reek/source/source_code_spec.rb'
 
 # FIXME: Split up files to avoid offenses
 RSpec/MultipleDescribes:

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development do
 
   if RUBY_VERSION >= '2.3'
     gem 'rubocop',       '~> 0.47.1'
-    gem 'rubocop-rspec', '~> 1.10.0'
+    gem 'rubocop-rspec', '~> 1.11.0'
   end
 
   platforms :mri do

--- a/features/command_line_interface/stdin.feature
+++ b/features/command_line_interface/stdin.feature
@@ -35,5 +35,5 @@ Feature: Reek reads from $stdin when no files are given
   Scenario: syntax error causes the source to be ignored
     When I pass "= invalid syntax =" to reek
     Then it reports a parsing error
-    Then it succeeds
+    And the exit status indicates an error
     And it reports nothing

--- a/lib/reek/errors/parse_error.rb
+++ b/lib/reek/errors/parse_error.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require_relative 'base_error'
+
+module Reek
+  module Errors
+    # Gets raised when Reek is unable to process the source
+    class ParseError < BaseError
+      MESSAGE_TEMPLATE = '%s: %s: %s'.freeze
+
+      def initialize(origin:, original_exception:)
+        message = format(MESSAGE_TEMPLATE,
+                         origin,
+                         original_exception.class.name,
+                         original_exception.message)
+        super message
+      end
+    end
+  end
+end

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -5,6 +5,7 @@ Reek::CLI::Silencer.silently do
 end
 require_relative '../tree_dresser'
 require_relative '../ast/node'
+require_relative '../errors/parse_error'
 
 # Opt in to new way of representing lambdas
 Parser::Builders::Default.emit_lambda = true
@@ -87,7 +88,7 @@ module Reek
             begin
               ast, comments = parser.parse_with_comments(source, origin)
             rescue Racc::ParseError, Parser::SyntaxError => error
-              $stderr.puts "#{origin}: #{error.class.name}: #{error}"
+              raise Errors::ParseError, origin: origin, original_exception: error
             end
 
             # See https://whitequark.github.io/parser/Parser/Source/Comment/Associator.html

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -26,36 +26,15 @@ RSpec.describe Reek::Source::SourceCode do
   end
 
   context 'when the parser fails' do
-    let(:catcher) { StringIO.new }
     let(:source_name) { 'Test source' }
     let(:error_message) { 'Error message' }
     let(:parser) { class_double(Parser::Ruby23) }
     let(:src) { described_class.new(code: '', origin: source_name, parser: parser) }
 
-    before { $stderr = catcher }
-
     shared_examples_for 'handling and recording the error' do
-      it 'does not raise an error' do
-        src.syntax_tree
-      end
-
-      it 'returns an empty syntax tree' do
-        expect(src.syntax_tree).to be_nil
-      end
-
-      it 'records the syntax error' do
-        src.syntax_tree
-        expect(catcher.string).to match(error_class.name)
-      end
-
-      it 'records the source name' do
-        src.syntax_tree
-        expect(catcher.string).to match(source_name)
-      end
-
-      it 'records the error message' do
-        src.syntax_tree
-        expect(catcher.string).to match(error_message)
+      it 'raises an informative error' do
+        expect { src.syntax_tree }.
+          to raise_error(/#{source_name}: #{error_class.name}: #{error_message}/)
       end
     end
 
@@ -91,10 +70,8 @@ RSpec.describe Reek::Source::SourceCode do
       end
 
       it 'raises the error' do
-        expect { src.syntax_tree }.to raise_error
+        expect { src.syntax_tree }.to raise_error error_class
       end
     end
-
-    after { $stderr = STDERR }
   end
 end


### PR DESCRIPTION
To keep things consistent, also let parse errors bubble up to Examiner#run, just like config and processing errors.