### PR TITLE
Improve TodoListCommand specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,11 +49,6 @@ RSpec/DescribeClass:
 RSpec/ExampleLength:
   Enabled: false
 
-# FIXME: Find a better way to block output during specs, and fix relevant examples.
-RSpec/ExpectOutput:
-  Exclude:
-    - 'spec/reek/cli/command/todo_list_command_spec.rb'
-
 # FIXME: Split up files to avoid offenses
 RSpec/MultipleDescribes:
   Exclude:

--- a/features/todo_list.feature
+++ b/features/todo_list.feature
@@ -1,5 +1,4 @@
-Feature:
-
+Feature: Auto-generate a todo file
   Write a Reek configuration as a kind of todo list that will prevent Reek
   from reporting smells on the current code.
   This can then be worked on later on.

--- a/spec/reek/cli/command/todo_list_command_spec.rb
+++ b/spec/reek/cli/command/todo_list_command_spec.rb
@@ -4,34 +4,25 @@ require_lib 'reek/cli/options'
 
 RSpec.describe Reek::CLI::Command::TodoListCommand do
   let(:nil_check) { build :smell_detector, smell_type: :NilCheck }
-  let(:feature_envy) { build :smell_detector, smell_type: :FeatureEnvy }
   let(:nested_iterators) { build :smell_detector, smell_type: :NestedIterators }
-  let(:too_many_statements) { build :smell_detector, smell_type: :TooManyStatements }
 
   describe '#execute' do
     let(:options) { Reek::CLI::Options.new [] }
     let(:configuration) { instance_double 'Reek::Configuration::AppConfiguration' }
+    let(:sources) { [source_file] }
 
     let(:command) do
       described_class.new(options: options,
-                          sources: [],
+                          sources: sources,
                           configuration: configuration)
     end
 
     before do
-      $stdout = StringIO.new
-      allow(File).to receive(:write)
-    end
-
-    after do
-      $stdout = STDOUT
+      allow(File).to receive(:write).with(described_class::FILE_NAME, String)
     end
 
     context 'smells found' do
-      before do
-        smells = [build(:smell_warning, context: 'Foo#bar')]
-        allow(command).to receive(:scan_for_smells).and_return(smells)
-      end
+      let(:source_file) { SMELLY_FILE }
 
       it 'shows a proper message' do
         expected = "\n'.todo.reek' generated! You can now use this as a starting point for your configuration.\n"
@@ -39,70 +30,22 @@ RSpec.describe Reek::CLI::Command::TodoListCommand do
       end
 
       it 'returns a success code' do
-        result = command.execute
+        result = Reek::CLI::Silencer.silently { command.execute }
         expect(result).to eq(Reek::CLI::Status::DEFAULT_SUCCESS_EXIT_CODE)
       end
 
-      it 'writes a todo file' do
-        command.execute
-        expected_yaml = { 'FeatureEnvy' => { 'exclude' => ['Foo#bar'] } }.to_yaml
-        expect(File).to have_received(:write).with(described_class::FILE_NAME, expected_yaml)
-      end
-    end
-
-    context 'smells with duplicate context found' do
-      before do
-        smells = [
-          build(:smell_warning, context: 'Foo#bar', smell_detector: feature_envy),
-          build(:smell_warning, context: 'Foo#bar', smell_detector: feature_envy)
-        ]
-        allow(command).to receive(:scan_for_smells).and_return(smells)
-      end
-
-      it 'writes the context into the todo file once' do
-        command.execute
-        expected_yaml = { 'FeatureEnvy' => { 'exclude' => ['Foo#bar'] } }.to_yaml
-        expect(File).to have_received(:write).with(described_class::FILE_NAME, expected_yaml)
-      end
-    end
-
-    context 'smells with default exclusions found' do
-      let(:smell) { build :smell_warning, smell_detector: too_many_statements, context: 'Foo#bar' }
-
-      before do
-        allow(command).to receive(:scan_for_smells).and_return [smell]
-      end
-
-      it 'includes the default exclusions in the generated yaml' do
-        command.execute
-        expected_yaml = { 'TooManyStatements' => { 'exclude' => ['initialize', 'Foo#bar'] } }.to_yaml
-        expect(File).to have_received(:write).with(described_class::FILE_NAME, expected_yaml)
-      end
-    end
-
-    context 'smells of different types found' do
-      before do
-        smells = [
-          build(:smell_warning, context: 'Foo#bar', smell_detector: nil_check),
-          build(:smell_warning, context: 'Bar#baz', smell_detector: nested_iterators)
-        ]
-        allow(command).to receive(:scan_for_smells).and_return(smells)
-      end
-
-      it 'writes the context into the todo file once' do
-        command.execute
+      it 'writes a todo file with exclusions for each smell' do
+        Reek::CLI::Silencer.silently { command.execute }
         expected_yaml = {
-          'NilCheck' => { 'exclude' => ['Foo#bar'] },
-          'NestedIterators' => { 'exclude' => ['Bar#baz'] }
+          'UncommunicativeMethodName' => { 'exclude' => ['Smelly#x'] },
+          'UncommunicativeVariableName' => { 'exclude' => ['Smelly#x'] }
         }.to_yaml
         expect(File).to have_received(:write).with(described_class::FILE_NAME, expected_yaml)
       end
     end
 
     context 'no smells found' do
-      before do
-        allow(command).to receive(:scan_for_smells).and_return []
-      end
+      let(:source_file) { CLEAN_FILE }
 
       it 'shows a proper message' do
         expected = "\n'.todo.reek' not generated because there were no smells found!\n"
@@ -110,12 +53,12 @@ RSpec.describe Reek::CLI::Command::TodoListCommand do
       end
 
       it 'returns a success code' do
-        result = command.execute
+        result = Reek::CLI::Silencer.silently { command.execute }
         expect(result).to eq Reek::CLI::Status::DEFAULT_SUCCESS_EXIT_CODE
       end
 
       it 'does not write a todo file' do
-        command.execute
+        Reek::CLI::Silencer.silently { command.execute }
         expect(File).not_to have_received(:write)
       end
     end


### PR DESCRIPTION
- Remove specs that duplicate specs for BaseDetector
- Avoid mocking a method on the object under test
- Narrow the spy on File
- Use Reek's own silencer instead of stream re-assignment
- Give cuke feature a name