### PR TITLE
Ensure Timeout is known

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'timeout'
 require_relative '../lib/reek'
 require_relative '../lib/reek/spec'
 require_relative '../lib/reek/ast/ast_node_class_map'


### PR DESCRIPTION
This ensures individual specs can be run using `rspec something_spec.rb`.