### PR TITLE
Update rubocop and fix offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,10 @@ AllCops:
     - 'vendor/**/*'
   TargetRubyVersion: 2.1
 
+# Assume the programmer knows how bracketed block syntax works
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
 Lint/HandleExceptions:
   Exclude:
     - 'spec/reek/configuration/configuration_file_finder_spec.rb'
@@ -106,6 +110,10 @@ Style/FrozenStringLiteralComment:
     - 'lib/**/*'
   EnforcedStyle: always
 
+# Use active_support's strip_heredoc to indent heredocs
+Style/IndentHeredoc:
+  EnforcedStyle: active_support
+
 # Allow multiline block chains
 Style/MultilineBlockChain:
   Enabled: false
@@ -126,6 +134,14 @@ Style/MultilineOperationIndentation:
 Style/ParallelAssignment:
   Enabled: false
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    default: ()
+    '%W': ()
+    '%I': ()
+    '%w': ()
+    '%i': ()
+
 # Allow Perl-style references to regex matches
 Style/PerlBackrefs:
   Enabled: false
@@ -133,6 +149,10 @@ Style/PerlBackrefs:
 # Allow single-line method definitions
 Style/SingleLineMethods:
   Enabled: false
+
+# Prefer symbols to look like symbols
+Style/SymbolArray:
+  EnforcedStyle: brackets
 
 # Allow small arrays of words with quotes
 Style/WordArray:

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ group :development do
   gem 'yard',          '~> 0.9.5'
 
   if RUBY_VERSION >= '2.3'
-    gem 'rubocop',       '~> 0.47.1'
-    gem 'rubocop-rspec', '~> 1.13.0'
+    gem 'rubocop',       '~> 0.48.1'
+    gem 'rubocop-rspec', '~> 1.15.0'
   end
 
   platforms :mri do

--- a/bin/code_climate_reek
+++ b/bin/code_climate_reek
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 #
 # Wrapper for the CodeClimate integration.
 

--- a/bin/reek
+++ b/bin/reek
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
+
 #
 # Reek examines Ruby source code for smells.
 # Visit https://wiki.github.com/troessner/reek for docs etc.

--- a/lib/reek.rb
+++ b/lib/reek.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #
 # Reek's core functionality
 #

--- a/lib/reek/ast/ast_node_class_map.rb
+++ b/lib/reek/ast/ast_node_class_map.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'node'
 require_relative 'sexp_extensions'
 

--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../cli/silencer'
 
 Reek::CLI::Silencer.silently do

--- a/lib/reek/ast/object_refs.rb
+++ b/lib/reek/ast/object_refs.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   # Represents functionality related to an Abstract Syntax Tree.
   module AST

--- a/lib/reek/ast/reference_collector.rb
+++ b/lib/reek/ast/reference_collector.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     #

--- a/lib/reek/ast/sexp_extensions.rb
+++ b/lib/reek/ast/sexp_extensions.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'reference_collector'
 
 require_relative 'sexp_extensions/arguments'

--- a/lib/reek/ast/sexp_extensions/arguments.rb
+++ b/lib/reek/ast/sexp_extensions/arguments.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/attribute_assignments.rb
+++ b/lib/reek/ast/sexp_extensions/attribute_assignments.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/block.rb
+++ b/lib/reek/ast/sexp_extensions/block.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/case.rb
+++ b/lib/reek/ast/sexp_extensions/case.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/constant.rb
+++ b/lib/reek/ast/sexp_extensions/constant.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/if.rb
+++ b/lib/reek/ast/sexp_extensions/if.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/lambda.rb
+++ b/lib/reek/ast/sexp_extensions/lambda.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/literal.rb
+++ b/lib/reek/ast/sexp_extensions/literal.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/logical_operators.rb
+++ b/lib/reek/ast/sexp_extensions/logical_operators.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/methods.rb
+++ b/lib/reek/ast/sexp_extensions/methods.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/module.rb
+++ b/lib/reek/ast/sexp_extensions/module.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/nested_assignables.rb
+++ b/lib/reek/ast/sexp_extensions/nested_assignables.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/self.rb
+++ b/lib/reek/ast/sexp_extensions/self.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/send.rb
+++ b/lib/reek/ast/sexp_extensions/send.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/super.rb
+++ b/lib/reek/ast/sexp_extensions/super.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/symbols.rb
+++ b/lib/reek/ast/sexp_extensions/symbols.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/variables.rb
+++ b/lib/reek/ast/sexp_extensions/variables.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/when.rb
+++ b/lib/reek/ast/sexp_extensions/when.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/ast/sexp_extensions/yield.rb
+++ b/lib/reek/ast/sexp_extensions/yield.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module AST
     module SexpExtensions

--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'options'
 require_relative 'status'
 require_relative '../configuration/app_configuration'

--- a/lib/reek/cli/command/base_command.rb
+++ b/lib/reek/cli/command/base_command.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module CLI
     module Command

--- a/lib/reek/cli/command/report_command.rb
+++ b/lib/reek/cli/command/report_command.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_command'
 require_relative '../../examiner'
 require_relative '../../logging_error_handler'

--- a/lib/reek/cli/command/todo_list_command.rb
+++ b/lib/reek/cli/command/todo_list_command.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_command'
 require_relative '../../examiner'
 

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'optparse'
 require 'rainbow'
 require_relative '../version'

--- a/lib/reek/cli/silencer.rb
+++ b/lib/reek/cli/silencer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'stringio'
 
 module Reek

--- a/lib/reek/cli/status.rb
+++ b/lib/reek/cli/status.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module CLI
     module Status

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'pathname'
 require_relative './configuration_file_finder'
 require_relative './configuration_validator'

--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'pathname'
 
 module Reek

--- a/lib/reek/configuration/configuration_validator.rb
+++ b/lib/reek/configuration/configuration_validator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module Configuration
     #

--- a/lib/reek/configuration/default_directive.rb
+++ b/lib/reek/configuration/default_directive.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module Configuration
     #

--- a/lib/reek/configuration/directory_directives.rb
+++ b/lib/reek/configuration/directory_directives.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative './configuration_validator'
 
 module Reek

--- a/lib/reek/configuration/excluded_paths.rb
+++ b/lib/reek/configuration/excluded_paths.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative './configuration_validator'
 
 module Reek

--- a/lib/reek/context/attribute_context.rb
+++ b/lib/reek/context/attribute_context.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'code_context'
 
 module Reek

--- a/lib/reek/context/class_context.rb
+++ b/lib/reek/context/class_context.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'module_context'
 
 module Reek

--- a/lib/reek/context/code_context.rb
+++ b/lib/reek/context/code_context.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../code_comment'
 require_relative '../ast/object_refs'
 require_relative 'statement_counter'
@@ -19,7 +20,7 @@ module Reek
       include Enumerable
       extend Forwardable
       delegate each_node: :exp
-      delegate %i(name type) => :exp
+      delegate [:name, :type] => :exp
 
       attr_reader :children, :parent, :exp, :statement_counter
 

--- a/lib/reek/context/ghost_context.rb
+++ b/lib/reek/context/ghost_context.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'code_context'
 require_relative 'singleton_method_context'
 

--- a/lib/reek/context/method_context.rb
+++ b/lib/reek/context/method_context.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'code_context'
 
 module Reek
@@ -40,10 +41,10 @@ module Reek
 
       # :reek:FeatureEnvy
       def unused_params
-        exp.arguments.select do |param|
-          next if param.anonymous_splat?
-          next if param.marked_unused?
-          !uses_param? param.plain_name
+        exp.arguments.reject do |param|
+          param.anonymous_splat? ||
+            param.marked_unused? ||
+            uses_param?(param.plain_name)
         end
       end
 

--- a/lib/reek/context/module_context.rb
+++ b/lib/reek/context/module_context.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'code_context'
 require_relative 'attribute_context'
 require_relative 'method_context'

--- a/lib/reek/context/root_context.rb
+++ b/lib/reek/context/root_context.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'code_context'
 require_relative 'method_context'
 

--- a/lib/reek/context/send_context.rb
+++ b/lib/reek/context/send_context.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'code_context'
 
 module Reek

--- a/lib/reek/context/singleton_attribute_context.rb
+++ b/lib/reek/context/singleton_attribute_context.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'attribute_context'
 
 module Reek

--- a/lib/reek/context/singleton_method_context.rb
+++ b/lib/reek/context/singleton_method_context.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'method_context'
 
 module Reek

--- a/lib/reek/context/statement_counter.rb
+++ b/lib/reek/context/statement_counter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../ast/node'
 
 module Reek

--- a/lib/reek/context/visibility_tracker.rb
+++ b/lib/reek/context/visibility_tracker.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module Context
     # Responsible for tracking visibilities in regards to CodeContexts.

--- a/lib/reek/context_builder.rb
+++ b/lib/reek/context_builder.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'context/attribute_context'
 require_relative 'context/class_context'
 require_relative 'context/ghost_context'

--- a/lib/reek/detector_repository.rb
+++ b/lib/reek/detector_repository.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'smell_detectors'
 require_relative 'smell_detectors/base_detector'
 require_relative 'configuration/app_configuration'

--- a/lib/reek/errors/bad_detector_configuration_key_in_comment_error.rb
+++ b/lib/reek/errors/bad_detector_configuration_key_in_comment_error.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_error'
 
 module Reek

--- a/lib/reek/errors/bad_detector_in_comment_error.rb
+++ b/lib/reek/errors/bad_detector_in_comment_error.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_error'
 
 module Reek

--- a/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
+++ b/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_error'
 
 module Reek

--- a/lib/reek/errors/incomprehensible_source_error.rb
+++ b/lib/reek/errors/incomprehensible_source_error.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_error'
 
 module Reek

--- a/lib/reek/errors/parse_error.rb
+++ b/lib/reek/errors/parse_error.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_error'
 
 module Reek

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'context_builder'
 require_relative 'detector_repository'
 require_relative 'errors/incomprehensible_source_error'

--- a/lib/reek/logging_error_handler.rb
+++ b/lib/reek/logging_error_handler.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'errors/bad_detector_configuration_key_in_comment_error'
 require_relative 'errors/bad_detector_in_comment_error'
 require_relative 'errors/garbage_detector_configuration_in_comment_error'

--- a/lib/reek/report.rb
+++ b/lib/reek/report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'report/code_climate'
 require_relative 'report/html_report'
 require_relative 'report/json_report'

--- a/lib/reek/report/base_report.rb
+++ b/lib/reek/report/base_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'json'
 require 'pathname'
 require 'rainbow'

--- a/lib/reek/report/code_climate.rb
+++ b/lib/reek/report/code_climate.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'code_climate/code_climate_fingerprint'
 require_relative 'code_climate/code_climate_formatter'
 require_relative 'code_climate/code_climate_report'

--- a/lib/reek/report/code_climate/code_climate_configuration.rb
+++ b/lib/reek/report/code_climate/code_climate_configuration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module Report
     # loads the smell type metadata to present in Code Climate

--- a/lib/reek/report/code_climate/code_climate_fingerprint.rb
+++ b/lib/reek/report/code_climate/code_climate_fingerprint.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'digest'
 
 module Reek

--- a/lib/reek/report/code_climate/code_climate_formatter.rb
+++ b/lib/reek/report/code_climate/code_climate_formatter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'codeclimate_engine'
 require_relative 'code_climate_configuration'
 

--- a/lib/reek/report/code_climate/code_climate_report.rb
+++ b/lib/reek/report/code_climate/code_climate_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../base_report'
 
 module Reek

--- a/lib/reek/report/formatter.rb
+++ b/lib/reek/report/formatter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'code_climate/code_climate_formatter'
 require_relative 'formatter/heading_formatter'
 require_relative 'formatter/location_formatter'

--- a/lib/reek/report/formatter/heading_formatter.rb
+++ b/lib/reek/report/formatter/heading_formatter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module Report
     module Formatter

--- a/lib/reek/report/formatter/location_formatter.rb
+++ b/lib/reek/report/formatter/location_formatter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module Report
     module Formatter

--- a/lib/reek/report/formatter/progress_formatter.rb
+++ b/lib/reek/report/formatter/progress_formatter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module Report
     module Formatter

--- a/lib/reek/report/formatter/wiki_link_warning_formatter.rb
+++ b/lib/reek/report/formatter/wiki_link_warning_formatter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'simple_warning_formatter'
 
 module Reek

--- a/lib/reek/report/html_report.rb
+++ b/lib/reek/report/html_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_report'
 
 module Reek

--- a/lib/reek/report/json_report.rb
+++ b/lib/reek/report/json_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_report'
 
 module Reek

--- a/lib/reek/report/text_report.rb
+++ b/lib/reek/report/text_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_report'
 
 module Reek

--- a/lib/reek/report/xml_report.rb
+++ b/lib/reek/report/xml_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_report'
 
 module Reek

--- a/lib/reek/report/yaml_report.rb
+++ b/lib/reek/report/yaml_report.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_report'
 
 module Reek

--- a/lib/reek/smell_configuration.rb
+++ b/lib/reek/smell_configuration.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   #
   # Represents a single set of configuration options for a smell detector

--- a/lib/reek/smell_detectors.rb
+++ b/lib/reek/smell_detectors.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'smell_detectors/attribute'
 require_relative 'smell_detectors/boolean_parameter'
 require_relative 'smell_detectors/class_variable'

--- a/lib/reek/smell_detectors/attribute.rb
+++ b/lib/reek/smell_detectors/attribute.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/base_detector.rb
+++ b/lib/reek/smell_detectors/base_detector.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'set'
 require_relative '../smell_warning'
 require_relative '../smell_configuration'

--- a/lib/reek/smell_detectors/boolean_parameter.rb
+++ b/lib/reek/smell_detectors/boolean_parameter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/class_variable.rb
+++ b/lib/reek/smell_detectors/class_variable.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'set'
 require_relative 'base_detector'
 

--- a/lib/reek/smell_detectors/control_parameter.rb
+++ b/lib/reek/smell_detectors/control_parameter.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/data_clump.rb
+++ b/lib/reek/smell_detectors/data_clump.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/duplicate_method_call.rb
+++ b/lib/reek/smell_detectors/duplicate_method_call.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/feature_envy.rb
+++ b/lib/reek/smell_detectors/feature_envy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/instance_variable_assumption.rb
+++ b/lib/reek/smell_detectors/instance_variable_assumption.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/irresponsible_module.rb
+++ b/lib/reek/smell_detectors/irresponsible_module.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/long_parameter_list.rb
+++ b/lib/reek/smell_detectors/long_parameter_list.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/long_yield_list.rb
+++ b/lib/reek/smell_detectors/long_yield_list.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/manual_dispatch.rb
+++ b/lib/reek/smell_detectors/manual_dispatch.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/module_initialize.rb
+++ b/lib/reek/smell_detectors/module_initialize.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/nested_iterators.rb
+++ b/lib/reek/smell_detectors/nested_iterators.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/nil_check.rb
+++ b/lib/reek/smell_detectors/nil_check.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/prima_donna_method.rb
+++ b/lib/reek/smell_detectors/prima_donna_method.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/repeated_conditional.rb
+++ b/lib/reek/smell_detectors/repeated_conditional.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../ast/node'
 require_relative 'base_detector'
 

--- a/lib/reek/smell_detectors/subclassed_from_core_class.rb
+++ b/lib/reek/smell_detectors/subclassed_from_core_class.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/too_many_constants.rb
+++ b/lib/reek/smell_detectors/too_many_constants.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/too_many_instance_variables.rb
+++ b/lib/reek/smell_detectors/too_many_instance_variables.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/too_many_methods.rb
+++ b/lib/reek/smell_detectors/too_many_methods.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/too_many_statements.rb
+++ b/lib/reek/smell_detectors/too_many_statements.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/uncommunicative_method_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_method_name.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/uncommunicative_module_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_module_name.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/uncommunicative_parameter_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_parameter_name.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/uncommunicative_variable_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_variable_name.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/unused_parameters.rb
+++ b/lib/reek/smell_detectors/unused_parameters.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek

--- a/lib/reek/smell_detectors/unused_private_method.rb
+++ b/lib/reek/smell_detectors/unused_private_method.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'base_detector'
 
 module Reek
@@ -67,8 +68,8 @@ module Reek
         defined_private_methods = ctx.defined_instance_methods(visibility: :private)
         called_method_names     = ctx.instance_method_calls.map(&:name)
 
-        defined_private_methods.select do |defined_method|
-          !called_method_names.include?(defined_method.name)
+        defined_private_methods.reject do |defined_method|
+          called_method_names.include?(defined_method.name)
         end
       end
 

--- a/lib/reek/smell_detectors/utility_function.rb
+++ b/lib/reek/smell_detectors/utility_function.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../ast/reference_collector'
 require_relative 'base_detector'
 

--- a/lib/reek/smell_warning.rb
+++ b/lib/reek/smell_warning.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'forwardable'
 
 module Reek

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../cli/silencer'
 Reek::CLI::Silencer.silently do
   require 'parser/ruby23'

--- a/lib/reek/source/source_locator.rb
+++ b/lib/reek/source/source_locator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'find'
 require 'pathname'
 

--- a/lib/reek/spec.rb
+++ b/lib/reek/spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'spec/should_reek'
 require_relative 'spec/should_reek_of'
 require_relative 'spec/should_reek_only_of'

--- a/lib/reek/spec/should_reek.rb
+++ b/lib/reek/spec/should_reek.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../examiner'
 require_relative '../report/formatter'
 

--- a/lib/reek/spec/should_reek_of.rb
+++ b/lib/reek/spec/should_reek_of.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../examiner'
 require_relative 'smell_matcher'
 

--- a/lib/reek/spec/should_reek_only_of.rb
+++ b/lib/reek/spec/should_reek_only_of.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative '../examiner'
 require_relative '../report/formatter'
 require_relative 'should_reek_of'

--- a/lib/reek/spec/smell_matcher.rb
+++ b/lib/reek/spec/smell_matcher.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Reek
   module Spec
     #
@@ -7,7 +8,7 @@ module Reek
     class SmellMatcher
       attr_reader :smell_warning
 
-      COMPARABLE_ATTRIBUTES = %i(message lines context source).freeze
+      COMPARABLE_ATTRIBUTES = [:message, :lines, :context, :source].freeze
 
       def initialize(smell_warning)
         @smell_warning = smell_warning

--- a/lib/reek/tree_dresser.rb
+++ b/lib/reek/tree_dresser.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative 'ast/ast_node_class_map'
 
 module Reek

--- a/lib/reek/version.rb
+++ b/lib/reek/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # @public
 module Reek
   #

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+
 require File.join(File.dirname(__FILE__), 'lib/reek/version')
 
 Gem::Specification.new do |s|

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -253,6 +253,7 @@ end
 
 RSpec.describe Reek::AST::SexpExtensions::LvarNode do
   let(:node) { sexp(:lvar, :foo) }
+
   describe '#var_name' do
     it 'returns the lvar’s name' do
       expect(node.var_name).to eq(:foo)

--- a/spec/reek/context/statement_counter_spec.rb
+++ b/spec/reek/context/statement_counter_spec.rb
@@ -3,6 +3,7 @@ require_lib 'reek/context/statement_counter'
 
 RSpec.describe Reek::Context::StatementCounter do
   let(:counter) { described_class.new }
+
   describe '#increase_by' do
     it 'does not increase if passed a falsy value' do
       counter.increase_by(nil)

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -145,6 +145,7 @@ RSpec.describe Reek::Examiner do
 
   describe 'bad comment config' do
     let(:examiner) { described_class.new(source) }
+
     context 'unknown smell detector' do
       let(:source) do
         <<-EOS

--- a/spec/reek/report/code_climate/code_climate_fingerprint_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_fingerprint_spec.rb
@@ -23,11 +23,13 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
 
     context 'with code at a specific location' do
       let(:lines) { [1] }
+
       it_behaves_like 'computes a fingerprint with no parameters'
     end
 
     context 'with code at a different location' do
       let(:lines) { [5] }
+
       it_behaves_like 'computes a fingerprint with no parameters'
     end
 

--- a/spec/reek/report/code_climate/code_climate_report_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_report_spec.rb
@@ -26,28 +26,28 @@ RSpec.describe Reek::Report::CodeClimateReport do
     let(:source) { 'def simple(a) a[3] end' }
 
     it 'prints smells as json' do
-      expected = <<-EOS.delete("\n")
-{\"type\":\"issue\",
-\"check_name\":\"UncommunicativeParameterName\",
-\"description\":\"simple has the parameter name 'a'\",
-\"categories\":[\"Complexity\"],
-\"location\":{\"path\":\"string\",\"lines\":{\"begin\":1,\"end\":1}},
-\"remediation_points\":150000,
-\"content\":{\"body\":\"An `Uncommunicative Parameter Name` is a parameter name that
- doesn't communicate its intent well enough.\\n\\nPoor names make it hard for the reader
- to build a mental picture of what's going on in the code. They can also be
- mis-interpreted; and they hurt the flow of reading, because the reader must slow down
- to interpret the names.\\n\"},
-\"fingerprint\":\"09970037d92b5a628bf682a3e2bb126d\"}\u0000
-{\"type\":\"issue\",
-\"check_name\":\"UtilityFunction\",
-\"description\":\"simple doesn't depend on instance state (maybe move it to another class?)\",
-\"categories\":[\"Complexity\"],
-\"location\":{\"path\":\"string\",\"lines\":{\"begin\":1,\"end\":1}},
-\"remediation_points\":250000,
-\"content\":{\"body\":\"A _Utility Function_ is any instance method that has no
- dependency on the state of the instance.\\n\"},
-\"fingerprint\":\"db456db7cb344bb5a98b8fc54a2f382e\"}\u0000
+      expected = <<-EOS.strip_heredoc.delete("\n")
+        {\"type\":\"issue\",
+        \"check_name\":\"UncommunicativeParameterName\",
+        \"description\":\"simple has the parameter name 'a'\",
+        \"categories\":[\"Complexity\"],
+        \"location\":{\"path\":\"string\",\"lines\":{\"begin\":1,\"end\":1}},
+        \"remediation_points\":150000,
+        \"content\":{\"body\":\"An `Uncommunicative Parameter Name` is a parameter name that
+         doesn't communicate its intent well enough.\\n\\nPoor names make it hard for the reader
+         to build a mental picture of what's going on in the code. They can also be
+         mis-interpreted; and they hurt the flow of reading, because the reader must slow down
+         to interpret the names.\\n\"},
+        \"fingerprint\":\"09970037d92b5a628bf682a3e2bb126d\"}\u0000
+        {\"type\":\"issue\",
+        \"check_name\":\"UtilityFunction\",
+        \"description\":\"simple doesn't depend on instance state (maybe move it to another class?)\",
+        \"categories\":[\"Complexity\"],
+        \"location\":{\"path\":\"string\",\"lines\":{\"begin\":1,\"end\":1}},
+        \"remediation_points\":250000,
+        \"content\":{\"body\":\"A _Utility Function_ is any instance method that has no
+         dependency on the state of the instance.\\n\"},
+        \"fingerprint\":\"db456db7cb344bb5a98b8fc54a2f382e\"}\u0000
       EOS
 
       expect { instance.show }.to output(expected).to_stdout

--- a/spec/reek/report/yaml_report_spec.rb
+++ b/spec/reek/report/yaml_report_spec.rb
@@ -31,21 +31,21 @@ RSpec.describe Reek::Report::YAMLReport do
       instance.show(out)
       out.rewind
       result = YAML.safe_load(out.read)
-      expected = YAML.safe_load <<-EOS
----
-- context:        "simple"
-  lines:
-  - 1
-  message:        "has the parameter name 'a'"
-  smell_type:     "UncommunicativeParameterName"
-  source:         "string"
-  name:           "a"
-- context:        "simple"
-  lines:
-  - 1
-  message:        "doesn't depend on instance state (maybe move it to another class?)"
-  smell_type:     "UtilityFunction"
-  source:         "string"
+      expected = YAML.safe_load <<-EOS.strip_heredoc
+        ---
+        - context:        "simple"
+          lines:
+          - 1
+          message:        "has the parameter name 'a'"
+          smell_type:     "UncommunicativeParameterName"
+          source:         "string"
+          name:           "a"
+        - context:        "simple"
+          lines:
+          - 1
+          message:        "doesn't depend on instance state (maybe move it to another class?)"
+          smell_type:     "UtilityFunction"
+          source:         "string"
       EOS
 
       expect(result).to eq expected
@@ -58,23 +58,23 @@ RSpec.describe Reek::Report::YAMLReport do
         instance.show(out)
         out.rewind
         result = YAML.safe_load(out.read)
-        expected = YAML.safe_load <<-EOS
----
-- context:        "simple"
-  lines:
-  - 1
-  message:        "has the parameter name 'a'"
-  smell_type:     "UncommunicativeParameterName"
-  source:         "string"
-  name:           "a"
-  wiki_link:      "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md"
-- context:        "simple"
-  lines:
-  - 1
-  message:        "doesn't depend on instance state (maybe move it to another class?)"
-  smell_type:     "UtilityFunction"
-  source:         "string"
-  wiki_link:      "https://github.com/troessner/reek/blob/master/docs/Utility-Function.md"
+        expected = YAML.safe_load <<-EOS.strip_heredoc
+          ---
+          - context:        "simple"
+            lines:
+            - 1
+            message:        "has the parameter name 'a'"
+            smell_type:     "UncommunicativeParameterName"
+            source:         "string"
+            name:           "a"
+            wiki_link:      "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md"
+          - context:        "simple"
+            lines:
+            - 1
+            message:        "doesn't depend on instance state (maybe move it to another class?)"
+            smell_type:     "UtilityFunction"
+            source:         "string"
+            wiki_link:      "https://github.com/troessner/reek/blob/master/docs/Utility-Function.md"
         EOS
 
         expect(result).to eq expected


### PR DESCRIPTION
Update Rubocop

- Update rubocop and rubocop-rspec
- Configure Style/SymbolArray to explicitely enforce regular array syntax for arrays of symbols
- Configure Style/IndentHeredoc to enforce use of ActiveSupport for heredoc indenting
- Disable AmbiguousBlockAssociation cop
- Configure PercentLiteralDelimiters to match the old behavior
- (Auto-)correct offenses
