### PR TITLE
Update Rails example configuration to take mailers into account

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,9 @@ Just add this to your configuration file:
     enabled: false
   UtilityFunction:
     enabled: false
+"app/mailers":
+  InstanceVariableAssumption:
+    enabled: false
 ```
 
 Be careful though, Reek does not merge your configuration entries, so if you already have a directory directive for "app/controllers" or "app/helpers" you need to update those directives instead of copying the above YAML sample into your configuration file.


### PR DESCRIPTION
From the [Rails Guides](http://guides.rubyonrails.org/action_mailer_basics.html):

> Just like controllers, any instance variables we define in the method become available for use in the views.

So I'd like to suggest to losen up the requirements for *ActionMailer* descendants by disabling [`InstanceVariableAssumption`](docs/Instance-Variable-Assumption.md) for `app/mailers`.

