### PR TITLE
Implement `--force-exclusion` flag

### DIFF
--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -67,6 +67,8 @@ Feature: Reek can be controlled using command-line options
               --sort-by SORTING            Sort reported files by the given criterium:
                                              smelliness ("smelliest" files first)
                                              none (default - output in processing order)
+              --force-exclusion            Force excluding files specified in the configuration `exclude_paths`
+                                             even if they are explicitly passed as arguments
 
      Exit codes:
               --success-exit-code CODE     The exit code when no smells are found (default: 0)

--- a/features/configuration_files/exclude_paths_directives.feature
+++ b/features/configuration_files/exclude_paths_directives.feature
@@ -22,3 +22,22 @@ Feature: Exclude paths directives
     When I run `reek -c config.reek .`
     Then it succeeds
     And it reports nothing
+  Scenario: Using a file name within an excluded directory
+    Given a file named "bad_files_live_here/smelly.rb" with:
+      """
+      # A smelly example class
+      class Smelly
+        def alfa(bravo); end
+      end
+      """
+    And a file named "config.reek" with:
+      """
+      ---
+      exclude_paths:
+        - bad_files_live_here
+      """
+    When I run `reek -c config.reek bad_files_live_here/smelly.rb`
+    Then the exit status indicates smells
+    When I run `reek -c config.reek --force-exclusion bad_files_live_here/smelly.rb`
+    Then it succeeds
+    And it reports nothing

--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -79,11 +79,11 @@ module Reek
       end
 
       def working_directory_as_source
-        Source::SourceLocator.new(['.'], configuration: configuration).sources
+        Source::SourceLocator.new(['.'], configuration: configuration, options: options).sources
       end
 
       def sources_from_argv
-        Source::SourceLocator.new(argv, configuration: configuration).sources
+        Source::SourceLocator.new(argv, configuration: configuration, options: options).sources
       end
 
       def source_from_pipe

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -11,8 +11,8 @@ module Reek
     #
     # See {file:docs/Command-Line-Options.md} for details.
     #
-    # :reek:TooManyInstanceVariables: { max_instance_variables: 11 }
-    # :reek:TooManyMethods: { max_methods: 17 }
+    # :reek:TooManyInstanceVariables: { max_instance_variables: 12 }
+    # :reek:TooManyMethods: { max_methods: 18 }
     # :reek:Attribute: { enabled: false }
     #
     class Options
@@ -27,7 +27,8 @@ module Reek
                     :sorting,
                     :success_exit_code,
                     :failure_exit_code,
-                    :generate_todo_list
+                    :generate_todo_list,
+                    :force_exclusion
 
       def initialize(argv = [])
         @argv               = argv
@@ -41,6 +42,7 @@ module Reek
         @success_exit_code  = Status::DEFAULT_SUCCESS_EXIT_CODE
         @failure_exit_code  = Status::DEFAULT_FAILURE_EXIT_CODE
         @generate_todo_list = false
+        @force_exclusion    = false
 
         set_up_parser
       end
@@ -49,6 +51,10 @@ module Reek
         parser.parse!(argv)
         Rainbow.enabled = colored
         self
+      end
+
+      def force_exclusion?
+        @force_exclusion
       end
 
       private
@@ -121,7 +127,7 @@ module Reek
         end
       end
 
-      # :reek:TooManyStatements: { max_statements: 6 }
+      # :reek:TooManyStatements: { max_statements: 7 }
       def set_report_formatting_options
         parser.separator "\nText format options:"
         set_up_color_option
@@ -129,6 +135,7 @@ module Reek
         set_up_location_formatting_options
         set_up_progress_formatting_options
         set_up_sorting_option
+        set_up_force_exclusion_option
       end
 
       def set_up_color_option
@@ -172,6 +179,14 @@ module Reek
                   '  smelliness ("smelliest" files first)',
                   '  none (default - output in processing order)') do |sorting|
           self.sorting = sorting
+        end
+      end
+
+      def set_up_force_exclusion_option
+        parser.on('--force-exclusion',
+                  'Force excluding files specified in the configuration `exclude_paths`',
+                  '  even if they are explicitly passed as arguments') do |force_exclusion|
+          self.force_exclusion = force_exclusion
         end
       end
 

--- a/spec/reek/cli/options_spec.rb
+++ b/spec/reek/cli/options_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe Reek::CLI::Options do
       allow($stdout).to receive_messages(tty?: false)
       expect(options.progress_format).to eq :quiet
     end
+
+    it 'sets force_exclusion to false by default' do
+      expect(options.force_exclusion?).to be false
+    end
   end
 
   describe 'parse' do


### PR DESCRIPTION
Closes #1196 

There is probably work to do on this (such as creating a new scenario as [@mvz suggests](https://github.com/troessner/reek/issues/1196#issuecomment-290972786)), but I wanted to get this up for review and feedback as soon as possible.

As discussed, this introduces a `--force-exclusion` flag that mirrors the behavior of Rubocop's similarly-named flag. If the config contains an `exclude_path` for `smelly_path` and  CLI is called with

`reek ./smelly_path/file.rb`

Then the behavior of Reek is unchanged and the file will be checked for smell violations

But if the CLI is called with

`reek --force-exclusion ./smelly_path/file.rb`

Then the file will not be checked and Reek will exit with 0.

There's no breaking changes in this commit and all existing tests -- Cucumber and RSpec -- continue to pass.