### PR TITLE
Properly handle absolute paths

### DIFF
--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -62,7 +62,7 @@ module Reek
       end
 
       def path_excluded?(path)
-        excluded_paths.include?(path)
+        excluded_paths.map(&:expand_path).include?(path.expand_path)
       end
 
       def load_values(configuration_hash)

--- a/spec/reek/source/source_locator_spec.rb
+++ b/spec/reek/source/source_locator_spec.rb
@@ -37,6 +37,36 @@ RSpec.describe Reek::Source::SourceLocator do
 
       let(:options) { instance_double('Reek::CLI::Options', force_exclusion?: false) }
 
+      context 'when the path is absolute' do
+        let(:path) do
+          SAMPLES_PATH.join('source_with_exclude_paths',
+                            'ignore_me',
+                            'uncommunicative_method_name.rb').expand_path
+        end
+
+        context 'and options.force_exclusion? is true' do
+          before do
+            allow(options).to receive(:force_exclusion?).and_return(true)
+          end
+
+          it 'excludes this file' do
+            sources = described_class.new([path], configuration: configuration, options: options).sources
+            expect(sources).not_to include(path)
+          end
+        end
+
+        context 'and options.force_exclusion? is false' do
+          before do
+            allow(options).to receive(:force_exclusion?).and_return(false)
+          end
+
+          it 'includes this file' do
+            sources = described_class.new([path], configuration: configuration, options: options).sources
+            expect(sources).to include(path)
+          end
+        end
+      end
+
       context 'when the path is a file name in an excluded directory' do
         let(:path) { SAMPLES_PATH.join('source_with_exclude_paths', 'ignore_me', 'uncommunicative_method_name.rb') }
 


### PR DESCRIPTION
Fixes #1202

I came at this a few different ways. First I looked at expanding all
paths when creating a new SourceLocator. That worked, but made a bunch
of tests fail because they were expecting output that contained relative
paths.

So, to fix the bug and not force a rewrite of all the tests I settled on
doing the conversion within the path_excluded method. Doing it here
ensures we're comparing two absolute paths and it prevents the expanded
paths from leaking throughout the app.

I tried implementing a feature test for this but had no success. It's
weirdly hard to get an absolute path for a file you create through
Aruba. But I'm not that familiar with Cucumber and Aruba, so maybe I'm
missing something.