### PR TITLE
Allow multiple documents within a config file

### DIFF
--- a/features/configuration_files/exclude_paths_directives.feature
+++ b/features/configuration_files/exclude_paths_directives.feature
@@ -41,3 +41,30 @@ Feature: Exclude paths directives
     When I run `reek -c config.reek --force-exclusion bad_files_live_here/smelly.rb`
     Then it succeeds
     And it reports nothing
+  Scenario: Two exclude_paths sections
+    Given a file named "bad_files_live_here/smelly.rb" with:
+      """
+      # A smelly example class
+      class Smelly
+        def alfa(bravo); end
+      end
+      """
+    And a file named "other_smelly_directory/smelly.rb" with:
+      """
+      # A smelly example class
+      class Smelly
+        def alfa(bravo); end
+      end
+      """
+    And a file named "config.reek" with:
+      """
+      ---
+      exclude_paths:
+        - bad_files_live_here
+      ---
+      exclude_paths:
+        - other_smelly_directory
+      """
+    When I run `reek -c config.reek .`
+    Then it succeeds
+    And it reports nothing

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -69,7 +69,7 @@ module Reek
       def load_values(configuration_hash)
         configuration_hash.each do |key, value|
           if key == EXCLUDE_PATHS_KEY
-            excluded_paths.add value
+            excluded_paths.add Array(value)
           elsif smell_type?(key)
             default_directive.add key, value
           else


### PR DESCRIPTION
Closes #1208

A new feature test shows off the usage of multiple yaml files within a single config.reek file.

The main change is switching from YAML.load_file to YAML.load_stream. I didn't come up with this, the approach comes from:

- http://stackoverflow.com/questions/18467461/when-converting-yaml-to-a-ruby-hash-how-can-i-distinguish-entries-with-the-same

But this array of hashes then needs to be combined back into a single hash that has the expected structure, hence the `array_of_hashes_to_hash` method. Again, this is mostly work I found elsewhere.

- http://stackoverflow.com/questions/22318495/how-to-merge-array-of-hash-based-same-keys-in-ruby
- http://stackoverflow.com/questions/30367487/creating-a-hash-with-values-as-arrays-and-default-value-as-empty-array#30367812

That method is not pretty, but it does work. Mostly.

The one problem is that if you have a config.reek file that contains just a single document with a single `exclude_paths` value

```yaml
---
exclude_paths:
  - spec
```

That will be converted to a hash like

```ruby
{"exclude_paths" => "spec"}
```

But `excluded_paths.add` expects an Array, and this now not an array. So I'm now using the `Kernel.Array` to turn the paths param into an array. I've added tests to cover the adding of both arrays and a single elements.