### PR TITLE
Add Ruby 2.4 to supported rubies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Reek is officially running on the following MRI rubies:
   - 2.1
   - 2.2
   - 2.3
+  - 2.4
 
 Other rubies like Rubinius or JRuby are not officially supported but should work as well.
 


### PR DESCRIPTION
It looks reek supporting Ruby 2.4.  https://github.com/troessner/reek/blob/78a05997c06f2d68110cce9b46568164d14eb267/.travis.yml#L11