### PR TITLE
Use Ruby 2.4 parser for parsing code

### DIFF
--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -2,7 +2,7 @@
 
 require_relative '../cli/silencer'
 Reek::CLI::Silencer.silently do
-  require 'parser/ruby23'
+  require 'parser/ruby24'
 end
 require_relative '../tree_dresser'
 require_relative '../ast/node'
@@ -27,7 +27,7 @@ module Reek
       # code   - Ruby code as String
       # origin - 'STDIN', 'string' or a filepath as String
       # parser - the parser to use for generating AST's out of the given source
-      def initialize(code:, origin:, parser: Parser::Ruby23)
+      def initialize(code:, origin:, parser: Parser::Ruby24)
         @source = code
         @origin = origin
         @parser = parser

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Reek::Source::SourceCode do
   context 'when the parser fails' do
     let(:source_name) { 'Test source' }
     let(:error_message) { 'Error message' }
-    let(:parser) { class_double(Parser::Ruby23) }
+    let(:parser) { class_double(Parser::Ruby24) }
     let(:src) { described_class.new(code: '', origin: source_name, parser: parser) }
 
     shared_examples_for 'handling and recording the error' do


### PR DESCRIPTION
In Ruby 2.3 or older, the following code is not parseable.

```ruby
if (a, b = foo)
end
```

So, if the above code exists in a repository, reek crashes.
This change fixes the problem.