### PR TITLE
Ensure parser gem 2.4.

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.summary = 'Code smell detector for Ruby'
 
   s.add_runtime_dependency 'codeclimate-engine-rb', '~> 0.4.0'
-  s.add_runtime_dependency 'parser',                '< 2.5', '>= 2.3.1.2'
+  s.add_runtime_dependency 'parser',                '< 2.5', '>= 2.4.0.0'
   s.add_runtime_dependency 'rainbow',               '~> 2.0'
 end


### PR DESCRIPTION
Necessary to make #1211 work since Ruby 2.4. is only supported with the parser of the same version.

@mvz do you actually recall why we put the "< 2.5" in there in #1183 ?