### PR TITLE
Prevent from breaking on a string with escape sequence incompatible with UTF-8

### DIFF
--- a/lib/reek/ast/builder.rb
+++ b/lib/reek/ast/builder.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Reek
+  module AST
+    #
+    # An AST Builder for ruby parser.
+    #
+    class Builder < ::Parser::Builders::Default
+      # This is a work around for parsing ruby code that has a string with invliad sequence as UTF-8.
+      # See. https://github.com/whitequark/parser/issues/283
+      def string_value(token)
+        value(token)
+      end
+    end
+  end
+end

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -23,12 +23,19 @@ RSpec.describe Reek::Source::SourceCode do
       result = source_code.syntax_tree
       expect(result).to be_nil
     end
+
+    it 'does not crash with sequences incompatible with UTF-8' do
+      source = '"\xFF"'
+      source_code = described_class.new(code: source, origin: '(string)')
+      result = source_code.syntax_tree
+      expect(result.children.first).to eq "\xFF"
+    end
   end
 
   context 'when the parser fails' do
     let(:source_name) { 'Test source' }
     let(:error_message) { 'Error message' }
-    let(:parser) { class_double(Parser::Ruby24) }
+    let(:parser) { instance_double('Parser::Ruby24') }
     let(:src) { described_class.new(code: '', origin: source_name, parser: parser) }
 
     shared_examples_for 'handling and recording the error' do


### PR DESCRIPTION


Currently, reek crashes on a string with escape sequence incompatible with UTF-8.

For example:

`test.rb`

```ruby
"\xFF"
```

```bash
$ reek
test.rb:1:1: error: literal contains escape sequences incompatible with UTF-8
test.rb:1: "\xFF"
test.rb:1: ^~~~~~
/home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/source/source_code.rb:92:in `rescue in syntax_tree': test.rb: Parser::SyntaxError: literal contains escape sequences incompatible with UTF-8 (Reek::Errors::ParseError)
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/source/source_code.rb:89:in `syntax_tree'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/examiner.rb:110:in `syntax_tree'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/examiner.rb:100:in `run'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/examiner.rb:67:in `smells'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/examiner.rb:75:in `smells_count'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/report/base_report.rb:48:in `add_examiner'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/report/text_report.rb:23:in `add_examiner'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/cli/command/report_command.rb:26:in `block in populate_reporter_with_smells'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/cli/command/report_command.rb:25:in `each'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/cli/command/report_command.rb:25:in `populate_reporter_with_smells'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/cli/command/report_command.rb:17:in `execute'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/lib/reek/cli/application.rb:29:in `execute'
	from /home/pocke/.gem/ruby/2.4.0/gems/reek-4.6.1/bin/reek:14:in `<top (required)>'
	from /home/pocke/.gem/ruby/2.4.0/bin//reek:22:in `load'
	from /home/pocke/.gem/ruby/2.4.0/bin//reek:22:in `<main>'
```

This change fixes the problem.
See https://github.com/whitequark/parser/issues/283