### PR TITLE
Use shorthand for README.md code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ class ShoppingCart < ActiveRecord::Base
   has_many :items
 
   def gross_price
-    items.sum { |item| item.gross_price }
+    items.sum(&:gross_price)
   end
 end
 


### PR DESCRIPTION
Similar to how `array.map { |x| x.foo }` can be written `array.map(&:foo)`,
`items.sum { |item| item.gross_price }` can be written
`items.sum(&:gross_price)`.

Proposed as I think it helps demonstrate the benefit of the rewrite in terms of conciseness and clarity?