### PR TITLE
Include warning.source for syntax smells

### DIFF
--- a/features/reports/codeclimate.feature
+++ b/features/reports/codeclimate.feature
@@ -1,0 +1,59 @@
+Feature: Report smells using Code Climate format
+  In order to run as an Engine on Code Climate, output format following their
+  spec.
+
+  Scenario: output is empty when there are no smells
+    Given a directory called 'clean' containing two clean files
+    When I run reek --format code_climate clean
+    Then it succeeds
+    And it reports this Code Climate output:
+    """
+    """
+
+  Scenario: Indicate smells and print them as JSON when using files
+    Given the smelly file 'smelly.rb'
+    When I run reek --format code_climate smelly.rb
+    Then it reports this Code Climate output:
+      """
+      {
+        "type": "issue",
+        "check_name": "UncommunicativeMethodName",
+        "description": "Smelly#x has the name 'x'",
+        "categories": [
+          "Complexity"
+        ],
+        "location": {
+          "path": "smelly.rb",
+          "lines": {
+            "begin": 4,
+            "end": 4
+          }
+        },
+        "remediation_points": 150000,
+        "content": {
+          "body": "An `Uncommunicative Method Name` is a method name that doesn't communicate its intent well enough.\n\nPoor names make it hard for the reader to build a mental picture of what's going on in the code. They can also be mis-interpreted; and they hurt the flow of reading, because the reader must slow down to interpret the names.\n"
+        },
+        "fingerprint": "2b41a3a4bb7de31ac4f5944bf68b7f5f"
+      }
+      NULL_BYTE_CHARACTER
+      {
+        "type": "issue",
+        "check_name": "UncommunicativeVariableName",
+        "description": "Smelly#x has the variable name 'y'",
+        "categories": [
+          "Complexity"
+        ],
+        "location": {
+          "path": "smelly.rb",
+          "lines": {
+            "begin": 5,
+            "end": 5
+          }
+        },
+        "remediation_points": 150000,
+        "content": {
+          "body": "An `Uncommunicative Variable Name` is a variable name that doesn't communicate its intent well enough.\n\nPoor names make it hard for the reader to build a mental picture of what's going on in the code. They can also be mis-interpreted; and they hurt the flow of reading, because the reader must slow down to interpret the names.\n"
+        },
+        "fingerprint": "72f0dc8f8da5f9d7b8b29318636e5609"
+      }
+      """

--- a/features/step_definitions/reek_steps.rb
+++ b/features/step_definitions/reek_steps.rb
@@ -84,3 +84,15 @@ end
 Then /^it reports the current version$/ do
   expect(last_command_started).to have_output("reek #{Reek::Version::STRING}")
 end
+
+Then /^it reports this Code Climate output:$/ do |expected_output|
+  expected_issues = expected_output.split('NULL_BYTE_CHARACTER').map do |issue|
+    JSON.parse(issue)
+  end
+
+  actual_issues = last_command_started.stdout.split("\0").map do |issue|
+    JSON.parse(issue)
+  end
+
+  expect(actual_issues).to eq(expected_issues)
+end

--- a/lib/reek/smell_detectors/syntax.rb
+++ b/lib/reek/smell_detectors/syntax.rb
@@ -7,9 +7,10 @@ module Reek
     # Check syntax errors.
     # Note: this detector is called by examiner directly unlike other detectors.
     class Syntax < BaseDetector
-      DummyContext = Struct.new(:exp, :full_name).new(
-        Struct.new('Exp', :source).new(nil),
-        'This file')
+      # Context duck type for this atypical smell detector
+      DummyContext = Struct.new(:exp, :full_name)
+      # Exp duck type for this atypical smell detector
+      DummyExp = Struct.new(:source)
 
       def self.contexts
         []
@@ -21,9 +22,12 @@ module Reek
 
       # :reek:FeatureEnvy
       def smells_from_source(source)
+        context = DummyContext.new(
+          DummyExp.new(source.origin),
+          'This file')
         source.diagnostics.map do |diagnostic|
           smell_warning(
-            context: DummyContext,
+            context: context,
             lines: [diagnostic.location.line],
             message: "has #{diagnostic.message}")
         end

--- a/spec/reek/smell_detectors/syntax_spec.rb
+++ b/spec/reek/smell_detectors/syntax_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../spec_helper'
+require_lib 'reek/smell_detectors/syntax'
+
+RSpec.describe Reek::SmellDetectors::Syntax do
+  it 'reports the right values' do
+    src = <<-EOS
+      class Alfa
+      edn
+    EOS
+
+    expect(src).to reek_of(:Syntax,
+                           lines: [3],
+                           context: 'This file',
+                           message: 'has unexpected token $end',
+                           source: 'string')
+  end
+end


### PR DESCRIPTION
When this is missing, the Code Climate formatter errors, because the
source is required to be a String.