### PR TITLE
Fixes cases where modules containing only method: thing don't reek

### DIFF
--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -37,6 +37,22 @@ module Reek
       end
 
       #
+      # Carries out a depth-first traversal of this syntax tree, yielding every
+      # Sexp except any node whose type is listed in the Array `ignoring`. Any
+      # node type in `dont_recurse_children` will be yielded, but its children
+      # will not be walked.
+      #
+      # Examples:
+      #   context.walk_tree() do |node| .... end
+      def walk_tree(ignoring = [], dont_recurse_children = [], &blk)
+        yield self unless ignoring.include?(type)
+        return if dont_recurse_children.include?(type)
+        each_sexp do |elem|
+          elem.walk_tree(ignoring, dont_recurse_children, &blk)
+        end
+      end
+
+      #
       # Carries out a depth-first traversal of this syntax tree, yielding
       # every Sexp of type `target_type`. The traversal ignores any node
       # whose type is listed in the Array `ignoring`.

--- a/lib/reek/context/module_context.rb
+++ b/lib/reek/context/module_context.rb
@@ -77,7 +77,22 @@ module Reek
       def namespace_module?
         return false if exp.type == :casgn
         contents = exp.children.last
-        contents && contents.find_nodes([:def, :defs], [:casgn, :class, :module]).empty?
+        return false unless contents
+
+        ignore = [:begin]
+        allowed_child_types = [:casgn, :class, :module]
+        non_namespace = false
+        alloweds = []
+        
+        contents.walk_tree(ignore, allowed_child_types) do |elem|
+          if !allowed_child_types.include?(elem.type)
+            non_namespace = true
+            break
+          end
+          alloweds << elem
+        end
+        
+        (!non_namespace && !alloweds.empty?)
       end
 
       def track_visibility(visibility, names)

--- a/spec/reek/smell_detectors/irresponsible_module_spec.rb
+++ b/spec/reek/smell_detectors/irresponsible_module_spec.rb
@@ -184,5 +184,15 @@ RSpec.describe Reek::SmellDetectors::IrresponsibleModule do
 
       expect(src).not_to reek_of(:IrresponsibleModule)
     end
+
+    it 'reports undocumented classes with method calls in it' do
+      src = <<-EOS
+        class Alfa
+          does :some_thing
+        end
+      EOS
+
+      expect(src).to reek_of(:IrresponsibleModule)
+    end
   end
 end


### PR DESCRIPTION
"Namespace modules" are allowed without documentation. However, reek
incorrectly thinks a module containing method calls like `some_method: thing`
is a namespace module. To fix this, it was suggested in #1227 that if a
module contains *anything* other than a casgn, class or module def, then
it should not be considered a namespace module.

Addresses #1227