### PR TITLE
Also report unused uncommunicative parameter names

### DIFF
--- a/features/configuration_files/directory_specific_directives.feature
+++ b/features/configuration_files/directory_specific_directives.feature
@@ -41,7 +41,7 @@ Feature: Directory directives
     And a file named "web_app/app/models/user.rb" with:
       """
       class User < ActiveRecord::Base
-        def logged_in_with_role(r)
+        def logged_in_with_role(role)
           true
         end
       end
@@ -53,7 +53,7 @@ Feature: Directory directives
       [1]:InstanceVariableAssumption: UsersController assumes too much for instance variable '@user' [https://github.com/troessner/reek/blob/master/docs/Instance-Variable-Assumption.md]
     web_app/app/models/user.rb -- 2 warnings:
       [1]:IrresponsibleModule: User has no descriptive comment [https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md]
-      [2]:UnusedParameters: User#logged_in_with_role has unused parameter 'r' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
+      [2]:UnusedParameters: User#logged_in_with_role has unused parameter 'role' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
     3 total warnings
     """
 
@@ -112,7 +112,7 @@ Feature: Directory directives
     And a file named "web_app/app/models/user.rb" with:
       """
       class User < ActiveRecord::Base
-        def logged_in_with_role(r)
+        def logged_in_with_role(role)
           true
         end
       end
@@ -125,7 +125,7 @@ Feature: Directory directives
       [1]:IrresponsibleModule: UsersController has no descriptive comment [https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md]
       [4]:NestedIterators: UsersController#show contains iterators nested 2 deep [https://github.com/troessner/reek/blob/master/docs/Nested-Iterators.md]
     web_app/app/models/user.rb -- 1 warning:
-      [2]:UnusedParameters: User#logged_in_with_role has unused parameter 'r' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
+      [2]:UnusedParameters: User#logged_in_with_role has unused parameter 'role' [https://github.com/troessner/reek/blob/master/docs/Unused-Parameters.md]
     4 total warnings
     """
 

--- a/lib/reek/context/method_context.rb
+++ b/lib/reek/context/method_context.rb
@@ -36,7 +36,7 @@ module Reek
         # stop at the `lvasgn` and not detect the contained `lvar`.
         # Hence we first get all `lvar` nodes followed by all `lvasgn` nodes.
         #
-        (local_nodes(:lvar) + local_nodes(:lvasgn)).find { |node| node.var_name == param.to_sym }
+        (local_nodes(:lvar) + local_nodes(:lvasgn)).find { |node| node.var_name == param.name }
       end
 
       # :reek:FeatureEnvy
@@ -44,7 +44,7 @@ module Reek
         exp.arguments.reject do |param|
           param.anonymous_splat? ||
             param.marked_unused? ||
-            uses_param?(param.plain_name)
+            uses_param?(param)
         end
       end
 

--- a/spec/reek/smell_detectors/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smell_detectors/uncommunicative_parameter_name_spec.rb
@@ -32,15 +32,6 @@ RSpec.describe Reek::SmellDetectors::UncommunicativeParameterName do
   { 'alfa.' => 'with a receiver',
     '' => 'without a receiver' }.each do |host, description|
     context "in a method definition #{description}" do
-      it 'does not recognise *' do
-        expect("def #{host}bravo(*); end").not_to reek_of(:UncommunicativeParameterName)
-      end
-
-      it 'does not report unused parameters' do
-        src = "def #{host}bravo(x); charlie; end"
-        expect(src).not_to reek_of(:UncommunicativeParameterName)
-      end
-
       it 'does not report two-letter parameter names' do
         src = "def #{host}bravo(ab); charlie(ab); end"
         expect(src).not_to reek_of(:UncommunicativeParameterName)
@@ -56,6 +47,26 @@ RSpec.describe Reek::SmellDetectors::UncommunicativeParameterName do
         expect(src).to reek_of(:UncommunicativeParameterName, name: 'param2')
       end
 
+      it 'reports unused parameters' do
+        src = "def #{host}bravo(x); charlie; end"
+        expect(src).to reek_of(:UncommunicativeParameterName)
+      end
+
+      it 'reports splat parameters' do
+        expect("def #{host}bravo(*a); charlie(a); end").
+          to reek_of(:UncommunicativeParameterName, name: 'a')
+      end
+
+      it 'reports double splat parameters' do
+        expect("def #{host}bravo(**a); charlie(a); end").
+          to reek_of(:UncommunicativeParameterName, name: 'a')
+      end
+
+      it 'reports block parameters' do
+        expect("def #{host}bravo(&a); charlie(a); end").
+          to reek_of(:UncommunicativeParameterName, name: 'a')
+      end
+
       it 'does not report unused anonymous parameter' do
         src = "def #{host}bravo(_); charlie; end"
         expect(src).not_to reek_of(:UncommunicativeParameterName)
@@ -63,12 +74,20 @@ RSpec.describe Reek::SmellDetectors::UncommunicativeParameterName do
 
       it 'reports used anonymous parameter' do
         src = "def #{host}bravo(_); charlie(_) end"
-        expect(src).to reek_of(:UncommunicativeParameterName)
+        expect(src).to reek_of(:UncommunicativeParameterName, name: '_')
       end
 
       it 'reports used parameters marked as unused' do
         src = "def #{host}bravo(_unused) charlie(_unused) end"
-        expect(src).to reek_of(:UncommunicativeParameterName)
+        expect(src).to reek_of(:UncommunicativeParameterName, name: '_unused')
+      end
+
+      it 'does not report anonymous splat' do
+        expect("def #{host}bravo(*); end").not_to reek_of(:UncommunicativeParameterName)
+      end
+
+      it 'does not report anonymous double splat' do
+        expect("def #{host}bravo(**); end").not_to reek_of(:UncommunicativeParameterName)
       end
 
       it 'reports names inside array decomposition' do


### PR DESCRIPTION
An unused parameter name should also be reported as uncommunicative, unless it is explicitly marked as unused.

Fixes #1045.

Note that unused parameters marked as such that would become uncommunicative if they became used (e.g., `_foo2`), are not reported.

