### PR TITLE
Initialize a fresh detector for each context

### DIFF
--- a/lib/reek/detector_repository.rb
+++ b/lib/reek/detector_repository.rb
@@ -35,31 +35,25 @@ module Reek
                    configuration: {})
       @configuration = configuration
       @smell_types   = smell_types
-      @detectors     = smell_types.map { |klass| klass.new configuration_for(klass) }
     end
 
     def examine(context)
-      smell_detectors_for(context.type).flat_map do |detector|
-        detector.run_for(context)
+      smell_detectors_for(context.type).flat_map do |klass|
+        detector = klass.new configuration: configuration_for(klass), context: context
+        detector.run
       end
     end
 
     private
 
-    attr_reader :configuration, :smell_types, :detectors
+    attr_reader :configuration, :smell_types
 
     def configuration_for(klass)
       configuration.fetch klass, {}
     end
 
     def smell_detectors_for(type)
-      enabled_detectors.select do |detector|
-        detector.contexts.include? type
-      end
-    end
-
-    def enabled_detectors
-      detectors.select { |detector| detector.config.enabled? }
+      smell_types.select { |detector| detector.contexts.include? type }
     end
   end
 end

--- a/lib/reek/smell_detectors/base_detector.rb
+++ b/lib/reek/smell_detectors/base_detector.rb
@@ -28,27 +28,20 @@ module Reek
       # in any configuration file.
       DEFAULT_EXCLUDE_SET = [].freeze
 
-      def initialize(config = {})
-        @config = SmellConfiguration.new self.class.default_config.merge(config)
+      def initialize(configuration: {}, context: nil)
+        @config = SmellConfiguration.new self.class.default_config.merge(configuration)
+        @context = context
       end
 
       def smell_type
         self.class.smell_type
       end
 
-      def contexts
-        self.class.contexts
-      end
-
-      def run_for(context)
-        return [] unless enabled_for?(context)
-        return [] if exception?(context)
+      def run
+        return [] unless enabled?
+        return [] if exception?
 
         sniff(context)
-      end
-
-      def exception?(context)
-        context.matches?(value(EXCLUDE_KEY, context))
       end
 
       def self.todo_configuration_for(smells)
@@ -59,7 +52,13 @@ module Reek
 
       private
 
-      def enabled_for?(context)
+      attr_reader :context
+
+      def exception?
+        context.matches?(value(EXCLUDE_KEY, context))
+      end
+
+      def enabled?
         config.enabled? && config_for(context)[SmellConfiguration::ENABLED_KEY] != false
       end
 

--- a/spec/reek/smell_detectors/irresponsible_module_spec.rb
+++ b/spec/reek/smell_detectors/irresponsible_module_spec.rb
@@ -49,17 +49,6 @@ RSpec.describe Reek::SmellDetectors::IrresponsibleModule do
       expect(src).not_to reek_of(:IrresponsibleModule)
     end
 
-    it "does not report re-opened #{scope} in the same file" do
-      src = <<-EOS
-        # This comment describes Alfa
-        #{scope} Alfa; end
-
-        #{scope} Alfa; def bravo; end; end
-      EOS
-
-      expect(src).not_to reek_of(:IrresponsibleModule)
-    end
-
     it "reports a #{scope} with an empty comment" do
       src = <<-EOS
         #


### PR DESCRIPTION
The existing implementation used the same detector for all contexts, which resulted in constantly passing around the current context and other values as parameters. This in turn has lead to a large number of
cases of feature envy and similar code smells.

By using each detector instance for just one context, we can migrate to a design where more of the state of the ongoing detection is stored in the detector and less is passed around.