### PR TITLE
Support visibility modifier of method definition

### DIFF
--- a/lib/reek/context_builder.rb
+++ b/lib/reek/context_builder.rb
@@ -152,13 +152,13 @@ module Reek
     # which we later use for smell detectors like FeatureEnvy.
     #
     def process_send(exp)
+      process(exp)
       case current_context
       when Context::ModuleContext
         handle_send_for_modules exp
       when Context::MethodContext
         handle_send_for_methods exp
       end
-      process(exp)
     end
 
     # Handles `op_asgn` nodes a.k.a. Ruby's assignment operators.

--- a/spec/reek/context_builder_spec.rb
+++ b/spec/reek/context_builder_spec.rb
@@ -220,6 +220,26 @@ RSpec.describe Reek::ContextBuilder do
       described_class.new(syntax_tree(code)).context_tree
     end
 
+    it 'marks instance methods when using a def modifier' do
+      code = <<-EOS
+        class Foo
+          private def bar
+          end
+
+          def baz
+          end
+        end
+      EOS
+
+      root = context_tree_for(code)
+      module_context = root.children.first
+      method_contexts = module_context.children
+      aggregate_failures do
+        expect(method_contexts[0].visibility).to eq :private
+        expect(method_contexts[1].visibility).to eq :public
+      end
+    end
+
     it 'does not mark class methods with instance visibility' do
       code = <<-EOS
         class Foo

--- a/spec/reek/smell_detectors/unused_private_method_spec.rb
+++ b/spec/reek/smell_detectors/unused_private_method_spec.rb
@@ -103,6 +103,17 @@ RSpec.describe Reek::SmellDetectors::UnusedPrivateMethod do
         to reek_of(:UnusedPrivateMethod, name: 'bravo', lines: [3]).
         and reek_of(:UnusedPrivateMethod, name: 'charlie', lines: [4])
     end
+
+    it 'reports instance methods defined as private with a modifier' do
+      source = <<-EOF
+        class Alfa
+          private def bravo; end
+        end
+      EOF
+
+      expect(source).
+        to reek_of(:UnusedPrivateMethod, name: 'bravo')
+    end
   end
 
   describe 'configuring the detector via source code comment' do

--- a/spec/reek/smell_detectors/utility_function_spec.rb
+++ b/spec/reek/smell_detectors/utility_function_spec.rb
@@ -221,6 +221,18 @@ RSpec.describe Reek::SmellDetectors::UtilityFunction do
 
         expect(src).not_to reek_of(:UtilityFunction).with_config(config)
       end
+
+      it 'does not report UtilityFunction when private is used as a def modifier' do
+        src = <<-EOS
+          class Alfa
+            private def bravo(charlie)
+              charlie.delta.echo
+            end
+          end
+        EOS
+
+        expect(src).not_to reek_of(:UtilityFunction).with_config(config)
+      end
     end
 
     context 'protected methods' do
@@ -229,6 +241,18 @@ RSpec.describe Reek::SmellDetectors::UtilityFunction do
           class Alfa
             protected
             def bravo(charlie)
+              charlie.delta.echo
+            end
+          end
+        EOS
+
+        expect(src).not_to reek_of(:UtilityFunction).with_config(config)
+      end
+
+      it 'does not report UtilityFunction when protected is used as a def modifier' do
+        src = <<-EOS
+          class Alfa
+            protected def bravo(charlie)
               charlie.delta.echo
             end
           end


### PR DESCRIPTION
This is a run-up to handling #1207: The `private def bla` construction was completely unsupported in Reek.