### PR TITLE
Remove parent attribute of Reek::AST::Node class

### DIFF
--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -12,11 +12,8 @@ module Reek
     # methods to ease the transition from Sexp to AST::Node.
     #
     class Node < ::Parser::AST::Node
-      attr_reader :parent
-
       def initialize(type, children = [], options = {})
         @comments = options.fetch(:comments, [])
-        @parent   = options.fetch(:parent, nil)
         super
       end
 

--- a/lib/reek/tree_dresser.rb
+++ b/lib/reek/tree_dresser.rb
@@ -39,13 +39,13 @@ module Reek
     #
     # :reek:FeatureEnvy
     # :reek:TooManyStatements: { max_statements: 6 }
-    def dress(sexp, comment_map, parent: nil)
+    def dress(sexp, comment_map)
       return sexp unless sexp.is_a? ::Parser::AST::Node
       type = sexp.type
-      children = sexp.children.map { |child| dress(child, comment_map, parent: sexp) }
+      children = sexp.children.map { |child| dress(child, comment_map) }
       comments = comment_map[sexp]
       klass_map.klass_for(type).new(type, children,
-                                    location: sexp.loc, comments: comments, parent: parent)
+                                    location: sexp.loc, comments: comments)
     end
 
     private


### PR DESCRIPTION
This attribute is no longer used, and is also confusing because it is not an object of class Reek::AST::Node.