### PR TITLE
Refactor ContextBuilder#handle_send_for_modules

### DIFF
--- a/lib/reek/ast/sexp_extensions/send.rb
+++ b/lib/reek/ast/sexp_extensions/send.rb
@@ -23,10 +23,6 @@ module Reek
           ([receiver] + args).compact
         end
 
-        def arg_names
-          args.map { |arg| arg.children.first }
-        end
-
         def module_creation_call?
           object_creation_call? && module_creation_receiver?
         end

--- a/lib/reek/context/ghost_context.rb
+++ b/lib/reek/context/ghost_context.rb
@@ -41,8 +41,6 @@ module Reek
                                             names: names
       end
 
-      def track_singleton_visibility(_visibility, _names); end
-
       def record_use_of_self
         parent.record_use_of_self
       end

--- a/lib/reek/context/module_context.rb
+++ b/lib/reek/context/module_context.rb
@@ -84,9 +84,6 @@ module Reek
         visibility_tracker.track_visibility children: instance_method_children,
                                             visibility: visibility,
                                             names: names
-      end
-
-      def track_singleton_visibility(visibility, names)
         visibility_tracker.track_singleton_visibility children: singleton_method_children,
                                                       visibility: visibility,
                                                       names: names

--- a/lib/reek/context_builder.rb
+++ b/lib/reek/context_builder.rb
@@ -509,10 +509,8 @@ module Reek
     end
 
     def handle_send_for_modules(exp)
-      method_name = exp.name
-      arg_names = exp.arg_names
-      current_context.track_visibility(method_name, arg_names)
-      current_context.track_singleton_visibility(method_name, arg_names)
+      arg_names = exp.args.map { |arg| arg.children.first }
+      current_context.track_visibility(exp.name, arg_names)
       register_attributes(exp)
     end
 

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -303,10 +303,6 @@ RSpec.describe Reek::AST::SexpExtensions::SendNode do
   context 'with no parameters' do
     let(:node) { sexp(:send, nil, :hello) }
 
-    it 'has no argument names' do
-      expect(node.arg_names).to eq []
-    end
-
     it 'is not considered to be a writable attr' do
       expect(sexp(:send, nil, :attr).attr_with_writable_flag?).to be_falsey
     end
@@ -341,22 +337,6 @@ RSpec.describe Reek::AST::SexpExtensions::SendNode do
 
     it 'is considered to be an object creation call' do
       expect(node.object_creation_call?).to be_truthy
-    end
-  end
-
-  context 'with 1 literal parameter' do
-    let(:node) { sexp(:send, nil, :hello, sexp(:lit, :param)) }
-
-    it 'has 1 argument name' do
-      expect(node.arg_names).to eq [:param]
-    end
-  end
-
-  context 'with 2 literal parameters' do
-    let(:node) { sexp(:send, nil, :hello, sexp(:lit, :x), sexp(:lit, :y)) }
-
-    it 'has 2 argument names' do
-      expect(node.arg_names).to eq [:x, :y]
     end
   end
 end


### PR DESCRIPTION
- Inline `SendNode#arg_names`. This method was not generally useful for `:send` nodes and did not return argument names in the general case.
- Merge `ModuleContext#track_visibility` and `#track_singleton_visibility`. Having two methods actually made the code more confusing.

Fixes #1239.