### PR TITLE
Restore emit_lambda setting

### DIFF
--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -9,7 +9,7 @@ require_relative '../ast/node'
 require_relative '../ast/builder'
 
 # Opt in to new way of representing lambdas
-Parser::Builders::Default.emit_lambda = true
+Reek::AST::Builder.emit_lambda = true
 
 module Reek
   module Source

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -30,6 +30,13 @@ RSpec.describe Reek::Source::SourceCode do
       result = source_code.syntax_tree
       expect(result.children.first).to eq "\xFF"
     end
+
+    it 'returns a :lambda node for lambda expressions' do
+      source = '->() { }'
+      source_code = described_class.new(code: source, origin: '(string)')
+      result = source_code.syntax_tree
+      expect(result.children.first.type).to eq :lambda
+    end
   end
 
   context 'when the parser fails' do


### PR DESCRIPTION
This setting was accidentally rendered useless by the introduction of a parser builder subclass in 146a5a19178e9b978a625061d94a2ee8f7a3a1e0.