### PR TITLE
Refactor smell detectors

### DIFF
--- a/docs/How-To-Write-New-Detectors.md
+++ b/docs/How-To-Write-New-Detectors.md
@@ -27,20 +27,21 @@ module Reek
       end
 
       #
-      # Here you should document what you expect "ctx" to look like.
+      # Here you should document what you expect the detector's context to look
+      # like.
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(ctx)
+      def sniff
         # "found_smells" below is just an abstraction for
-        # "find the smells in question" and iteratore over them.
+        # "find the smells in question" and iterate over them.
         # This can just be a method but it can also be a more sophisticated set up.
         # Check out other smell detectors to get a feeling for what to do here.
-        found_smells(ctx).map do |smell|
+        found_smells.map do |smell|
           # "smell_warning" is defined in BaseDetector and should be used by you
           # to construct smell warnings
           smell_warning(
-            context: ctx,
+            context: context,
             lines: [], # lines on which the smell was detected
             message: "...", # the message that is printed on STDOUT
             # whatever you interpolate into the "message" should go into

--- a/lib/reek/smell_detectors/attribute.rb
+++ b/lib/reek/smell_detectors/attribute.rb
@@ -16,10 +16,6 @@ module Reek
     #
     # TODO: Catch attributes declared "by hand"
     class Attribute < BaseDetector
-      def initialize(*args)
-        super
-      end
-
       def self.contexts # :nodoc:
         [:sym]
       end
@@ -29,10 +25,10 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(ctx)
-        attributes_in(ctx).map do |_attribute, line|
+      def sniff
+        attributes_in_context.map do |_attribute, line|
           smell_warning(
-            context: ctx,
+            context: context,
             lines: [line],
             message: 'is a writable attribute')
         end
@@ -40,10 +36,9 @@ module Reek
 
       private
 
-      # :reek:UtilityFunction
-      def attributes_in(module_ctx)
-        if module_ctx.visibility == :public
-          call_node = module_ctx.exp
+      def attributes_in_context
+        if context.visibility == :public
+          call_node = expression
           [[call_node.name, call_node.line]]
         else
           []

--- a/lib/reek/smell_detectors/base_detector.rb
+++ b/lib/reek/smell_detectors/base_detector.rb
@@ -41,7 +41,7 @@ module Reek
         return [] unless enabled?
         return [] if exception?
 
-        sniff(context)
+        sniff
       end
 
       def self.todo_configuration_for(smells)
@@ -53,6 +53,14 @@ module Reek
       private
 
       attr_reader :context
+
+      def expression
+        @expression ||= context.exp
+      end
+
+      def source_line
+        @line ||= expression.line
+      end
 
       def exception?
         context.matches?(value(EXCLUDE_KEY, context))

--- a/lib/reek/smell_detectors/boolean_parameter.rb
+++ b/lib/reek/smell_detectors/boolean_parameter.rb
@@ -19,14 +19,13 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      # :reek:FeatureEnvy
-      def sniff(ctx)
-        ctx.default_assignments.select do |_parameter, value|
+      def sniff
+        context.default_assignments.select do |_parameter, value|
           [:true, :false].include?(value.type)
         end.map do |parameter, _value|
           smell_warning(
-            context: ctx,
-            lines: [ctx.exp.line],
+            context: context,
+            lines: [source_line],
             message: "has boolean parameter '#{parameter}'",
             parameters: { parameter: parameter.to_s })
         end

--- a/lib/reek/smell_detectors/class_variable.rb
+++ b/lib/reek/smell_detectors/class_variable.rb
@@ -24,10 +24,10 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(ctx)
-        class_variables_in(ctx.exp).map do |variable, lines|
+      def sniff
+        class_variables_in_context.map do |variable, lines|
           smell_warning(
-            context: ctx,
+            context: context,
             lines: lines,
             message: "declares the class variable '#{variable}'",
             parameters: { name: variable.to_s })
@@ -39,14 +39,13 @@ module Reek
       # in the given module.
       #
       # :reek:TooManyStatements: { max_statements: 7 }
-      # :reek:FeatureEnvy
-      def class_variables_in(exp)
+      def class_variables_in_context
         result = Hash.new { |hash, key| hash[key] = [] }
         collector = proc do |cvar_node|
           result[cvar_node.name].push(cvar_node.line)
         end
         [:cvar, :cvasgn, :cvdecl].each do |stmt_type|
-          exp.each_node(stmt_type, [:class, :module], &collector)
+          expression.each_node(stmt_type, [:class, :module], &collector)
         end
         result
       end

--- a/lib/reek/smell_detectors/control_parameter.rb
+++ b/lib/reek/smell_detectors/control_parameter.rb
@@ -50,11 +50,11 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       # :reek:FeatureEnvy
-      def sniff(ctx)
-        ControlParameterCollector.new(ctx).control_parameters.map do |control_parameter|
+      def sniff
+        ControlParameterCollector.new(context).control_parameters.map do |control_parameter|
           argument = control_parameter.name.to_s
           smell_warning(
-            context: ctx,
+            context: context,
             lines: control_parameter.lines,
             message: "is controlled by argument '#{argument}'",
             parameters: { argument: argument })

--- a/lib/reek/smell_detectors/data_clump.rb
+++ b/lib/reek/smell_detectors/data_clump.rb
@@ -50,14 +50,11 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      # :reek:FeatureEnvy
-      def sniff(ctx)
-        max_copies = value(MAX_COPIES_KEY, ctx)
-        min_clump_size = value(MIN_CLUMP_SIZE_KEY, ctx)
-        MethodGroup.new(ctx, min_clump_size, max_copies).clumps.map do |clump, methods|
+      def sniff
+        MethodGroup.new(context, min_clump_size, max_copies).clumps.map do |clump, methods|
           methods_length = methods.length
           smell_warning(
-            context: ctx,
+            context: context,
             lines: methods.map(&:line),
             message: "takes parameters #{DataClump.print_clump(clump)} " \
                      "to #{methods_length} methods",
@@ -71,6 +68,16 @@ module Reek
       # @private
       def self.print_clump(clump)
         "[#{clump.map { |parameter| "'#{parameter}'" }.join(', ')}]"
+      end
+
+      private
+
+      def max_copies
+        value(MAX_COPIES_KEY, context)
+      end
+
+      def min_clump_size
+        value(MIN_CLUMP_SIZE_KEY, context)
       end
     end
   end

--- a/lib/reek/smell_detectors/duplicate_method_call.rb
+++ b/lib/reek/smell_detectors/duplicate_method_call.rb
@@ -37,24 +37,31 @@ module Reek
       end
 
       #
-      # Looks for duplicate calls within the body of the method +ctx+.
+      # Looks for duplicate calls within the body of the method context.
       #
       # @return [Array<SmellWarning>]
       #
-      # :reek:FeatureEnvy
-      # :reek:DuplicateMethodCall: { max_calls: 2 }
-      def sniff(ctx)
-        max_allowed_calls = value(MAX_ALLOWED_CALLS_KEY, ctx)
-        allow_calls = value(ALLOW_CALLS_KEY, ctx)
-
-        collector = CallCollector.new(ctx, max_allowed_calls, allow_calls)
+      def sniff
+        collector = CallCollector.new(context, max_allowed_calls, allow_calls)
         collector.smelly_calls.map do |found_call|
+          call = found_call.call
+          occurs = found_call.occurs
           smell_warning(
-            context: ctx,
+            context: context,
             lines: found_call.lines,
-            message: "calls '#{found_call.call}' #{found_call.occurs} times",
-            parameters: { name: found_call.call, count: found_call.occurs })
+            message: "calls '#{call}' #{occurs} times",
+            parameters: { name: call, count: occurs })
         end
+      end
+
+      private
+
+      def max_allowed_calls
+        value(MAX_ALLOWED_CALLS_KEY, context)
+      end
+
+      def allow_calls
+        value(ALLOW_CALLS_KEY, context)
       end
 
       # Collects information about a single found call

--- a/lib/reek/smell_detectors/feature_envy.rb
+++ b/lib/reek/smell_detectors/feature_envy.rb
@@ -42,11 +42,11 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(ctx)
-        return [] unless ctx.references_self?
-        envious_receivers(ctx).map do |name, lines|
+      def sniff
+        return [] unless context.references_self?
+        envious_receivers.map do |name, lines|
           smell_warning(
-            context: ctx,
+            context: context,
             lines: lines,
             message: "refers to '#{name}' more than self (maybe move it to another class?)",
             parameters: { name: name.to_s })
@@ -55,9 +55,11 @@ module Reek
 
       private
 
-      # :reek:UtilityFunction
-      def envious_receivers(ctx)
-        refs = ctx.refs
+      def refs
+        @refs ||= context.refs
+      end
+
+      def envious_receivers
         return {} if refs.self_is_max?
         refs.most_popular
       end

--- a/lib/reek/smell_detectors/irresponsible_module.rb
+++ b/lib/reek/smell_detectors/irresponsible_module.rb
@@ -19,24 +19,18 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(ctx)
-        return [] if descriptive?(ctx) || ctx.namespace_module?
-        expression = ctx.exp
+      def sniff
+        return [] if descriptive_context? || context.namespace_module?
         [smell_warning(
-          context: ctx,
-          lines: [expression.line],
+          context: context,
+          lines: [source_line],
           message: 'has no descriptive comment')]
       end
 
       private
 
-      def descriptive
-        @descriptive ||= {}
-      end
-
-      # :reek:FeatureEnvy
-      def descriptive?(ctx)
-        descriptive[ctx.full_name] ||= ctx.descriptively_commented?
+      def descriptive_context?
+        context.descriptively_commented?
       end
     end
   end

--- a/lib/reek/smell_detectors/long_parameter_list.rb
+++ b/lib/reek/smell_detectors/long_parameter_list.rb
@@ -32,16 +32,20 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(ctx)
-        max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, ctx)
-        exp = ctx.exp
-        count = exp.arg_names.length
+      def sniff
+        count = expression.arg_names.length
         return [] if count <= max_allowed_params
         [smell_warning(
-          context: ctx,
-          lines: [exp.line],
+          context: context,
+          lines: [source_line],
           message: "has #{count} parameters",
           parameters: { count: count })]
+      end
+
+      private
+
+      def max_allowed_params
+        value(MAX_ALLOWED_PARAMS_KEY, context)
       end
     end
   end

--- a/lib/reek/smell_detectors/long_yield_list.rb
+++ b/lib/reek/smell_detectors/long_yield_list.rb
@@ -24,20 +24,24 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      # :reek:FeatureEnvy
       # :reek:DuplicateMethodCall: { max_calls: 2 }
-      def sniff(ctx)
-        max_allowed_params = value(MAX_ALLOWED_PARAMS_KEY, ctx)
-        ctx.local_nodes(:yield).select do |yield_node|
+      def sniff
+        context.local_nodes(:yield).select do |yield_node|
           yield_node.args.length > max_allowed_params
         end.map do |yield_node|
           count = yield_node.args.length
           smell_warning(
-            context: ctx,
+            context: context,
             lines: [yield_node.line],
             message: "yields #{count} parameters",
             parameters: { count: count })
         end
+      end
+
+      private
+
+      def max_allowed_params
+        value(MAX_ALLOWED_PARAMS_KEY, context)
       end
     end
   end

--- a/lib/reek/smell_detectors/manual_dispatch.rb
+++ b/lib/reek/smell_detectors/manual_dispatch.rb
@@ -19,12 +19,11 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      # :reek:FeatureEnvy
-      def sniff(ctx)
-        smelly_nodes = ctx.each_node(:send).select { |node| node.name == :respond_to? }
+      def sniff
+        smelly_nodes = context.each_node(:send).select { |node| node.name == :respond_to? }
         return [] if smelly_nodes.empty?
         lines = smelly_nodes.map(&:line)
-        [smell_warning(context: ctx, lines: lines, message: MESSAGE)]
+        [smell_warning(context: context, lines: lines, message: MESSAGE)]
       end
     end
   end

--- a/lib/reek/smell_detectors/module_initialize.rb
+++ b/lib/reek/smell_detectors/module_initialize.rb
@@ -20,13 +20,12 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      # :reek:FeatureEnvy
-      def sniff(ctx)
-        ctx.local_nodes(:def) do |node|
+      def sniff
+        context.local_nodes(:def) do |node|
           if node.name == :initialize
             return smell_warning(
-              context: ctx,
-              lines:   [ctx.exp.line],
+              context: context,
+              lines:   [source_line],
               message: 'has initialize method')
           end
         end

--- a/lib/reek/smell_detectors/nil_check.rb
+++ b/lib/reek/smell_detectors/nil_check.rb
@@ -9,11 +9,11 @@ module Reek
     #
     # See {file:docs/Nil-Check.md} for details.
     class NilCheck < BaseDetector
-      def sniff(ctx)
-        lines = NodeDetector.new(ctx).detect.map(&:line)
+      def sniff
+        lines = detect_nodes.map(&:line)
         if lines.any?
           [smell_warning(
-            context: ctx,
+            context: context,
             lines: lines,
             message: 'performs a nil-check')]
         else
@@ -21,19 +21,13 @@ module Reek
         end
       end
 
-      # Detect all nodes that smell of NilCheck
-      class NodeDetector
-        attr_reader :ctx
-        def initialize(ctx)
-          @ctx = ctx
-        end
+      private
 
-        def detect
-          finders = [NodeFinder.new(ctx, :send, NilCallNodeDetector),
-                     NodeFinder.new(ctx, :when, NilWhenNodeDetector),
-                     NodeFinder.new(ctx, :csend, SafeNavigationNodeDetector)]
-          finders.flat_map(&:smelly_nodes)
-        end
+      def detect_nodes
+        finders = [NodeFinder.new(context, :send, NilCallNodeDetector),
+                   NodeFinder.new(context, :when, NilWhenNodeDetector),
+                   NodeFinder.new(context, :csend, SafeNavigationNodeDetector)]
+        finders.flat_map(&:smelly_nodes)
       end
 
       #

--- a/lib/reek/smell_detectors/prima_donna_method.rb
+++ b/lib/reek/smell_detectors/prima_donna_method.rb
@@ -30,7 +30,6 @@ module Reek
       end
 
       #
-      # @param ctx [Context::ModuleContext]
       # @return [Array<SmellWarning>]
       #
       # Given this code:
@@ -40,21 +39,21 @@ module Reek
       #   end
       # end
       #
-      # An example `ctx` could look like this:
+      # An example context could look like this:
       #
       # s(:class,
       #   s(:const, nil, :Alfa), nil,
       #     s(:def, :bravo!,
       #       s(:args), nil))
       #
-      def sniff(ctx)
-        ctx.node_instance_methods.select do |method_sexp|
-          prima_donna_method?(method_sexp, ctx)
+      def sniff
+        context.node_instance_methods.select do |method_sexp|
+          prima_donna_method?(method_sexp)
         end.map do |method_sexp|
           name = method_sexp.name
           smell_warning(
-            context: ctx,
-            lines: [ctx.exp.line],
+            context: context,
+            lines: [source_line],
             message: "has prima donna method '#{name}'",
             parameters: { name: name.to_s })
         end
@@ -62,16 +61,15 @@ module Reek
 
       private
 
-      def prima_donna_method?(method_sexp, ctx)
+      def prima_donna_method?(method_sexp)
         return false unless method_sexp.ends_with_bang?
-        return false if ignore_method?(method_sexp, ctx)
-        return false if version_without_bang_exists?(method_sexp, ctx)
+        return false if ignore_method? method_sexp
+        return false if version_without_bang_exists? method_sexp
         true
       end
 
-      # :reek:UtilityFunction
-      def version_without_bang_exists?(method_sexp, ctx)
-        ctx.node_instance_methods.find do |sexp_item|
+      def version_without_bang_exists?(method_sexp)
+        context.node_instance_methods.find do |sexp_item|
           sexp_item.name.to_s == method_sexp.name_without_bang
         end
       end
@@ -79,12 +77,15 @@ module Reek
       #
       # @param method_node [Reek::AST::Node],
       #   e.g. s(:def, :bravo!, s(:args), nil)
-      # @param ctx [Context::ModuleContext]
       # @return [Boolean]
       #
-      def ignore_method?(method_node, ctx)
-        ignore_method_names = value(EXCLUDE_KEY, ctx) # e.g. ["bravo!"]
+      def ignore_method?(method_node)
         ignore_method_names.include? method_node.name.to_s # method_node.name is e.g.: :bravo!
+      end
+
+      # e.g. ["bravo!"]
+      def ignore_method_names
+        @ignore_method_names ||= value(EXCLUDE_KEY, context)
       end
     end
   end

--- a/lib/reek/smell_detectors/subclassed_from_core_class.rb
+++ b/lib/reek/smell_detectors/subclassed_from_core_class.rb
@@ -26,26 +26,26 @@ module Reek
       # class Foo < Bar; end;
       #
       # @return [Array<SmellWarning>]
-      def sniff(ctx)
-        superclass = ctx.exp.superclass
+      def sniff
+        superclass = expression.superclass
 
         return [] unless superclass
 
-        sniff_superclass(ctx, superclass.name)
+        sniff_superclass superclass.name
       end
 
       private
 
-      def sniff_superclass(ctx, superclass_name)
+      def sniff_superclass(superclass_name)
         return [] unless CORE_CLASSES.include?(superclass_name)
 
-        [build_smell_warning(ctx, superclass_name)]
+        [build_smell_warning(superclass_name)]
       end
 
-      def build_smell_warning(ctx, ancestor_name)
+      def build_smell_warning(ancestor_name)
         smell_attributes = {
-          context: ctx,
-          lines: [ctx.exp.line],
+          context: context,
+          lines: [source_line],
           message: "inherits from core class '#{ancestor_name}'",
           parameters: { ancestor: ancestor_name }
         }

--- a/lib/reek/smell_detectors/too_many_constants.rb
+++ b/lib/reek/smell_detectors/too_many_constants.rb
@@ -34,22 +34,24 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(ctx)
-        max_allowed_constants = value(MAX_ALLOWED_CONSTANTS_KEY, ctx)
-
-        count = ctx.each_node(:casgn, IGNORED_NODES).delete_if(&:defines_module?).length
+      def sniff
+        count = context.each_node(:casgn, IGNORED_NODES).delete_if(&:defines_module?).length
 
         return [] if count <= max_allowed_constants
 
-        build_smell_warning(ctx, count)
+        build_smell_warning(count)
       end
 
       private
 
-      def build_smell_warning(ctx, count)
+      def max_allowed_constants
+        value(MAX_ALLOWED_CONSTANTS_KEY, context)
+      end
+
+      def build_smell_warning(count)
         [smell_warning(
-          context: ctx,
-          lines: [ctx.exp.line],
+          context: context,
+          lines: [source_line],
           message: "has #{count} constants",
           parameters: { count: count })]
       end

--- a/lib/reek/smell_detectors/too_many_instance_variables.rb
+++ b/lib/reek/smell_detectors/too_many_instance_variables.rb
@@ -33,16 +33,21 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(ctx)
-        max_allowed_ivars = value(MAX_ALLOWED_IVARS_KEY, ctx)
-        variables = ctx.local_nodes(:ivasgn, [:or_asgn]).map(&:name)
+      def sniff
+        variables = context.local_nodes(:ivasgn, [:or_asgn]).map(&:name)
         count = variables.uniq.size
         return [] if count <= max_allowed_ivars
         [smell_warning(
-          context: ctx,
-          lines: [ctx.exp.line],
+          context: context,
+          lines: [source_line],
           message: "has at least #{count} instance variables",
           parameters: { count: count })]
+      end
+
+      private
+
+      def max_allowed_ivars
+        value(MAX_ALLOWED_IVARS_KEY, context)
       end
     end
   end

--- a/lib/reek/smell_detectors/too_many_methods.rb
+++ b/lib/reek/smell_detectors/too_many_methods.rb
@@ -31,20 +31,25 @@ module Reek
       end
 
       #
-      # Checks +ctx+ for too many methods
+      # Checks context for too many methods
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(ctx)
-        max_allowed_methods = value(MAX_ALLOWED_METHODS_KEY, ctx)
+      def sniff
         # TODO: Only checks instance methods!
-        actual = ctx.node_instance_methods.length
+        actual = context.node_instance_methods.length
         return [] if actual <= max_allowed_methods
         [smell_warning(
-          context: ctx,
-          lines: [ctx.exp.line],
+          context: context,
+          lines: [source_line],
           message: "has at least #{actual} methods",
           parameters: { count: actual })]
+      end
+
+      private
+
+      def max_allowed_methods
+        value(MAX_ALLOWED_METHODS_KEY, context)
       end
     end
   end

--- a/lib/reek/smell_detectors/too_many_statements.rb
+++ b/lib/reek/smell_detectors/too_many_statements.rb
@@ -27,15 +27,20 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(ctx)
-        max_allowed_statements = value(MAX_ALLOWED_STATEMENTS_KEY, ctx)
-        count = ctx.number_of_statements
+      def sniff
+        count = context.number_of_statements
         return [] if count <= max_allowed_statements
         [smell_warning(
-          context: ctx,
-          lines: [ctx.exp.line],
+          context: context,
+          lines: [source_line],
           message: "has approx #{count} statements",
           parameters: { count: count })]
+      end
+
+      private
+
+      def max_allowed_statements
+        value(MAX_ALLOWED_STATEMENTS_KEY, context)
       end
     end
   end

--- a/lib/reek/smell_detectors/uncommunicative_method_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_method_name.rb
@@ -36,29 +36,29 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(context)
+      def sniff
         name = context.name.to_s
-        return [] if acceptable_name?(name: name, context: context)
+        return [] if acceptable_name?(name)
 
         [smell_warning(
           context: context,
-          lines: [context.exp.line],
+          lines: [source_line],
           message: "has the name '#{name}'",
           parameters: { name: name })]
       end
 
       private
 
-      def acceptable_name?(name:, context:)
-        accept_patterns(context).any? { |accept_pattern| name.match accept_pattern } ||
-          reject_patterns(context).none? { |reject_pattern| name.match reject_pattern }
+      def acceptable_name?(name)
+        accept_patterns.any? { |accept_pattern| name.match accept_pattern } ||
+          reject_patterns.none? { |reject_pattern| name.match reject_pattern }
       end
 
-      def reject_patterns(context)
+      def reject_patterns
         Array value(REJECT_KEY, context)
       end
 
-      def accept_patterns(context)
+      def accept_patterns
         Array value(ACCEPT_KEY, context)
       end
     end

--- a/lib/reek/smell_detectors/uncommunicative_module_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_module_name.rb
@@ -41,40 +41,37 @@ module Reek
       end
 
       #
-      # Checks the given +context+ for uncommunicative names.
+      # Checks the detector's context for uncommunicative names.
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(context)
+      def sniff
         fully_qualified_name = context.full_name
-        exp                  = context.exp
-        module_name          = exp.simple_name
+        module_name          = expression.simple_name
 
-        return [] if acceptable_name?(context: context,
-                                      module_name: module_name,
+        return [] if acceptable_name?(module_name: module_name,
                                       fully_qualified_name: fully_qualified_name)
 
         [smell_warning(
           context: context,
-          lines: [exp.line],
+          lines: [source_line],
           message: "has the name '#{module_name}'",
           parameters: { name: module_name })]
       end
 
       private
 
-      # :reek:ControlParameter
-      def acceptable_name?(context:, module_name:, fully_qualified_name:)
-        accept_patterns(context).any? { |accept_pattern| fully_qualified_name.match accept_pattern } ||
-          reject_patterns(context).none? { |reject_pattern| module_name.match reject_pattern }
+      def acceptable_name?(module_name:, fully_qualified_name:)
+        accept_patterns.any? { |accept_pattern| fully_qualified_name.match accept_pattern } ||
+          reject_patterns.none? { |reject_pattern| module_name.match reject_pattern }
       end
 
-      def reject_patterns(context)
-        Array value(REJECT_KEY, context)
+      def reject_patterns
+        @reject_patterns ||= Array value(REJECT_KEY, context)
       end
 
-      def accept_patterns(context)
-        Array value(ACCEPT_KEY, context)
+      def accept_patterns
+        @accept_patterns ||= Array value(ACCEPT_KEY, context)
       end
     end
   end

--- a/lib/reek/smell_detectors/uncommunicative_parameter_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_parameter_name.rb
@@ -38,17 +38,15 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      def sniff(context)
-        expression = context.exp
-
+      def sniff
         params = expression.parameters.select do |param|
-          uncommunicative_parameter?(parameter: param, context: context)
+          uncommunicative_parameter?(param)
         end
 
         params.map(&:name).map do |name|
           smell_warning(
             context: context,
-            lines: [expression.line],
+            lines: [source_line],
             message: "has the parameter name '#{name}'",
             parameters: { name: name.to_s })
         end
@@ -56,22 +54,21 @@ module Reek
 
       private
 
-      def uncommunicative_parameter?(parameter:, context:)
-        !acceptable_name?(parameter: parameter, context: context) &&
+      def uncommunicative_parameter?(parameter)
+        !acceptable_name?(parameter.plain_name) &&
           (context.uses_param?(parameter) || !parameter.marked_unused?)
       end
 
-      def acceptable_name?(parameter:, context:)
-        name = parameter.plain_name
-        accept_patterns(context).any? { |accept_pattern| name.match accept_pattern } ||
-          reject_patterns(context).none? { |reject_pattern| name.match reject_pattern }
+      def acceptable_name?(name)
+        accept_patterns.any? { |accept_pattern| name.match accept_pattern } ||
+          reject_patterns.none? { |reject_pattern| name.match reject_pattern }
       end
 
-      def reject_patterns(context)
+      def reject_patterns
         Array value(REJECT_KEY, context)
       end
 
-      def accept_patterns(context)
+      def accept_patterns
         Array value(ACCEPT_KEY, context)
       end
     end

--- a/lib/reek/smell_detectors/unused_parameters.rb
+++ b/lib/reek/smell_detectors/unused_parameters.rb
@@ -14,14 +14,13 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      # :reek:FeatureEnvy
-      def sniff(ctx)
-        return [] if ctx.uses_super_with_implicit_arguments?
-        ctx.unused_params.map do |param|
+      def sniff
+        return [] if context.uses_super_with_implicit_arguments?
+        context.unused_params.map do |param|
           name = param.name.to_s
           smell_warning(
-            context: ctx,
-            lines: [ctx.exp.line],
+            context: context,
+            lines: [source_line],
             message: "has unused parameter '#{name}'",
             parameters: { name: name })
         end

--- a/lib/reek/smell_detectors/unused_private_method.rb
+++ b/lib/reek/smell_detectors/unused_private_method.rb
@@ -32,15 +32,13 @@ module Reek
       end
 
       #
-      # @param ctx [Context::ClassContext]
       # @return [Array<SmellWarning>]
       #
-      # :reek:FeatureEnvy
-      def sniff(ctx)
-        hits(ctx).map do |hit|
+      def sniff
+        hits.map do |hit|
           name = hit.name
           smell_warning(
-            context: ctx,
+            context: context,
             lines: [hit.line],
             message: "has the unused private instance method '#{name}'",
             parameters: { name: name.to_s })
@@ -50,23 +48,20 @@ module Reek
       private
 
       #
-      # @param ctx [Context::ClassContext]
       # @return [Array<Hit>]
       #
-      def hits(ctx)
-        unused_private_methods(ctx).map do |defined_method|
-          Hit.new(defined_method) unless ignore_method?(ctx, defined_method)
+      def hits
+        unused_private_methods.map do |defined_method|
+          Hit.new(defined_method) unless ignore_method?(defined_method)
         end.compact
       end
 
       #
-      # @param ctx [Context::ClassContext]
       # @return [Array<Context::MethodContext]
       #
-      # :reek:UtilityFunction
-      def unused_private_methods(ctx)
-        defined_private_methods = ctx.defined_instance_methods(visibility: :private)
-        called_method_names     = ctx.instance_method_calls.map(&:name)
+      def unused_private_methods
+        defined_private_methods = context.defined_instance_methods(visibility: :private)
+        called_method_names     = context.instance_method_calls.map(&:name)
 
         defined_private_methods.reject do |defined_method|
           called_method_names.include?(defined_method.name)
@@ -74,14 +69,12 @@ module Reek
       end
 
       #
-      # @param ctx [Context::ClassContext]
       # @param method [Context::MethodContext]
       # @return [Boolean]
       #
-      # :reek:FeatureEnvy
-      def ignore_method?(ctx, method)
+      def ignore_method?(method)
         # ignore_contexts will be e.g. ["Foo::Smelly#my_method", "..."]
-        ignore_contexts = value(EXCLUDE_KEY, ctx)
+        ignore_contexts = value(EXCLUDE_KEY, context)
         ignore_contexts.any? do |ignore_context|
           full_name = "#{method.parent.full_name}##{method.name}"
           full_name[ignore_context]

--- a/lib/reek/smell_detectors/utility_function.rb
+++ b/lib/reek/smell_detectors/utility_function.rb
@@ -56,30 +56,27 @@ module Reek
       #
       # @return [Array<SmellWarning>]
       #
-      # :reek:FeatureEnvy
-      # :reek:TooManyStatements: { max_statements: 6 }
-      def sniff(ctx)
-        return [] if ctx.singleton_method? || ctx.module_function?
-        return [] if ctx.references_self?
-        return [] if num_helper_methods(ctx).zero?
-        return [] if ignore_method?(ctx)
+      def sniff
+        return [] if context.singleton_method? || context.module_function?
+        return [] if context.references_self?
+        return [] if num_helper_methods.zero?
+        return [] if ignore_method?
 
         [smell_warning(
-          context: ctx,
-          lines: [ctx.exp.line],
+          context: context,
+          lines: [source_line],
           message: "doesn't depend on instance state (maybe move it to another class?)")]
       end
 
       private
 
-      # :reek:UtilityFunction
-      def num_helper_methods(method_ctx)
-        method_ctx.local_nodes(:send).length
+      def num_helper_methods
+        context.local_nodes(:send).length
       end
 
-      def ignore_method?(method_ctx)
-        method_ctx.non_public_visibility? &&
-          value(PUBLIC_METHODS_ONLY_KEY, method_ctx)
+      def ignore_method?
+        context.non_public_visibility? &&
+          value(PUBLIC_METHODS_ONLY_KEY, context)
       end
     end
   end


### PR DESCRIPTION
This completes the process started in #1234: Instead of taking the `context` as a parameter to the `sniff` method, the detectors now use the attribute. This cleans up quite a few cases of FeatureEnvy and UtilityFunction.