### PR TITLE
Make prima donna method report the method definition line

### DIFF
--- a/lib/reek/smell_detectors/prima_donna_method.rb
+++ b/lib/reek/smell_detectors/prima_donna_method.rb
@@ -53,7 +53,7 @@ module Reek
           name = method_sexp.name
           smell_warning(
             context: context,
-            lines: [source_line],
+            lines: [method_sexp.line],
             message: "has prima donna method '#{name}'",
             parameters: { name: name.to_s })
         end

--- a/spec/reek/smell_detectors/prima_donna_method_spec.rb
+++ b/spec/reek/smell_detectors/prima_donna_method_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Reek::SmellDetectors::PrimaDonnaMethod do
     EOS
 
     expect(src).to reek_of(:PrimaDonnaMethod,
-                           lines:   [1],
+                           lines:   [2],
                            context: 'Alfa',
                            message: "has prima donna method 'bravo!'",
                            source:  'string',
@@ -30,8 +30,8 @@ RSpec.describe Reek::SmellDetectors::PrimaDonnaMethod do
     EOS
 
     expect(src).
-      to reek_of(:PrimaDonnaMethod, lines: [1], name: 'bravo!').
-      and reek_of(:PrimaDonnaMethod, lines: [1], name: 'charlie!')
+      to reek_of(:PrimaDonnaMethod, lines: [2], name: 'bravo!').
+      and reek_of(:PrimaDonnaMethod, lines: [5], name: 'charlie!')
   end
 
   it 'reports nothing when method and bang counterpart exist' do


### PR DESCRIPTION
This improves the Prima Donna Method detector by making it report the line where the method is defined, rather than the (mostly useless) line where the class starts.

This fixes #1256.