### PR TITLE
Update rubocop(-rspec) and fix offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,15 @@ Layout/MultilineOperationIndentation:
 Lint/AmbiguousBlockAssociation:
   Enabled: false
 
+# Some of our source examples include interpolation explicitely.
+Lint/InterpolationCheck:
+  Exclude:
+    - 'spec/**/*'
+
+# We use :true and :false as AST node types.
+Lint/BooleanSymbol:
+  Enabled: false
+
 Lint/HandleExceptions:
   Exclude:
     - 'spec/reek/configuration/configuration_file_finder_spec.rb'
@@ -62,6 +71,15 @@ Metrics/LineLength:
 # Keyword arguments make long parameter lists readable
 Metrics/ParameterLists:
   CountKeywordArgs: false
+
+Naming/AccessorMethodName:
+  Exclude:
+    - 'lib/reek/context/visibility_tracker.rb'
+
+# EOS is a fine name to use in our specs
+Naming/HeredocDelimiterNaming:
+  Exclude:
+    - 'spec/**/*'
 
 # FIXME: Update specs to avoid offenses
 RSpec/AnyInstance:
@@ -108,10 +126,6 @@ RSpec/FilePath:
     - 'spec/reek/report/code_climate/code_climate_fingerprint_spec.rb'
     - 'spec/reek/report/code_climate/code_climate_formatter_spec.rb'
     - 'spec/reek/report/code_climate/code_climate_report_spec.rb'
-
-Style/AccessorMethodName:
-  Exclude:
-    - 'lib/reek/context/visibility_tracker.rb'
 
 # Allow and/or for control flow only
 Style/AndOr:

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ group :development do
   gem 'yard',          '~> 0.9.5'
 
   if RUBY_VERSION >= '2.3'
-    gem 'rubocop',       '~> 0.49.1'
-    gem 'rubocop-rspec', '~> 1.15.0'
+    gem 'rubocop',       '~> 0.50.0'
+    gem 'rubocop-rspec', '~> 1.17.0'
   end
 
   platforms :mri do

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -82,7 +82,7 @@ module Reek
 
       def set_banner
         program_name = parser.program_name
-        parser.banner = <<-EOB.gsub(/^[ ]+/, '')
+        parser.banner = <<-BANNER.gsub(/^[ ]+/, '')
           Usage: #{program_name} [options] [files]
 
           Examples:
@@ -93,7 +93,7 @@ module Reek
 
           See https://wiki.github.com/troessner/reek for detailed help.
 
-        EOB
+        BANNER
       end
 
       # :reek:TooManyStatements: { max_statements: 6 }

--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -18,7 +18,7 @@ module Reek
     # The order in which ConfigurationFileFinder tries to find such a
     # configuration file is exactly like above.
     module ConfigurationFileFinder
-      TOO_MANY_CONFIGURATION_FILES_MESSAGE = <<-EOS.freeze
+      TOO_MANY_CONFIGURATION_FILES_MESSAGE = <<-MESSAGE.freeze
 
         Error: Found multiple configuration files %s
         while scanning directory %s.
@@ -27,7 +27,7 @@ module Reek
         1) Remove all offending files.
         2) Be specific about which one you want to load via the -c switch.
 
-      EOS
+      MESSAGE
 
       class << self
         #
@@ -64,7 +64,7 @@ module Reek
           return {} unless path
           begin
             configuration = YAML.load_file(path) || {}
-          rescue => error
+          rescue StandardError => error
             raise ConfigFileException, "Invalid configuration file #{path}, error is #{error}"
           end
 

--- a/lib/reek/errors/bad_detector_configuration_key_in_comment_error.rb
+++ b/lib/reek/errors/bad_detector_configuration_key_in_comment_error.rb
@@ -7,7 +7,7 @@ module Reek
     # Gets raised when trying to configure a detector with an option
     # which is unknown to it.
     class BadDetectorConfigurationKeyInCommentError < BaseError
-      UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-EOS.freeze
+      UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-MESSAGE.freeze
 
         Error: You are trying to configure the smell detector '%s'
         in one of your source code comments with the unknown option %s.
@@ -22,7 +22,7 @@ module Reek
           * what custom options are available by checking the detector specific documentation in /docs
         Update the offensive comment (or remove it if no longer applicable) and re-run Reek.
 
-      EOS
+      MESSAGE
 
       def initialize(detector_name:, offensive_keys:, source:, line:, original_comment:)
         message = format(UNKNOWN_SMELL_DETECTOR_MESSAGE,

--- a/lib/reek/errors/bad_detector_in_comment_error.rb
+++ b/lib/reek/errors/bad_detector_in_comment_error.rb
@@ -8,7 +8,7 @@ module Reek
     # This might happen for multiple reasons. The users might have a typo in
     # his comment or he might use a detector that does not exist anymore.
     class BadDetectorInCommentError < BaseError
-      UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-EOS.freeze
+      UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-MESSAGE.freeze
 
         Error: You are trying to configure an unknown smell detector '%s' in one
         of your source code comments.
@@ -22,7 +22,7 @@ module Reek
           * what smell detectors are available: https://github.com/troessner/reek/blob/master/docs/Code-Smells.md
         Update the offensive comment (or remove it if no longer applicable) and re-run Reek.
 
-      EOS
+      MESSAGE
 
       def initialize(detector_name:, source:, line:, original_comment:)
         message = format(UNKNOWN_SMELL_DETECTOR_MESSAGE,

--- a/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
+++ b/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
@@ -7,7 +7,7 @@ module Reek
     # Gets raised when trying to use a configuration for a detector
     # that can't be parsed into a hash.
     class GarbageDetectorConfigurationInCommentError < BaseError
-      BAD_DETECTOR_CONFIGURATION_MESSAGE = <<-EOS.freeze
+      BAD_DETECTOR_CONFIGURATION_MESSAGE = <<-MESSAGE.freeze
 
         Error: You are trying to configure the smell detector '%s'.
         Unfortunately we can not parse the configuration you have given.
@@ -21,7 +21,7 @@ module Reek
           * what smell detectors are available: https://github.com/troessner/reek/blob/master/docs/Code-Smells.md
         Update the offensive comment (or remove it if no longer applicable) and re-run Reek.
 
-      EOS
+      MESSAGE
 
       def initialize(detector_name:, source:, line:, original_comment:)
         message = format(BAD_DETECTOR_CONFIGURATION_MESSAGE,

--- a/lib/reek/errors/incomprehensible_source_error.rb
+++ b/lib/reek/errors/incomprehensible_source_error.rb
@@ -6,7 +6,7 @@ module Reek
   module Errors
     # Gets raised when Reek is unable to process the source
     class IncomprehensibleSourceError < BaseError
-      INCOMPREHENSIBLE_SOURCE_TEMPLATE = <<-EOS.freeze
+      INCOMPREHENSIBLE_SOURCE_TEMPLATE = <<-MESSAGE.freeze
         !!!
         Source %s can not be processed by Reek.
 
@@ -34,7 +34,7 @@ module Reek
         %s
 
         !!!
-      EOS
+      MESSAGE
 
       def initialize(origin:, original_exception:)
         message = format(INCOMPREHENSIBLE_SOURCE_TEMPLATE,

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 require File.join(File.dirname(__FILE__), 'lib/reek/version')
 
 Gem::Specification.new do |s|

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe Reek::AST::SexpExtensions::SendNode do
     let(:node) { sexp(:send, nil, :hello) }
 
     it 'is not considered to be a writable attr' do
-      expect(sexp(:send, nil, :attr).attr_with_writable_flag?).to be_falsey
+      expect(sexp(:send, nil, :attr)).not_to be_attr_with_writable_flag
     end
   end
 
@@ -312,15 +312,15 @@ RSpec.describe Reek::AST::SexpExtensions::SendNode do
     let(:bare_new) { sexp(:send, nil, :new) }
 
     it 'is not considered to be a module creation call' do
-      expect(bare_new.module_creation_call?).to be_falsey
+      expect(bare_new).not_to be_module_creation_call
     end
 
     it 'is not considered to have a module creation receiver' do
-      expect(bare_new.module_creation_receiver?).to be_falsey
+      expect(bare_new).not_to be_module_creation_receiver
     end
 
     it 'is considered to be an object creation call' do
-      expect(bare_new.object_creation_call?).to be_truthy
+      expect(bare_new).to be_object_creation_call
     end
   end
 
@@ -328,15 +328,15 @@ RSpec.describe Reek::AST::SexpExtensions::SendNode do
     let(:node) { Reek::Source::SourceCode.from('(foo ? bar : baz).new').syntax_tree }
 
     it 'is not considered to be a module creation call' do
-      expect(node.module_creation_call?).to be_falsey
+      expect(node).not_to be_module_creation_call
     end
 
     it 'is not considered to have a module creation receiver' do
-      expect(node.module_creation_receiver?).to be_falsey
+      expect(node).not_to be_module_creation_receiver
     end
 
     it 'is considered to be an object creation call' do
-      expect(node.object_creation_call?).to be_truthy
+      expect(node).to be_object_creation_call
     end
   end
 end
@@ -446,14 +446,14 @@ RSpec.describe Reek::AST::SexpExtensions::CasgnNode do
     context 'with single assignment' do
       it 'does not define a module' do
         exp = sexp(:casgn, nil, :Foo)
-        expect(exp.defines_module?).to be_falsey
+        expect(exp).not_to be_defines_module
       end
     end
 
     context 'with implicit receiver to new' do
       it 'does not define a module' do
         exp = sexp(:casgn, nil, :Foo, sexp(:send, nil, :new))
-        expect(exp.defines_module?).to be_falsey
+        expect(exp).not_to be_defines_module
       end
     end
 
@@ -461,7 +461,7 @@ RSpec.describe Reek::AST::SexpExtensions::CasgnNode do
       it 'does not define a module' do
         exp = Reek::Source::SourceCode.from('Foo = Class.new(Bar)').syntax_tree
 
-        expect(exp.defines_module?).to be_truthy
+        expect(exp).to be_defines_module
       end
     end
 
@@ -469,7 +469,7 @@ RSpec.describe Reek::AST::SexpExtensions::CasgnNode do
       it 'does not define a module' do
         exp = Reek::Source::SourceCode.from('C = ->{}').syntax_tree
 
-        expect(exp.defines_module?).to be_falsey
+        expect(exp).not_to be_defines_module
       end
     end
 
@@ -477,7 +477,7 @@ RSpec.describe Reek::AST::SexpExtensions::CasgnNode do
       it 'does not define a module' do
         exp = Reek::Source::SourceCode.from('C = "hello"').syntax_tree
 
-        expect(exp.defines_module?).to be_falsey
+        expect(exp).not_to be_defines_module
       end
     end
   end

--- a/spec/reek/cli/application_spec.rb
+++ b/spec/reek/cli/application_spec.rb
@@ -15,13 +15,11 @@ RSpec.describe Reek::CLI::Application do
     end
   end
 
-  let(:path_excluded_in_configuration) do
-    SAMPLES_PATH.join('source_with_exclude_paths/ignore_me/uncommunicative_method_name.rb')
-  end
-
-  let(:configuration) { test_configuration_for(CONFIG_PATH.join('with_excluded_paths.reek')) }
-
   describe '#execute' do
+    let(:path_excluded_in_configuration) do
+      SAMPLES_PATH.join('source_with_exclude_paths/ignore_me/uncommunicative_method_name.rb')
+    end
+    let(:configuration) { test_configuration_for(CONFIG_PATH.join('with_excluded_paths.reek')) }
     let(:command) { instance_double 'Reek::CLI::Command::ReportCommand' }
     let(:app) { described_class.new [] }
 

--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'fileutils'
 require 'pathname'
 require 'tmpdir'

--- a/spec/reek/smell_detectors/base_detector_spec.rb
+++ b/spec/reek/smell_detectors/base_detector_spec.rb
@@ -21,16 +21,15 @@ RSpec.describe Reek::SmellDetectors::BaseDetector do
     context 'with default exclusions present' do
       let(:subclass) { Reek::SmellDetectors::TooManyStatements }
 
-      before do
-        expect(subclass.default_config['exclude']).to eq ['initialize']
-      end
-
       it 'includes default exclusions' do
         detector = subclass.new
         smell = create(:smell_warning, smell_detector: detector, context: 'Foo#bar')
         result = subclass.todo_configuration_for([smell])
 
-        expect(result).to eq('TooManyStatements' => { 'exclude' => ['initialize', 'Foo#bar'] })
+        aggregate_failures do
+          expect(subclass.default_config['exclude']).to eq ['initialize']
+          expect(result).to eq('TooManyStatements' => { 'exclude' => ['initialize', 'Foo#bar'] })
+        end
       end
     end
   end

--- a/spec/reek/spec/should_reek_of_spec.rb
+++ b/spec/reek/spec/should_reek_of_spec.rb
@@ -27,16 +27,16 @@ RSpec.describe Reek::Spec::ShouldReekOf do
       let(:smelly_code) { 'def x() y = 4; end' }
 
       it 'matches a smelly String' do
-        expect(matcher.matches?(smelly_code)).to be_truthy
+        expect(matcher).to be_matches(smelly_code)
       end
 
       it 'doesnt match a fragrant String' do
-        expect(matcher.matches?(clean_code)).to be_falsey
+        expect(matcher).not_to be_matches(clean_code)
       end
 
       it 're-calculates matches every time' do
         matcher.matches? smelly_code
-        expect(matcher.matches?(clean_code)).to be_falsey
+        expect(matcher).not_to be_matches(clean_code)
       end
     end
 
@@ -44,11 +44,11 @@ RSpec.describe Reek::Spec::ShouldReekOf do
       let(:matcher) { described_class.new(:UncommunicativeMethodName, name: 'x') }
 
       it 'matches a smelly file' do
-        expect(matcher.matches?(SMELLY_FILE)).to be_truthy
+        expect(matcher).to be_matches(SMELLY_FILE)
       end
 
       it 'doesnt match a fragrant file' do
-        expect(matcher.matches?(CLEAN_FILE)).to be_falsey
+        expect(matcher).not_to be_matches(CLEAN_FILE)
       end
     end
   end
@@ -68,7 +68,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
       let(:smelly_code) { 'def x() y = 4; end' }
 
       it 'is truthy' do
-        expect(matcher.matches?(smelly_code)).to be_truthy
+        expect(matcher).to be_matches(smelly_code)
       end
     end
 
@@ -79,7 +79,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
       let(:truthy_matcher) { described_class.new(:UncommunicativeVariableName, name: 'y') }
 
       it 'is falsey' do
-        expect(falsey_matcher.matches?(smelly_code)).to be_falsey
+        expect(falsey_matcher).not_to be_matches(smelly_code)
       end
 
       it 'sets the proper error message' do
@@ -102,7 +102,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
       let(:matcher) { described_class.new(:DuplicateMethodCall, name: 'foo', count: 15) }
 
       it 'is falsey' do
-        expect(matcher.matches?(smelly_code)).to be_falsey
+        expect(matcher).not_to be_matches(smelly_code)
       end
 
       it 'sets the proper error message' do
@@ -130,14 +130,14 @@ RSpec.describe Reek::Spec::ShouldReekOf do
   end
 
   context 'for a smell that is disabled by default' do
-    before do
-      default_config = Reek::SmellDetectors::UnusedPrivateMethod.default_config
-      expect(default_config[Reek::SmellConfiguration::ENABLED_KEY]).to be_falsy
-    end
-
     it 'enables the smell detector to match automatically' do
+      default_config = Reek::SmellDetectors::UnusedPrivateMethod.default_config
       src = 'class C; private; def foo; end; end'
-      expect(src).to reek_of(:UnusedPrivateMethod)
+
+      aggregate_failures do
+        expect(default_config[Reek::SmellConfiguration::ENABLED_KEY]).to be_falsy
+        expect(src).to reek_of(:UnusedPrivateMethod)
+      end
     end
   end
 
@@ -146,13 +146,13 @@ RSpec.describe Reek::Spec::ShouldReekOf do
     let(:configured_matcher) { matcher.with_config('accept' => 'x') }
 
     it 'uses the passed-in configuration for matching' do
-      expect(configured_matcher.matches?('def foo; q = 2; end')).to be_truthy
-      expect(configured_matcher.matches?('def foo; x = 2; end')).to be_falsey
+      expect(configured_matcher).to be_matches('def foo; q = 2; end')
+      expect(configured_matcher).not_to be_matches('def foo; x = 2; end')
     end
 
     it 'leaves the original matcher intact' do
-      expect(configured_matcher.matches?('def foo; x = 2; end')).to be_falsey
-      expect(matcher.matches?('def foo; x = 2; end')).to be_truthy
+      expect(configured_matcher).not_to be_matches('def foo; x = 2; end')
+      expect(matcher).to be_matches('def foo; x = 2; end')
     end
   end
 end

--- a/spec/reek/spec/should_reek_spec.rb
+++ b/spec/reek/spec/should_reek_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Reek::Spec::ShouldReek do
     let(:smelly_code) { 'def x() y = 4; end' }
 
     it 'matches a smelly String' do
-      expect(matcher.matches?(smelly_code)).to be_truthy
+      expect(matcher).to be_matches(smelly_code)
     end
 
     it 'doesnt match a fragrant String' do
-      expect(matcher.matches?(clean_code)).to be_falsey
+      expect(matcher).not_to be_matches(clean_code)
     end
 
     it 'reports the smells when should_not fails' do
@@ -26,11 +26,11 @@ RSpec.describe Reek::Spec::ShouldReek do
       let(:matcher) { described_class.new }
 
       it 'matches a smelly File' do
-        expect(matcher.matches?(SMELLY_FILE)).to be_truthy
+        expect(matcher).to be_matches(SMELLY_FILE)
       end
 
       it 'doesnt match a fragrant File' do
-        expect(matcher.matches?(CLEAN_FILE)).to be_falsey
+        expect(matcher).not_to be_matches(CLEAN_FILE)
       end
 
       it 'reports the smells when should_not fails' do
@@ -45,7 +45,7 @@ RSpec.describe Reek::Spec::ShouldReek do
       let(:matcher) { described_class.new(configuration: configuration) }
 
       it 'masks smells using the relevant configuration' do
-        expect(matcher.matches?(SMELLY_FILE)).to be_falsey
+        expect(matcher).not_to be_matches(SMELLY_FILE)
       end
     end
   end

--- a/spec/reek/spec/smell_matcher_spec.rb
+++ b/spec/reek/spec/smell_matcher_spec.rb
@@ -12,33 +12,33 @@ RSpec.describe Reek::Spec::SmellMatcher do
 
   context '#matches?' do
     it 'matches on class symbol' do
-      expect(matcher.matches?(:UncommunicativeVariableName)).to be_truthy
+      expect(matcher).to be_matches(:UncommunicativeVariableName)
     end
 
     it 'matches on class symbol and params' do
-      expect(matcher.matches?(:UncommunicativeVariableName,
-                              test: 'something')).to be_truthy
+      expect(matcher).to be_matches(:UncommunicativeVariableName,
+                                    test: 'something')
     end
 
     it 'matches on class symbol, params and attributes' do
-      expect(matcher.matches?(:UncommunicativeVariableName,
-                              test: 'something',
-                              message: "has the variable name '@s'")).to be_truthy
+      expect(matcher).to be_matches(:UncommunicativeVariableName,
+                                    test: 'something',
+                                    message: "has the variable name '@s'")
     end
 
     it 'does not match on different class symbol' do
-      expect(matcher.matches?(:FeatureEnvy)).to be_falsy
+      expect(matcher).not_to be_matches(:FeatureEnvy)
     end
 
     it 'does not match on different params' do
-      expect(matcher.matches?(:UncommunicativeVariableName,
-                              test: 'something else')).to be_falsy
+      expect(matcher).not_to be_matches(:UncommunicativeVariableName,
+                                        test: 'something else')
     end
 
     it 'does not match on different attributes' do
-      expect(matcher.matches?(:UncommunicativeVariableName,
-                              test: 'something',
-                              message: 'nothing')).to be_falsy
+      expect(matcher).not_to be_matches(:UncommunicativeVariableName,
+                                        test: 'something',
+                                        message: 'nothing')
     end
 
     it 'raises error on uncomparable attribute' do
@@ -52,31 +52,31 @@ RSpec.describe Reek::Spec::SmellMatcher do
 
   context '#matches_smell_type?' do
     it 'matches on class symbol' do
-      expect(matcher.matches_smell_type?(:UncommunicativeVariableName)).to be_truthy
+      expect(matcher).to be_matches_smell_type(:UncommunicativeVariableName)
     end
 
     it 'does not match on different class symbol' do
-      expect(matcher.matches_smell_type?(:FeatureEnvy)).to be_falsy
+      expect(matcher).not_to be_matches_smell_type(:FeatureEnvy)
     end
   end
 
   context '#matches_attributes?' do
     it 'matches on params' do
-      expect(matcher.matches_attributes?(test: 'something')).to be_truthy
+      expect(matcher).to be_matches_attributes(test: 'something')
     end
 
     it 'matches on class symbol, params and attributes' do
-      expect(matcher.matches_attributes?(test: 'something',
-                                         message: "has the variable name '@s'")).to be_truthy
+      expect(matcher).to be_matches_attributes(test: 'something',
+                                               message: "has the variable name '@s'")
     end
 
     it 'does not match on different params' do
-      expect(matcher.matches_attributes?(test: 'something else')).to be_falsy
+      expect(matcher).not_to be_matches_attributes(test: 'something else')
     end
 
     it 'does not match on different attributes' do
-      expect(matcher.matches_attributes?(test: 'something',
-                                         message: 'nothing')).to be_falsy
+      expect(matcher).not_to be_matches_attributes(test: 'something',
+                                                   message: 'nothing')
     end
 
     it 'raises error on uncomparable attribute' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,7 +90,7 @@ RSpec.configure do |config|
   # mutation tester. Set the DEBUG environment variable to something truthy
   # like '1' to disable this and allow using pry without specs failing.
   unless ENV['DEBUG']
-    config.around(:each) do |example|
+    config.around do |example|
       Timeout.timeout(5, &example)
     end
   end


### PR DESCRIPTION
Noteworthy parts:
* I only corrected HeredocDelimiterNaming in `lib/`, not in `spec/`.
* I disabled InterpolationCheck and BooleanSymbol.