### PR TITLE
Improve wording of exception messages and other texts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ regard than if it were run in a terminal.
 
 #### Failing Cucumber Scenarios
 
-If there is a failing scenario and you can not figure out why it is failing,
+If there is a failing scenario and you cannot figure out why it is failing,
 just run the failing scenario: `bundle exec cucumber
 features/failing_scenario.feature:line`. By doing so Aruba will leave its set
 up in the `tmp/aruba` directory. You can then `cd` into this directory and run

--- a/docs/Unused-Private-Method.md
+++ b/docs/Unused-Private-Method.md
@@ -78,7 +78,7 @@ end
 ## Known limitations
 
 * Method calls via dynamic dispatch (e.g. via `send`) is something Reek (or any other
-  static tool for that matter) can not detect.
+  static tool for that matter) cannot detect.
 * Method calls via callback like [Rails filters](http://guides.rubyonrails.org/action_controller_overview.html#filters)
   will trigger this as well, e.g.:
 

--- a/features/configuration_via_source_comments/erroneous_source_comments.feature
+++ b/features/configuration_via_source_comments/erroneous_source_comments.feature
@@ -48,7 +48,7 @@ Feature: Erroneous source comments are handled properly
       """
     When I run reek bad_comment.rb
     Then it reports the error "Error: You are trying to configure the smell detector 'UncommunicativeMethodName'"
-    And it reports the error "Unfortunately we can not parse the configuration you have given."
+    And it reports the error "Unfortunately we cannot parse the configuration you have given."
     And it reports the error "The source is 'bad_comment.rb'"
     And it reports the error "the comment belongs to the expression starting in line 3"
 

--- a/lib/reek/errors/encoding_error.rb
+++ b/lib/reek/errors/encoding_error.rb
@@ -8,7 +8,7 @@ module Reek
     class EncodingError < BaseError
       ENCODING_ERROR_TEMPLATE = <<-MESSAGE.freeze
         !!!
-        Source '%s' can not be processed by Reek due to an encoding error in the source file.
+        Source '%s' cannot be processed by Reek due to an encoding error in the source file.
 
         This is a problem that is outside of Reek's scope and should be fixed by you, the
         user, in order for Reek being able to continue.

--- a/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
+++ b/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
@@ -10,7 +10,7 @@ module Reek
       BAD_DETECTOR_CONFIGURATION_MESSAGE = <<-MESSAGE.freeze
 
         Error: You are trying to configure the smell detector '%s'.
-        Unfortunately we can not parse the configuration you have given.
+        Unfortunately we cannot parse the configuration you have given.
         The source is '%s' and the comment belongs to the expression starting in line %d.
         Here's the original comment:
 

--- a/lib/reek/errors/incomprehensible_source_error.rb
+++ b/lib/reek/errors/incomprehensible_source_error.rb
@@ -8,9 +8,9 @@ module Reek
     class IncomprehensibleSourceError < BaseError
       INCOMPREHENSIBLE_SOURCE_TEMPLATE = <<-MESSAGE.freeze
         !!!
-        Source %s can not be processed by Reek.
+        Source %s cannot be processed by Reek.
 
-        This is most likely either a bug in your Reek configuration (config file or
+        This is most likely either a problem in your Reek configuration (config file or
         source code comments) or a Reek bug.
 
         Please double check your Reek configuration taking the original exception

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Reek::Source::SourceCode do
     end
 
     it 'explains the origin of the error' do
-      message = "Source '#{source_name}' can not be processed by Reek due to an encoding error in the source file."
+      message = "Source '#{source_name}' cannot be processed by Reek due to an encoding error in the source file."
       expect { src.syntax_tree }.to raise_error.with_message(/#{message}/)
     end
   end


### PR DESCRIPTION
Mainly changes 'can not' to 'cannot'.