### PR TITLE
Simplify error handling in SourceCode

### DIFF
--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -3,6 +3,7 @@
 require_relative 'context_builder'
 require_relative 'detector_repository'
 require_relative 'errors/incomprehensible_source_error'
+require_relative 'errors/encoding_error'
 require_relative 'source/source_code'
 
 module Reek
@@ -112,8 +113,10 @@ module Reek
       case exception
       when Errors::BaseError
         exception
+      when EncodingError
+        Errors::EncodingError.new origin: origin, original_exception: exception
       else
-        Errors::IncomprehensibleSourceError.new(origin: origin, original_exception: exception)
+        Errors::IncomprehensibleSourceError.new origin: origin, original_exception: exception
       end
     end
 

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -7,7 +7,6 @@ end
 require_relative '../tree_dresser'
 require_relative '../ast/node'
 require_relative '../ast/builder'
-require_relative '../errors/encoding_error'
 
 # Opt in to new way of representing lambdas
 Reek::AST::Builder.emit_lambda = true
@@ -109,20 +108,12 @@ module Reek
       # @param source [String] - Ruby code
       # @return [Anonymous subclass of Reek::AST::Node] the AST presentation
       #         for the given source
-      # :reek:TooManyStatements { max_statements: 8 }
+      # :reek:TooManyStatements { max_statements: 6 }
       def parse(parser, source)
-        begin
-          buffer = Parser::Source::Buffer.new(origin, 1)
-          source.force_encoding(Encoding::UTF_8)
-          buffer.source = source
-        rescue EncodingError => exception
-          raise Errors::EncodingError, origin: origin, original_exception: exception
-        end
-        begin
-          ast, comments = parser.parse_with_comments(buffer)
-        rescue Parser::SyntaxError # rubocop:disable Lint/HandleExceptions
-          # All errors are in diagnostics. No need to handle exception.
-        end
+        buffer = Parser::Source::Buffer.new(origin, 1)
+        source.force_encoding(Encoding::UTF_8)
+        buffer.source = source
+        ast, comments = parser.parse_with_comments(buffer)
 
         # See https://whitequark.github.io/parser/Parser/Source/Comment/Associator.html
         comment_map = Parser::Source::Comment.associate(ast, comments) if ast

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -180,6 +180,29 @@ RSpec.describe Reek::Examiner do
     end
   end
 
+  context 'with a source that triggers an encoding error' do
+    let(:examiner) { described_class.new(source) }
+    let(:source) do
+      <<-SRC.strip_heredoc
+      # encoding: US-ASCII
+      puts 'こんにちは世界'
+      SRC
+    end
+
+    it 'does not raise an error during initialization' do
+      expect { examiner }.not_to raise_error
+    end
+
+    it 'raises an encoding error when asked for smells' do
+      expect { examiner.smells }.to raise_error Reek::Errors::EncodingError
+    end
+
+    it 'explains the origin of the error' do
+      message = "Source 'string' cannot be processed by Reek due to an encoding error in the source file."
+      expect { examiner.smells }.to raise_error.with_message(/#{message}/)
+    end
+  end
+
   describe 'bad comment config' do
     let(:examiner) { described_class.new(source) }
 

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -39,26 +39,6 @@ RSpec.describe Reek::Source::SourceCode do
     end
   end
 
-  context 'with a source that triggers an encoding error' do
-    let(:source_name) { 'Bad source' }
-    let(:code) do
-      <<-SRC.strip_heredoc
-      # encoding: US-ASCII
-      puts 'こんにちは世界'
-      SRC
-    end
-    let(:src) { described_class.new(code: code, origin: source_name) }
-
-    it 'raises an encoding error' do
-      expect { src.syntax_tree }.to raise_error Reek::Errors::EncodingError
-    end
-
-    it 'explains the origin of the error' do
-      message = "Source '#{source_name}' cannot be processed by Reek due to an encoding error in the source file."
-      expect { src.syntax_tree }.to raise_error.with_message(/#{message}/)
-    end
-  end
-
   context 'when the parser fails' do
     let(:source_name) { 'Test source' }
     let(:src) { described_class.new(code: code, origin: source_name, **parser) }


### PR DESCRIPTION
- Move error wrapping to Examiner
- Do not rescue ParseError since it is never raised