### PR TITLE
Update rubocop-rspec and fix new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -117,6 +117,7 @@ RSpec/MultipleExpectations:
 # FIXME: Update specs to avoid offenses
 RSpec/NestedGroups:
   Exclude:
+    - 'spec/reek/report/code_climate/code_climate_fingerprint_spec.rb'
     - 'spec/reek/cli/application_spec.rb'
 
 # rubocop-rspec expects a CodeClimate namespace to go with the code_climate directory.

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :development do
 
   if RUBY_VERSION >= '2.3'
     gem 'rubocop',       '~> 0.51.0'
-    gem 'rubocop-rspec', '~> 1.19.0'
+    gem 'rubocop-rspec', '~> 1.20.0'
   end
 
   platforms :mri do

--- a/spec/reek/ast/node_spec.rb
+++ b/spec/reek/ast/node_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Reek::AST::Node do
     end
   end
 
-  context 'hash' do
+  describe '#hash' do
     it 'hashes equal for equal sexps' do
       node1 = sexp(:def, :jim, sexp(:args), sexp(:send, sexp(:int, 4), :+, sexp(:send, nil, :fred)))
       node2 = sexp(:def, :jim, sexp(:args), sexp(:send, sexp(:int, 4), :+, sexp(:send, nil, :fred)))
@@ -77,7 +77,7 @@ RSpec.describe Reek::AST::Node do
   end
 
   describe '#line' do
-    context 'source from file' do
+    context 'with source from a file' do
       let(:file) { SAMPLES_PATH.join('smelly.rb') }
       let(:ast) { Reek::Source::SourceCode.from(file).syntax_tree }
 
@@ -86,7 +86,7 @@ RSpec.describe Reek::AST::Node do
       end
     end
 
-    context 'source from string' do
+    context 'with source from a string' do
       let(:source) { File.read(SAMPLES_PATH.join('smelly.rb')) }
       let(:ast) { Reek::Source::SourceCode.from(source).syntax_tree }
 
@@ -97,7 +97,7 @@ RSpec.describe Reek::AST::Node do
   end
 
   describe '#source' do
-    context 'source from file' do
+    context 'with source from a file' do
       let(:file) { SAMPLES_PATH.join('smelly.rb') }
       let(:ast) { Reek::Source::SourceCode.from(file).syntax_tree }
 
@@ -106,7 +106,7 @@ RSpec.describe Reek::AST::Node do
       end
     end
 
-    context 'source from string' do
+    context 'with source from a string' do
       let(:source) { File.read(SAMPLES_PATH.join('smelly.rb')) }
       let(:ast) { Reek::Source::SourceCode.from(source).syntax_tree }
 

--- a/spec/reek/ast/reference_collector_spec.rb
+++ b/spec/reek/ast/reference_collector_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_lib 'reek/ast/reference_collector'
 
 RSpec.describe Reek::AST::ReferenceCollector do
-  context 'counting refs to self' do
+  describe '#num_refs_to_self' do
     def refs_to_self(src)
       syntax_tree = Reek::Source::SourceCode.from(src).syntax_tree
       described_class.new(syntax_tree).num_refs_to_self

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -374,7 +374,7 @@ end
 RSpec.describe Reek::AST::SexpExtensions::LambdaNode do
   let(:node) { sexp(:lambda) }
 
-  context '#name' do
+  describe '#name' do
     it 'returns :lambda' do
       expect(node.name).to eq 'lambda'
     end

--- a/spec/reek/cli/application_spec.rb
+++ b/spec/reek/cli/application_spec.rb
@@ -32,57 +32,55 @@ RSpec.describe Reek::CLI::Application do
       expect(app.execute).to eq 'foo'
     end
 
-    context 'when no source files given' do
-      context 'and input was piped' do
-        before do
-          allow_any_instance_of(IO).to receive(:tty?).and_return(false)
-        end
-
-        it 'uses source form pipe' do
-          app.execute
-          expect(Reek::CLI::Command::ReportCommand).to have_received(:new).
-            with(sources: [$stdin],
-                 configuration: Reek::Configuration::AppConfiguration,
-                 options: Reek::CLI::Options)
-        end
+    context 'when no source files given and input was piped' do
+      before do
+        allow_any_instance_of(IO).to receive(:tty?).and_return(false)
       end
 
-      context 'and input was not piped' do
+      it 'uses source form pipe' do
+        app.execute
+        expect(Reek::CLI::Command::ReportCommand).to have_received(:new).
+          with(sources: [$stdin],
+               configuration: Reek::Configuration::AppConfiguration,
+               options: Reek::CLI::Options)
+      end
+    end
+
+    context 'when no source files given and no input was piped' do
+      before do
+        allow_any_instance_of(IO).to receive(:tty?).and_return(true)
+      end
+
+      it 'uses working directory as source' do
+        expected_sources = Reek::Source::SourceLocator.new(['.']).sources
+        app.execute
+        expect(Reek::CLI::Command::ReportCommand).to have_received(:new).
+          with(sources: expected_sources,
+               configuration: Reek::Configuration::AppConfiguration,
+               options: Reek::CLI::Options)
+      end
+
+      context 'when source files are excluded through configuration' do
+        let(:app) { described_class.new ['--config', 'some_file.reek'] }
+
         before do
-          allow_any_instance_of(IO).to receive(:tty?).and_return(true)
+          allow(Reek::Configuration::AppConfiguration).
+            to receive(:from_path).
+            with(Pathname.new('some_file.reek')).
+            and_return configuration
         end
 
-        it 'uses working directory as source' do
-          expected_sources = Reek::Source::SourceLocator.new(['.']).sources
+        it 'uses configuration for excluded paths' do
+          expected_sources = Reek::Source::SourceLocator.
+            new(['.'], configuration: configuration).sources
+          expect(expected_sources).not_to include(path_excluded_in_configuration)
+
           app.execute
+
           expect(Reek::CLI::Command::ReportCommand).to have_received(:new).
             with(sources: expected_sources,
-                 configuration: Reek::Configuration::AppConfiguration,
+                 configuration: configuration,
                  options: Reek::CLI::Options)
-        end
-
-        context 'when source files are excluded through configuration' do
-          let(:app) { described_class.new ['--config', 'some_file.reek'] }
-
-          before do
-            allow(Reek::Configuration::AppConfiguration).
-              to receive(:from_path).
-              with(Pathname.new('some_file.reek')).
-              and_return configuration
-          end
-
-          it 'uses configuration for excluded paths' do
-            expected_sources = Reek::Source::SourceLocator.
-              new(['.'], configuration: configuration).sources
-            expect(expected_sources).not_to include(path_excluded_in_configuration)
-
-            app.execute
-
-            expect(Reek::CLI::Command::ReportCommand).to have_received(:new).
-              with(sources: expected_sources,
-                   configuration: configuration,
-                   options: Reek::CLI::Options)
-          end
         end
       end
     end

--- a/spec/reek/cli/command/todo_list_command_spec.rb
+++ b/spec/reek/cli/command/todo_list_command_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Reek::CLI::Command::TodoListCommand do
       allow(File).to receive(:write).with(described_class::FILE_NAME, String)
     end
 
-    context 'smells found' do
+    context 'when smells are found' do
       let(:source_file) { SMELLY_FILE }
 
       it 'shows a proper message' do
@@ -44,7 +44,7 @@ RSpec.describe Reek::CLI::Command::TodoListCommand do
       end
     end
 
-    context 'no smells found' do
+    context 'when no smells re found' do
       let(:source_file) { CLEAN_FILE }
 
       it 'shows a proper message' do

--- a/spec/reek/code_comment_spec.rb
+++ b/spec/reek/code_comment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Reek::CodeComment do
     end
   end
 
-  context 'comment checks' do
+  describe '#descriptive' do
     it 'rejects an empty comment' do
       comment = FactoryGirl.build(:code_comment, comment: '#')
       expect(comment).not_to be_descriptive
@@ -36,7 +36,7 @@ RSpec.describe Reek::CodeComment do
     end
   end
 
-  context 'good comment config' do
+  describe 'good comment config' do
     it 'parses hashed options' do
       comment = '# :reek:DuplicateMethodCall { enabled: false }'
       config = FactoryGirl.build(:code_comment,
@@ -125,7 +125,7 @@ RSpec.describe Reek::CodeComment do
 end
 
 RSpec.describe Reek::CodeComment::CodeCommentValidator do
-  context 'bad detector' do
+  context 'when the comment contains an unknown detector name' do
     it 'raises BadDetectorInCommentError' do
       expect do
         FactoryGirl.build(:code_comment,
@@ -134,7 +134,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
     end
   end
 
-  context 'unparsable detector configuration' do
+  context 'when the comment contains an unparsable detector configuration' do
     it 'raises GarbageDetectorConfigurationInCommentError' do
       expect do
         comment = '# :reek:UncommunicativeMethodName { thats: a: bad: config }'
@@ -144,7 +144,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
   end
 
   describe 'validating configuration keys' do
-    context 'basic options mispelled' do
+    context 'when basic options are mispelled' do
       it 'raises BadDetectorConfigurationKeyInCommentError' do
         expect do
           # exclude -> exlude and enabled -> nabled
@@ -154,7 +154,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
       end
     end
 
-    context 'basic options not mispelled' do
+    context 'when basic options are not mispelled' do
       it 'does not raise' do
         expect do
           comment = '# :reek:UncommunicativeMethodName { exclude: alfa, enabled: true }'
@@ -170,7 +170,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
       end
     end
 
-    context 'unknown custom options' do
+    context 'when unknown custom options are specified' do
       it 'raises BadDetectorConfigurationKeyInCommentError' do
         expect do
           # max_copies -> mx_copies and min_clump_size -> mn_clump_size
@@ -180,7 +180,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
       end
     end
 
-    context 'valid custom options' do
+    context 'when valid custom options are specified' do
       it 'does not raise' do
         expect do
           comment = '# :reek:DataClump { max_copies: 4, min_clump_size: 3 }'

--- a/spec/reek/configuration/app_configuration_spec.rb
+++ b/spec/reek/configuration/app_configuration_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Reek::Configuration::AppConfiguration do
   end
 
   describe '#directive_for' do
-    context 'multiple directory directives and no default directive present' do
+    context 'with multiple directory directives and no default directive present' do
       let(:source_via) { 'samples/three_clean_files/dummy.rb' }
       let(:baz_config)  { { Reek::SmellDetectors::IrresponsibleModule => { enabled: false } } }
       let(:bang_config) { { Reek::SmellDetectors::Attribute => { enabled: true } } }
@@ -93,7 +93,7 @@ RSpec.describe Reek::Configuration::AppConfiguration do
       end
     end
 
-    context 'directory directive and default directive present' do
+    context 'with directory directive and default directive present' do
       let(:directory) { 'spec/samples/two_smelly_files/' }
       let(:directory_config) { { Reek::SmellDetectors::TooManyStatements => { max_statements: 8 } } }
       let(:directory_directives) { { directory => directory_config } }
@@ -116,7 +116,7 @@ RSpec.describe Reek::Configuration::AppConfiguration do
       end
     end
 
-    context 'no directory directive but a default directive present' do
+    context 'with no directory directive but a default directive present' do
       let(:source_via) { 'spec/samples/three_clean_files/dummy.rb' }
       let(:default_directive) { { Reek::SmellDetectors::IrresponsibleModule => { enabled: false } } }
       let(:attribute_config) { { Reek::SmellDetectors::Attribute => { enabled: false } } }

--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Reek::Configuration::ConfigurationFileFinder do
       end
     end
 
-    context 'more than one configuration file' do
+    context 'with more than one configuration file' do
       let(:path) { CONFIG_PATH.join('more_than_one_configuration_file') }
 
       it 'prints a message on STDERR' do

--- a/spec/reek/configuration/directory_directives_spec.rb
+++ b/spec/reek/configuration/directory_directives_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
     end
     let(:source_via) { 'foo/bar/bang/dummy.rb' }
 
-    context 'our source is in a directory for which we have a directive' do
+    context 'when our source is in a directory for which we have a directive' do
       it 'returns the corresponding directive' do
         expect(directives.directive_for(source_via)).to eq(bang_config)
       end
     end
 
-    context 'our source is not in a directory for which we have a directive' do
+    context 'when our source is not in a directory for which we have a directive' do
       it 'returns nil' do
         expect(directives.directive_for('does/not/exist')).to eq(nil)
       end
@@ -31,7 +31,7 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
       {}.extend(described_class)
     end
 
-    context 'one of given paths is a file' do
+    context 'when one of given paths is a file' do
       let(:file_as_path) { SAMPLES_PATH.join('inline.rb') }
 
       it 'raises an error' do

--- a/spec/reek/configuration/excluded_paths_spec.rb
+++ b/spec/reek/configuration/excluded_paths_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reek::Configuration::ExcludedPaths do
   describe '#add' do
     let(:exclusions) { [].extend(described_class) }
 
-    context 'one of given paths is a file' do
+    context 'when one of given paths is a file' do
       let(:file_as_path) { SAMPLES_PATH.join('inline.rb') }
       let(:paths) { [SAMPLES_PATH, file_as_path] }
 

--- a/spec/reek/context/ghost_context_spec.rb
+++ b/spec/reek/context/ghost_context_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Reek::Context::GhostContext do
       expect(ghost.children).to include child
     end
 
-    context 'if the grandparent is also a ghost' do
+    context 'when the grandparent is also a ghost' do
       let(:child_ghost) { described_class.new(nil) }
 
       before do

--- a/spec/reek/context/root_context_spec.rb
+++ b/spec/reek/context/root_context_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_lib 'reek/context/root_context'
 
 RSpec.describe Reek::Context::RootContext do
-  context 'full_name' do
+  describe '#full_name' do
     it 'reports full context' do
       ast = Reek::Source::SourceCode.from('foo = 1').syntax_tree
       root = described_class.new(ast)

--- a/spec/reek/report/code_climate/code_climate_fingerprint_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_fingerprint_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
   describe '#compute' do
     let(:computed) { described_class.new(warning).compute }
 
-    shared_examples_for 'computes a fingerprint with no parameters' do
+    context 'when fingerprinting a warning with no parameters' do
       let(:expected_fingerprint) { 'e68badd29db51c92363a7c6a2438d722' }
       let(:warning) do
         FactoryGirl.build(:smell_warning,
@@ -16,21 +16,21 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
                           source:         'a/ruby/source/file.rb')
       end
 
-      it 'computes the fingerprint' do
-        expect(computed).to eq expected_fingerprint
+      context 'with code at a specific location' do
+        let(:lines) { [1] }
+
+        it 'computes the fingerprint' do
+          expect(computed).to eq expected_fingerprint
+        end
       end
-    end
 
-    context 'with code at a specific location' do
-      let(:lines) { [1] }
+      context 'with code at a different location' do
+        let(:lines) { [5] }
 
-      it_behaves_like 'computes a fingerprint with no parameters'
-    end
-
-    context 'with code at a different location' do
-      let(:lines) { [5] }
-
-      it_behaves_like 'computes a fingerprint with no parameters'
+        it 'computes the same fingerprint' do
+          expect(computed).to eq expected_fingerprint
+        end
+      end
     end
 
     context 'when the fingerprint should not be computed' do
@@ -48,7 +48,7 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
       end
     end
 
-    shared_examples_for 'computes a fingerprint with identifying parameters' do
+    context 'when the smell warning has only identifying parameters' do
       let(:warning) do
         FactoryGirl.build(:smell_warning,
                           smell_detector: Reek::SmellDetectors::ClassVariable.new,
@@ -59,26 +59,26 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
                           source:         'a/ruby/source/file.rb')
       end
 
-      it 'computes the fingerprint' do
-        expect(computed).to eq expected_fingerprint
+      context 'when the name is one thing' do
+        let(:name) { 'bravo' }
+        let(:expected_fingerprint) { '9c3fd378178118a67e9509f87cae24f9' }
+
+        it 'computes the fingerprint' do
+          expect(computed).to eq expected_fingerprint
+        end
+      end
+
+      context 'when the name is another thing' do
+        let(:name) { 'echo' }
+        let(:expected_fingerprint) { 'd2a6d2703ce04cca65e7300b7de4b89f' }
+
+        it 'computes another fingerprint' do
+          expect(computed).to eq expected_fingerprint
+        end
       end
     end
 
-    context 'when the name is one thing it has one fingerprint' do
-      let(:name) { 'bravo' }
-      let(:expected_fingerprint) { '9c3fd378178118a67e9509f87cae24f9' }
-
-      it_behaves_like 'computes a fingerprint with identifying parameters'
-    end
-
-    context 'when the name is another thing it has another fingerprint' do
-      let(:name) { 'echo' }
-      let(:expected_fingerprint) { 'd2a6d2703ce04cca65e7300b7de4b89f' }
-
-      it_behaves_like 'computes a fingerprint with identifying parameters'
-    end
-
-    shared_examples_for 'computes a fingerprint with identifying and non-identifying parameters' do
+    context 'when the smell warning has identifying and non-identifying parameters' do
       let(:warning) do
         FactoryGirl.build(:smell_warning,
                           smell_detector: Reek::SmellDetectors::DuplicateMethodCall.new,
@@ -89,36 +89,38 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
                           source:         'a/ruby/source/file.rb')
       end
 
-      it 'computes the fingerprint' do
-        expect(computed).to eq expected_fingerprint
+      context 'when the parameters are provided' do
+        let(:name) { 'bravo' }
+        let(:count) { 5 }
+        let(:lines) { [1, 7, 10, 13, 15] }
+        let(:expected_fingerprint) { '238733f4f51ba5473dcbe94a43ec5400' }
+
+        it 'computes the fingerprint' do
+          expect(computed).to eq expected_fingerprint
+        end
       end
-    end
 
-    context 'when the parameters are provided' do
-      let(:name) { 'bravo' }
-      let(:count) { 5 }
-      let(:lines) { [1, 7, 10, 13, 15] }
-      let(:expected_fingerprint) { '238733f4f51ba5473dcbe94a43ec5400' }
+      context 'when the non-identifying parameters change' do
+        let(:name) { 'bravo' }
+        let(:count) { 9 }
+        let(:lines) { [1, 7, 10, 13, 15, 17, 19, 20, 25] }
+        let(:expected_fingerprint) { '238733f4f51ba5473dcbe94a43ec5400' }
 
-      it_behaves_like 'computes a fingerprint with identifying and non-identifying parameters'
-    end
+        it 'computes the same fingerprint' do
+          expect(computed).to eq expected_fingerprint
+        end
+      end
 
-    context 'when the non-identifying parameters change, it computes the same fingerprint' do
-      let(:name) { 'bravo' }
-      let(:count) { 9 }
-      let(:lines) { [1, 7, 10, 13, 15, 17, 19, 20, 25] }
-      let(:expected_fingerprint) { '238733f4f51ba5473dcbe94a43ec5400' }
+      context 'when the identifying parameters change' do
+        let(:name) { 'echo' }
+        let(:count) { 5 }
+        let(:lines) { [1, 7, 10, 13, 15] }
+        let(:expected_fingerprint) { 'e0c35e9223cc19bdb9a04fb3e60573e1' }
 
-      it_behaves_like 'computes a fingerprint with identifying and non-identifying parameters'
-    end
-
-    context 'but when the identifying parameters change, it computes a different fingerprint' do
-      let(:name) { 'echo' }
-      let(:count) { 5 }
-      let(:lines) { [1, 7, 10, 13, 15] }
-      let(:expected_fingerprint) { 'e0c35e9223cc19bdb9a04fb3e60573e1' }
-
-      it_behaves_like 'computes a fingerprint with identifying and non-identifying parameters'
+        it 'computes a different fingerprint' do
+          expect(computed).to eq expected_fingerprint
+        end
+      end
     end
   end
 end

--- a/spec/reek/report/xml_report_spec.rb
+++ b/spec/reek/report/xml_report_spec.rb
@@ -5,7 +5,7 @@ require_lib 'reek/report/xml_report'
 RSpec.describe Reek::Report::XMLReport do
   let(:xml_report) { described_class.new }
 
-  context 'empty source' do
+  context 'with an empty source' do
     it 'prints empty checkstyle XML' do
       xml_report.add_examiner Reek::Examiner.new('')
       xml = "<?xml version='1.0'?>\n<checkstyle/>\n"
@@ -13,7 +13,7 @@ RSpec.describe Reek::Report::XMLReport do
     end
   end
 
-  context 'source with voliations' do
+  context 'with a source with violations' do
     it 'prints non-empty checkstyle XML' do
       xml_report.add_examiner Reek::Examiner.new(SMELLY_FILE)
       xml = SAMPLES_PATH.join('checkstyle.xml').read

--- a/spec/reek/smell_detectors/boolean_parameter_spec.rb
+++ b/spec/reek/smell_detectors/boolean_parameter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Reek::SmellDetectors::BooleanParameter do
       and reek_of(:BooleanParameter, lines: [1], context: 'alfa', parameter: 'charlie')
   end
 
-  context 'in a method' do
+  context 'when examining an instance method' do
     it 'reports a parameter defaulted to false' do
       src = 'def alfa(bravo = false) end'
       expect(src).to reek_of(:BooleanParameter)
@@ -70,7 +70,7 @@ RSpec.describe Reek::SmellDetectors::BooleanParameter do
     end
   end
 
-  context 'in a singleton method' do
+  context 'when examining a singleton method' do
     it 'reports a parameter defaulted to true' do
       src = 'def self.alfa(bravo = true) end'
       expect(src).to reek_of(:BooleanParameter)

--- a/spec/reek/smell_detectors/class_variable_spec.rb
+++ b/spec/reek/smell_detectors/class_variable_spec.rb
@@ -63,49 +63,43 @@ RSpec.describe Reek::SmellDetectors::ClassVariable do
   end
 
   ['class', 'module'].each do |scope|
-    context "Scoped to #{scope}" do
-      context 'set in a method' do
-        it 'reports correctly' do
-          src = <<-EOS
-            #{scope} Alfa
-              def bravo
-                @@charlie = {}
-              end
+    context "when examining a #{scope}" do
+      it 'reports a class variable set in a method' do
+        src = <<-EOS
+          #{scope} Alfa
+            def bravo
+              @@charlie = {}
             end
-          EOS
+          end
+        EOS
 
-          expect(src).to reek_of(:ClassVariable)
-        end
+        expect(src).to reek_of(:ClassVariable, name: '@@charlie')
       end
 
-      context 'used in a method' do
-        it 'reports correctly' do
-          src = <<-EOS
-            #{scope} Alfa
-              def bravo
-                puts @@charlie
-              end
+      it 'reports a class variable used in a method' do
+        src = <<-EOS
+          #{scope} Alfa
+            def bravo
+              puts @@charlie
             end
-          EOS
+          end
+        EOS
 
-          expect(src).to reek_of(:ClassVariable)
-        end
+        expect(src).to reek_of(:ClassVariable, name: '@@charlie')
       end
 
-      context "set in #{scope} and used in a method" do
-        it 'reports correctly' do
-          src = <<-EOS
-            #{scope} Alfa
-              @@bravo = 42
+      it "reports a class variable set in the #{scope} body and used in a method" do
+        src = <<-EOS
+          #{scope} Alfa
+            @@bravo = 42
 
-              def charlie
-                puts @@bravo
-              end
+            def charlie
+              puts @@bravo
             end
-          EOS
+          end
+        EOS
 
-          expect(src).to reek_of(:ClassVariable)
-        end
+        expect(src).to reek_of(:ClassVariable, name: '@@bravo')
       end
     end
   end

--- a/spec/reek/smell_detectors/control_parameter_spec.rb
+++ b/spec/reek/smell_detectors/control_parameter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Reek::SmellDetectors::ControlParameter do
       and reek_of(:ControlParameter, lines: [3], argument: 'charlie')
   end
 
-  context 'parameter not used to determine code path' do
+  context 'when a parameter is not used to determine code path' do
     it 'does not report a ternary check on an ivar' do
       src = 'def alfa(bravo) @charlie ? bravo : false end'
       expect(src).not_to reek_of(:ControlParameter)
@@ -52,7 +52,7 @@ RSpec.describe Reek::SmellDetectors::ControlParameter do
     end
   end
 
-  context 'parameter only used to determine code path' do
+  context 'when a parameter is only used to determine code path' do
     it 'reports a ternary check on a parameter' do
       src = 'def alfa(bravo); bravo ? true : false; end'
       expect(src).to reek_of(:ControlParameter)
@@ -188,7 +188,7 @@ RSpec.describe Reek::SmellDetectors::ControlParameter do
     end
   end
 
-  context 'parameter used besides determining code path' do
+  context 'when a parameter is used besides determining code path' do
     it 'does not report on if conditional expression' do
       src = 'def alfa(bravo); if bravo then charlie(bravo); end end'
       expect(src).not_to reek_of(:ControlParameter)

--- a/spec/reek/smell_detectors/duplicate_method_call_spec.rb
+++ b/spec/reek/smell_detectors/duplicate_method_call_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Reek::SmellDetectors::DuplicateMethodCall do
     end
   end
 
-  context 'non-repeated method calls' do
+  context 'with non-repeated method calls' do
     it 'does not report similar calls' do
       src = 'def alfa(bravo) bravo.charlie == self.charlie end'
       expect(src).not_to reek_of(:DuplicateMethodCall)
@@ -162,7 +162,7 @@ RSpec.describe Reek::SmellDetectors::DuplicateMethodCall do
     end
   end
 
-  context 'allowing up to 3 calls' do
+  context 'when allowing up to 3 calls' do
     let(:config) do
       { Reek::SmellDetectors::DuplicateMethodCall::MAX_ALLOWED_CALLS_KEY => 3 }
     end
@@ -189,7 +189,7 @@ RSpec.describe Reek::SmellDetectors::DuplicateMethodCall do
     end
   end
 
-  context 'allowing calls to some methods' do
+  context 'when allowing calls to some methods' do
     it 'does not report calls to some methods' do
       config = { Reek::SmellDetectors::DuplicateMethodCall::ALLOW_CALLS_KEY => ['@bravo.charlie'] }
       src = 'def alfa; @bravo.charlie + @bravo.charlie; end'

--- a/spec/reek/smell_detectors/nested_iterators_spec.rb
+++ b/spec/reek/smell_detectors/nested_iterators_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Reek::SmellDetectors::NestedIterators do
     expect(src).not_to reek_of(:NestedIterators)
   end
 
-  context 'setting the allowed nesting depth to 3' do
+  context 'when setting the allowed nesting depth to 3' do
     let(:config) do
       { Reek::SmellDetectors::NestedIterators::MAX_ALLOWED_NESTING_KEY => 3 }
     end

--- a/spec/reek/smell_detectors/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smell_detectors/uncommunicative_variable_name_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Reek::SmellDetectors::UncommunicativeVariableName do
       and reek_of(:UncommunicativeVariableName, lines: [3], name: 'y')
   end
 
-  context 'instance variables' do
+  context 'when examining instance variables' do
     it 'does not report use of one-letter names' do
       src = 'class Alfa; def bravo; @x; end; end'
       expect(src).not_to reek_of(:UncommunicativeVariableName)
@@ -41,7 +41,7 @@ RSpec.describe Reek::SmellDetectors::UncommunicativeVariableName do
     end
   end
 
-  context 'local variables' do
+  context 'when examining local variables' do
     it 'does not report single underscore as a variable name' do
       src = 'def alfa; _ = bravo(); end'
       expect(src).not_to reek_of(:UncommunicativeVariableName)
@@ -78,7 +78,7 @@ RSpec.describe Reek::SmellDetectors::UncommunicativeVariableName do
     end
   end
 
-  context 'block parameters' do
+  context 'when examining block parameters' do
     it 'reports all relevant block parameters' do
       src = <<-EOS
         def alfa

--- a/spec/reek/smell_detectors/unused_parameters_spec.rb
+++ b/spec/reek/smell_detectors/unused_parameters_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Reek::SmellDetectors::UnusedParameters do
     expect(src).not_to reek_of(:UnusedParameters)
   end
 
-  context 'using super' do
+  context 'when using super' do
     it 'reports nothing with implicit arguments' do
       src = 'def alfa(*bravo); super; end'
       expect(src).not_to reek_of(:UnusedParameters)
@@ -83,7 +83,7 @@ RSpec.describe Reek::SmellDetectors::UnusedParameters do
     end
   end
 
-  context 'anonymous parameters' do
+  context 'with anonymous parameters' do
     it 'reports nothing for unused anonymous parameter' do
       src = 'def alfa(_); end'
       expect(src).not_to reek_of(:UnusedParameters)
@@ -95,7 +95,7 @@ RSpec.describe Reek::SmellDetectors::UnusedParameters do
     end
   end
 
-  context 'splatted parameters' do
+  context 'with splatted parameters' do
     it 'reports nothing for used splatted parameter' do
       src = 'def alfa(*bravo); bravo; end'
       expect(src).not_to reek_of(:UnusedParameters)

--- a/spec/reek/smell_detectors/unused_private_method_spec.rb
+++ b/spec/reek/smell_detectors/unused_private_method_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Reek::SmellDetectors::UnusedPrivateMethod do
       and reek_of(:UnusedPrivateMethod, lines: [7], name: 'charlie')
   end
 
-  context 'unused private methods' do
+  context 'when a class has unused private methods' do
     it 'reports instance methods' do
       source = <<-EOF
         class Alfa
@@ -116,7 +116,7 @@ RSpec.describe Reek::SmellDetectors::UnusedPrivateMethod do
     end
   end
 
-  describe 'configuring the detector via source code comment' do
+  context 'when the detector is configured via a source code comment' do
     it 'does not report methods we excluded' do
       source = <<-EOF
         # :reek:UnusedPrivateMethod: { exclude: [ bravo ] }
@@ -133,8 +133,8 @@ RSpec.describe Reek::SmellDetectors::UnusedPrivateMethod do
     end
   end
 
-  context 'used private methods' do
-    it 'are not reported' do
+  context 'when a class has only used private methods' do
+    it 'reports nothing' do
       source = <<-EOF
         class Alfa
           def bravo
@@ -150,8 +150,8 @@ RSpec.describe Reek::SmellDetectors::UnusedPrivateMethod do
     end
   end
 
-  context 'unused protected methods' do
-    it 'are not reported' do
+  context 'when a class has unused protected methods' do
+    it 'reports nothing' do
       source = <<-EOF
         class Alfa
           protected
@@ -163,8 +163,8 @@ RSpec.describe Reek::SmellDetectors::UnusedPrivateMethod do
     end
   end
 
-  context 'unused public methods' do
-    it 'are not reported' do
+  context 'when a class has unused public methods' do
+    it 'reports nothing' do
       source = <<-EOF
         class Alfa
           def bravo; end
@@ -175,7 +175,7 @@ RSpec.describe Reek::SmellDetectors::UnusedPrivateMethod do
     end
   end
 
-  describe 'prevent methods from being reported' do
+  describe 'preventing methods from being reported' do
     let(:source) do
       <<-EOF
         class Alfa

--- a/spec/reek/smell_detectors/utility_function_spec.rb
+++ b/spec/reek/smell_detectors/utility_function_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Reek::SmellDetectors::UtilityFunction do
     expect(src).to reek_of(:UtilityFunction, context: 'simple')
   end
 
-  context 'Singleton methods' do
+  context 'when examining singleton methods' do
     ['class', 'module'].each do |scope|
       it "does not report for #{scope} with `class << self` notation" do
         src = "#{scope} Alfa; class << self; def bravo(charlie) charlie.to_s; end; end; end"
@@ -111,7 +111,7 @@ RSpec.describe Reek::SmellDetectors::UtilityFunction do
       end
     end
 
-    context 'by using `module_function`' do
+    context 'when defined by using `module_function`' do
       it 'does not report UtilityFunction also when using multiple arguments' do
         src = <<-EOS
           class Alfa
@@ -194,7 +194,7 @@ RSpec.describe Reek::SmellDetectors::UtilityFunction do
       { Reek::SmellDetectors::UtilityFunction::PUBLIC_METHODS_ONLY_KEY => true }
     end
 
-    context 'public methods' do
+    context 'when examining public methods' do
       it 'still reports UtilityFunction' do
         src = <<-EOS
           class Alfa
@@ -208,7 +208,7 @@ RSpec.describe Reek::SmellDetectors::UtilityFunction do
       end
     end
 
-    context 'private methods' do
+    context 'when examining private methods' do
       it 'does not report UtilityFunction' do
         src = <<-EOS
           class Alfa
@@ -235,7 +235,7 @@ RSpec.describe Reek::SmellDetectors::UtilityFunction do
       end
     end
 
-    context 'protected methods' do
+    context 'when examining protected methods' do
       it 'does not report UtilityFunction' do
         src = <<-EOS
           class Alfa

--- a/spec/reek/smell_warning_spec.rb
+++ b/spec/reek/smell_warning_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Reek::SmellWarning do
   let(:utility_function_detector) { build(:smell_detector, smell_type: 'UtilityFunction') }
   let(:uncommunicative_name_detector) { build(:smell_detector, smell_type: 'UncommunicativeVariableName') }
 
-  context 'sort order' do
+  describe 'sort order' do
     shared_examples_for 'first sorts ahead of second' do
       it 'hash differently' do
         expect(first.hash).not_to eq(second.hash)
@@ -26,21 +26,21 @@ RSpec.describe Reek::SmellWarning do
       end
     end
 
-    context 'smells differing only by detector' do
+    context 'when smells differ only by detector' do
       let(:first) { build(:smell_warning, smell_detector: duplication_detector) }
       let(:second) { build(:smell_warning, smell_detector: feature_envy_detector) }
 
       it_behaves_like 'first sorts ahead of second'
     end
 
-    context 'smells differing only by lines' do
+    context 'when smells differ only by lines' do
       let(:first) { build(:smell_warning, smell_detector: feature_envy_detector, lines: [2]) }
       let(:second) { build(:smell_warning, smell_detector: feature_envy_detector, lines: [3]) }
 
       it_behaves_like 'first sorts ahead of second'
     end
 
-    context 'smells differing only by context' do
+    context 'when smells differ only by context' do
       let(:first) { build(:smell_warning, smell_detector: duplication_detector, context: 'first') }
       let(:second) do
         build(:smell_warning, smell_detector: duplication_detector, context: 'second')
@@ -49,7 +49,7 @@ RSpec.describe Reek::SmellWarning do
       it_behaves_like 'first sorts ahead of second'
     end
 
-    context 'smells differing only by message' do
+    context 'when smells differ only by message' do
       let(:first) do
         build(:smell_warning, smell_detector: duplication_detector,
                               context: 'ctx', message: 'first message')
@@ -62,7 +62,7 @@ RSpec.describe Reek::SmellWarning do
       it_behaves_like 'first sorts ahead of second'
     end
 
-    context 'smell name takes precedence over message' do
+    context 'when smells differ by name and message' do
       let(:first) do
         build(:smell_warning, smell_detector: feature_envy_detector, message: 'second message')
       end
@@ -73,7 +73,7 @@ RSpec.describe Reek::SmellWarning do
       it_behaves_like 'first sorts ahead of second'
     end
 
-    context 'smells differing everywhere' do
+    context 'when smells differ everywhere' do
       let(:first) do
         build(:smell_warning, smell_detector: duplication_detector,
                               context: 'Dirty#a',
@@ -97,7 +97,7 @@ RSpec.describe Reek::SmellWarning do
     end
   end
 
-  context '#yaml_hash' do
+  describe '#yaml_hash' do
     let(:context_name) { 'Module::Class#method/block' }
     let(:lines) { [24, 513] }
     let(:message) { 'test message' }

--- a/spec/reek/source/source_locator_spec.rb
+++ b/spec/reek/source/source_locator_spec.rb
@@ -5,7 +5,7 @@ require_lib 'reek/source/source_locator'
 
 RSpec.describe Reek::Source::SourceLocator do
   describe '#sources' do
-    context 'applied to hidden directories' do
+    context 'when applied to hidden directories' do
       let(:path) { SAMPLES_PATH.join('source_with_hidden_directories') }
 
       let(:expected_paths) do
@@ -30,7 +30,7 @@ RSpec.describe Reek::Source::SourceLocator do
     end
 
     # rubocop:disable RSpec/NestedGroups
-    context 'exclude paths' do
+    context 'with excluded paths' do
       let(:configuration) do
         test_configuration_for(CONFIG_PATH.join('with_excluded_paths.reek'))
       end
@@ -44,7 +44,7 @@ RSpec.describe Reek::Source::SourceLocator do
                             'uncommunicative_method_name.rb').expand_path
         end
 
-        context 'and options.force_exclusion? is true' do
+        context 'when options.force_exclusion? is true' do
           before do
             allow(options).to receive(:force_exclusion?).and_return(true)
           end
@@ -55,7 +55,7 @@ RSpec.describe Reek::Source::SourceLocator do
           end
         end
 
-        context 'and options.force_exclusion? is false' do
+        context 'when options.force_exclusion? is false' do
           before do
             allow(options).to receive(:force_exclusion?).and_return(false)
           end
@@ -120,7 +120,7 @@ RSpec.describe Reek::Source::SourceLocator do
     end
     # rubocop:enable RSpec/NestedGroups
 
-    context 'non-Ruby paths' do
+    context 'with non-Ruby paths' do
       let(:path) { SAMPLES_PATH.join('source_with_non_ruby_files') }
       let(:expected_sources) do
         [path.join('uncommunicative_parameter_name.rb')]
@@ -145,7 +145,7 @@ RSpec.describe Reek::Source::SourceLocator do
       end
     end
 
-    context 'passing "." or "./" as argument' do
+    context 'when passing "." or "./" as argument' do
       let(:expected_sources) do
         [Pathname.new('spec/spec_helper.rb'), Pathname.new('lib/reek.rb')]
       end

--- a/spec/reek/spec/should_reek_of_spec.rb
+++ b/spec/reek/spec/should_reek_of_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
   end
 
   describe 'different sources of input' do
-    context 'checking code in a string' do
+    context 'when checking code in a string' do
       let(:clean_code) { 'def good() true; end' }
       let(:matcher) { described_class.new(:UncommunicativeVariableName, name: 'y') }
       let(:smelly_code) { 'def x() y = 4; end' }
@@ -40,7 +40,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
       end
     end
 
-    context 'checking code in a File' do
+    context 'when checking code in a File' do
       let(:matcher) { described_class.new(:UncommunicativeMethodName, name: 'x') }
 
       it 'matches a smelly file' do
@@ -54,7 +54,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
   end
 
   describe 'smell types and smell details' do
-    context 'passing in smell_details with unknown parameter name' do
+    context 'when passing in smell_details with unknown parameter name' do
       let(:matcher) { described_class.new(:UncommunicativeVariableName, foo: 'y') }
       let(:smelly_code) { 'def x() y = 4; end' }
 
@@ -63,7 +63,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
       end
     end
 
-    context 'both are matching' do
+    context 'when both are matching' do
       let(:matcher) { described_class.new(:UncommunicativeVariableName, name: 'y') }
       let(:smelly_code) { 'def x() y = 4; end' }
 
@@ -72,7 +72,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
       end
     end
 
-    context 'no smell_type is matching' do
+    context 'when no smell_type is matching' do
       let(:smelly_code) { 'def dummy() y = 4; end' }
 
       let(:falsey_matcher) { described_class.new(:FeatureEnvy, name: 'y') }
@@ -97,7 +97,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
       end
     end
 
-    context 'smell type is matching but smell details are not' do
+    context 'when smell type is matching but smell details are not' do
       let(:smelly_code) { 'def double_thing() @other.thing.foo + @other.thing.foo end' }
       let(:matcher) { described_class.new(:DuplicateMethodCall, name: 'foo', count: 15) }
 
@@ -129,7 +129,7 @@ RSpec.describe Reek::Spec::ShouldReekOf do
     end
   end
 
-  context 'for a smell that is disabled by default' do
+  context 'with a smell that is disabled by default' do
     it 'enables the smell detector to match automatically' do
       default_config = Reek::SmellDetectors::UnusedPrivateMethod.default_config
       src = 'class C; private; def foo; end; end'

--- a/spec/reek/spec/should_reek_spec.rb
+++ b/spec/reek/spec/should_reek_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Reek::Spec::ShouldReek do
   end
 
   describe 'checking code in a File' do
-    context 'matcher without masking' do
+    context 'without masking' do
       let(:matcher) { described_class.new }
 
       it 'matches a smelly File' do
@@ -39,7 +39,7 @@ RSpec.describe Reek::Spec::ShouldReek do
       end
     end
 
-    context 'matcher without masking' do
+    context 'with masking' do
       let(:path) { CONFIG_PATH.join('full_mask.reek') }
       let(:configuration) { test_configuration_for(path) }
       let(:matcher) { described_class.new(configuration: configuration) }

--- a/spec/reek/spec/smell_matcher_spec.rb
+++ b/spec/reek/spec/smell_matcher_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Reek::Spec::SmellMatcher do
   end
   let(:matcher) { described_class.new(smell_warning) }
 
-  context '#matches?' do
+  describe '#matches?' do
     it 'matches on class symbol' do
       expect(matcher).to be_matches(:UncommunicativeVariableName)
     end
@@ -50,7 +50,7 @@ RSpec.describe Reek::Spec::SmellMatcher do
     end
   end
 
-  context '#matches_smell_type?' do
+  describe '#matches_smell_type?' do
     it 'matches on class symbol' do
       expect(matcher).to be_matches_smell_type(:UncommunicativeVariableName)
     end
@@ -60,7 +60,7 @@ RSpec.describe Reek::Spec::SmellMatcher do
     end
   end
 
-  context '#matches_attributes?' do
+  describe '#matches_attributes?' do
     it 'matches on params' do
       expect(matcher).to be_matches_attributes(test: 'something')
     end

--- a/spec/reek/tree_dresser_spec.rb
+++ b/spec/reek/tree_dresser_spec.rb
@@ -7,11 +7,13 @@ require_relative '../spec_helper'
 require_lib 'reek/tree_dresser'
 
 RSpec.describe Reek::TreeDresser do
-  let(:dresser) { described_class.new }
-  let(:sexp) do
-    Parser::Ruby22.parse('class Klazz; def meth(argument); argument.call_me; end; end')
-  end
-  let(:dressed_ast) do
+  describe '#dress' do
+    let(:dresser) { described_class.new }
+    let(:sexp) do
+      Parser::Ruby22.parse('class Klazz; def meth(argument); argument.call_me; end; end')
+    end
+    let(:dressed_ast) { dresser.dress(sexp, {}) }
+
     # The dressed AST looks like this:
     #   (class
     #     (const nil :Klazz) nil
@@ -20,14 +22,11 @@ RSpec.describe Reek::TreeDresser do
     #         (arg :argument))
     #       (send
     #         (lvar :argument) :call_me)))
-    dresser.dress(sexp, {})
-  end
-  let(:const_node) { dressed_ast.children.first }
-  let(:def_node) { dressed_ast.children.last }
-  let(:args_node) { def_node.children[1] }
-  let(:send_node) { def_node.children[2] }
+    let(:const_node) { dressed_ast.children.first }
+    let(:def_node) { dressed_ast.children.last }
+    let(:args_node) { def_node.children[1] }
+    let(:send_node) { def_node.children[2] }
 
-  context 'dresses the given sexp' do
     it 'dresses `const` nodes properly' do
       expect(const_node).to be_a Reek::AST::SexpExtensions::ConstNode
     end


### PR DESCRIPTION
Rubocop-RSpec added a cop for checking the description of context blocks.