### PR TITLE
Replace FactoryGirl with FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :development do
   gem 'aruba',         '~> 0.14.0'
   gem 'ataru',         '~> 0.2.0'
   gem 'cucumber',      '~> 3.0'
-  gem 'factory_girl',  '~> 4.0'
+  gem 'factory_bot',   '~> 4.0'
   gem 'rake',          '~> 12.0'
   gem 'rspec',         '~> 3.0'
   gem 'simplecov',     '~> 0.15.0'

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -3,7 +3,7 @@ require_relative '../../lib/reek/smell_detectors/base_detector'
 require_relative '../../lib/reek/smell_warning'
 require_relative '../../lib/reek/cli/options'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :method_context, class: Reek::Context::MethodContext do
     skip_create
     transient do

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -4,17 +4,6 @@ require_relative '../../lib/reek/smell_warning'
 require_relative '../../lib/reek/cli/options'
 
 FactoryBot.define do
-  factory :method_context, class: Reek::Context::MethodContext do
-    skip_create
-    transient do
-      source 'def foo; end'
-    end
-
-    initialize_with do
-      new(nil, Reek::Source::SourceCode.from(source).syntax_tree)
-    end
-  end
-
   factory :smell_detector, class: Reek::SmellDetectors::BaseDetector do
     skip_create
     transient do

--- a/spec/reek/code_comment_spec.rb
+++ b/spec/reek/code_comment_spec.rb
@@ -3,7 +3,7 @@ require_lib 'reek/code_comment'
 
 RSpec.describe Reek::CodeComment do
   context 'with an empty comment' do
-    let(:comment) { FactoryGirl.build(:code_comment, comment: '') }
+    let(:comment) { build(:code_comment, comment: '') }
 
     it 'is not descriptive' do
       expect(comment).not_to be_descriptive
@@ -16,22 +16,22 @@ RSpec.describe Reek::CodeComment do
 
   context 'comment checks' do
     it 'rejects an empty comment' do
-      comment = FactoryGirl.build(:code_comment, comment: '#')
+      comment = build(:code_comment, comment: '#')
       expect(comment).not_to be_descriptive
     end
 
     it 'rejects a 1-word comment' do
-      comment = FactoryGirl.build(:code_comment, comment: "# alpha\n#  ")
+      comment = build(:code_comment, comment: "# alpha\n#  ")
       expect(comment).not_to be_descriptive
     end
 
     it 'accepts a 2-word comment' do
-      comment = FactoryGirl.build(:code_comment, comment: '# alpha bravo  ')
+      comment = build(:code_comment, comment: '# alpha bravo  ')
       expect(comment).to be_descriptive
     end
 
     it 'accepts a multi-word comment' do
-      comment = FactoryGirl.build(:code_comment, comment: "# alpha bravo \n# charlie \n   # delta ")
+      comment = build(:code_comment, comment: "# alpha bravo \n# charlie \n   # delta ")
       expect(comment).to be_descriptive
     end
   end
@@ -39,8 +39,8 @@ RSpec.describe Reek::CodeComment do
   context 'good comment config' do
     it 'parses hashed options' do
       comment = '# :reek:DuplicateMethodCall { enabled: false }'
-      config = FactoryGirl.build(:code_comment,
-                                 comment: comment).config
+      config = build(:code_comment,
+                     comment: comment).config
 
       expect(config).to include('DuplicateMethodCall')
       expect(config['DuplicateMethodCall']).to include('enabled')
@@ -49,8 +49,8 @@ RSpec.describe Reek::CodeComment do
 
     it "supports hashed options with the legacy separator ':' after the smell detector" do
       comment = '# :reek:DuplicateMethodCall: { enabled: false }'
-      config = FactoryGirl.build(:code_comment,
-                                 comment: comment).config
+      config = build(:code_comment,
+                     comment: comment).config
 
       expect(config).to include('DuplicateMethodCall')
       expect(config['DuplicateMethodCall']).to include('enabled')
@@ -62,7 +62,7 @@ RSpec.describe Reek::CodeComment do
         # :reek:DuplicateMethodCall { enabled: false }
         # :reek:NestedIterators { enabled: true }
       EOF
-      config = FactoryGirl.build(:code_comment, comment: comment).config
+      config = build(:code_comment, comment: comment).config
 
       expect(config).to include('DuplicateMethodCall', 'NestedIterators')
       expect(config['DuplicateMethodCall']).to include('enabled')
@@ -75,7 +75,7 @@ RSpec.describe Reek::CodeComment do
       comment = <<-EOF
         #:reek:DuplicateMethodCall { enabled: false } and :reek:NestedIterators { enabled: true }
       EOF
-      config = FactoryGirl.build(:code_comment, comment: comment).config
+      config = build(:code_comment, comment: comment).config
 
       expect(config).to include('DuplicateMethodCall', 'NestedIterators')
       expect(config['DuplicateMethodCall']).to include('enabled')
@@ -86,7 +86,7 @@ RSpec.describe Reek::CodeComment do
 
     it 'parses multiple unhashed options on the same line' do
       comment = '# :reek:DuplicateMethodCall and :reek:NestedIterators'
-      config = FactoryGirl.build(:code_comment, comment: comment).config
+      config = build(:code_comment, comment: comment).config
 
       expect(config).to include('DuplicateMethodCall', 'NestedIterators')
       expect(config['DuplicateMethodCall']).to include('enabled')
@@ -97,7 +97,7 @@ RSpec.describe Reek::CodeComment do
 
     it 'disables the smell if no options are specifed' do
       comment = '# :reek:DuplicateMethodCall'
-      config = FactoryGirl.build(:code_comment, comment: comment).config
+      config = build(:code_comment, comment: comment).config
 
       expect(config).to include('DuplicateMethodCall')
       expect(config['DuplicateMethodCall']).to include('enabled')
@@ -105,8 +105,8 @@ RSpec.describe Reek::CodeComment do
     end
 
     it 'ignores smells after a space' do
-      config = FactoryGirl.build(:code_comment,
-                                 comment: '# :reek: DuplicateMethodCall').config
+      config = build(:code_comment,
+                     comment: '# :reek: DuplicateMethodCall').config
       expect(config).not_to include('DuplicateMethodCall')
     end
 
@@ -117,7 +117,7 @@ RSpec.describe Reek::CodeComment do
         # :reek:NestedIterators { enabled: true }
         # comment
       EOF
-      comment = FactoryGirl.build(:code_comment, comment: original_comment)
+      comment = build(:code_comment, comment: original_comment)
 
       expect(comment.send(:sanitized_comment)).to eq('Actual comment')
     end
@@ -128,8 +128,8 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
   context 'bad detector' do
     it 'raises BadDetectorInCommentError' do
       expect do
-        FactoryGirl.build(:code_comment,
-                          comment: '# :reek:DoesNotExist')
+        build(:code_comment,
+              comment: '# :reek:DoesNotExist')
       end.to raise_error(Reek::Errors::BadDetectorInCommentError)
     end
   end
@@ -138,7 +138,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
     it 'raises GarbageDetectorConfigurationInCommentError' do
       expect do
         comment = '# :reek:UncommunicativeMethodName { thats: a: bad: config }'
-        FactoryGirl.build(:code_comment, comment: comment)
+        build(:code_comment, comment: comment)
       end.to raise_error(Reek::Errors::GarbageDetectorConfigurationInCommentError)
     end
   end
@@ -149,7 +149,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
         expect do
           # exclude -> exlude and enabled -> nabled
           comment = '# :reek:UncommunicativeMethodName { exlude: alfa, nabled: true }'
-          FactoryGirl.build(:code_comment, comment: comment)
+          build(:code_comment, comment: comment)
         end.to raise_error(Reek::Errors::BadDetectorConfigurationKeyInCommentError)
       end
     end
@@ -158,14 +158,14 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
       it 'does not raise' do
         expect do
           comment = '# :reek:UncommunicativeMethodName { exclude: alfa, enabled: true }'
-          FactoryGirl.build(:code_comment, comment: comment)
+          build(:code_comment, comment: comment)
         end.not_to raise_error
       end
 
       it 'does not raise on regexps' do
         expect do
           comment = '# :reek:UncommunicativeMethodName { exclude: !ruby/regexp /alfa/ }'
-          FactoryGirl.build(:code_comment, comment: comment)
+          build(:code_comment, comment: comment)
         end.not_to raise_error
       end
     end
@@ -175,7 +175,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
         expect do
           # max_copies -> mx_copies and min_clump_size -> mn_clump_size
           comment = '# :reek:DataClump { mx_copies: 4, mn_clump_size: 3 }'
-          FactoryGirl.build(:code_comment, comment: comment)
+          build(:code_comment, comment: comment)
         end.to raise_error(Reek::Errors::BadDetectorConfigurationKeyInCommentError)
       end
     end
@@ -184,7 +184,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
       it 'does not raise' do
         expect do
           comment = '# :reek:DataClump { max_copies: 4, min_clump_size: 3 }'
-          FactoryGirl.build(:code_comment, comment: comment)
+          build(:code_comment, comment: comment)
         end.not_to raise_error
       end
     end

--- a/spec/reek/report/code_climate/code_climate_fingerprint_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_fingerprint_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
     shared_examples_for 'computes a fingerprint with no parameters' do
       let(:expected_fingerprint) { 'e68badd29db51c92363a7c6a2438d722' }
       let(:warning) do
-        FactoryGirl.build(:smell_warning,
-                          smell_detector: Reek::SmellDetectors::UtilityFunction.new,
-                          context:        'alfa',
-                          message:        "doesn't depend on instance state (maybe move it to another class?)",
-                          lines:          lines,
-                          source:         'a/ruby/source/file.rb')
+        build(:smell_warning,
+              smell_detector: Reek::SmellDetectors::UtilityFunction.new,
+              context:        'alfa',
+              message:        "doesn't depend on instance state (maybe move it to another class?)",
+              lines:          lines,
+              source:         'a/ruby/source/file.rb')
       end
 
       it 'computes the fingerprint' do
@@ -35,12 +35,12 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
 
     context 'when the fingerprint should not be computed' do
       let(:warning) do
-        FactoryGirl.build(:smell_warning,
-                          smell_detector: Reek::SmellDetectors::ManualDispatch.new,
-                          context:        'Alfa#bravo',
-                          message:        'manually dispatches method call',
-                          lines:          [4],
-                          source:         'a/ruby/source/file.rb')
+        build(:smell_warning,
+              smell_detector: Reek::SmellDetectors::ManualDispatch.new,
+              context:        'Alfa#bravo',
+              message:        'manually dispatches method call',
+              lines:          [4],
+              source:         'a/ruby/source/file.rb')
       end
 
       it 'returns nil' do
@@ -50,13 +50,13 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
 
     shared_examples_for 'computes a fingerprint with identifying parameters' do
       let(:warning) do
-        FactoryGirl.build(:smell_warning,
-                          smell_detector: Reek::SmellDetectors::ClassVariable.new,
-                          context:        'Alfa',
-                          message:        "declares the class variable '@@#{name}'",
-                          lines:          [4],
-                          parameters:     { name: "@@#{name}" },
-                          source:         'a/ruby/source/file.rb')
+        build(:smell_warning,
+              smell_detector: Reek::SmellDetectors::ClassVariable.new,
+              context:        'Alfa',
+              message:        "declares the class variable '@@#{name}'",
+              lines:          [4],
+              parameters:     { name: "@@#{name}" },
+              source:         'a/ruby/source/file.rb')
       end
 
       it 'computes the fingerprint' do
@@ -80,13 +80,13 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
 
     shared_examples_for 'computes a fingerprint with identifying and non-identifying parameters' do
       let(:warning) do
-        FactoryGirl.build(:smell_warning,
-                          smell_detector: Reek::SmellDetectors::DuplicateMethodCall.new,
-                          context:        "Alfa##{name}",
-                          message:        "calls '#{name}' #{count} times",
-                          lines:          lines,
-                          parameters:     { name: "@@#{name}", count: count },
-                          source:         'a/ruby/source/file.rb')
+        build(:smell_warning,
+              smell_detector: Reek::SmellDetectors::DuplicateMethodCall.new,
+              context:        "Alfa##{name}",
+              message:        "calls '#{name}' #{count} times",
+              lines:          lines,
+              parameters:     { name: "@@#{name}", count: count },
+              source:         'a/ruby/source/file.rb')
       end
 
       it 'computes the fingerprint' do

--- a/spec/reek/report/code_climate/code_climate_formatter_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_formatter_spec.rb
@@ -4,12 +4,12 @@ require_lib 'reek/report/code_climate/code_climate_formatter'
 RSpec.describe Reek::Report::CodeClimateFormatter do
   describe '#render' do
     let(:warning) do
-      FactoryGirl.build(:smell_warning,
-                        smell_detector: Reek::SmellDetectors::UtilityFunction.new,
-                        context:        'context foo',
-                        message:        'message bar',
-                        lines:          [1, 2],
-                        source:         'a/ruby/source/file.rb')
+      build(:smell_warning,
+            smell_detector: Reek::SmellDetectors::UtilityFunction.new,
+            context:        'context foo',
+            message:        'message bar',
+            lines:          [1, 2],
+            source:         'a/ruby/source/file.rb')
     end
     let(:rendered) { described_class.new(warning).render }
     let(:json) { JSON.parse rendered.chop }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,8 +15,8 @@ Reek::CLI::Silencer.silently do
   end
 end
 
-require 'factory_girl'
-FactoryGirl.find_definitions
+require 'factory_bot'
+FactoryBot.find_definitions
 
 # Simple helpers for our specs.
 module Helpers
@@ -76,7 +76,7 @@ end
 RSpec.configure do |config|
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.include Helpers
 
   config.disable_monkey_patching!


### PR DESCRIPTION
The factory_girl gem was renamed to factory_but. This PR:

* Updates our dependency
* Changes references to FactoryGirl to FactoryBot
* Simplifies calls to build by removing the module name
* Removes an unused factory