### PR TITLE
Only show long error message when exception is handled

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,6 +3,12 @@ engines:
     enabled: true
   reek:
     enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+        ruby:
+          mass_threshold: 29
 ratings:
   paths:
     - lib/**/*

--- a/lib/reek/errors/base_error.rb
+++ b/lib/reek/errors/base_error.rb
@@ -4,6 +4,9 @@ module Reek
   module Errors
     # Base class for all runtime Reek errors
     class BaseError < ::RuntimeError
+      def long_message
+        message
+      end
     end
   end
 end

--- a/lib/reek/errors/encoding_error.rb
+++ b/lib/reek/errors/encoding_error.rb
@@ -6,9 +6,11 @@ module Reek
   module Errors
     # Gets raised when Reek is unable to process the source due to an EncodingError
     class EncodingError < BaseError
-      ENCODING_ERROR_TEMPLATE = <<-MESSAGE.freeze
+      TEMPLATE = "Source '%s' cannot be processed by Reek due to an encoding error in the source file.".freeze
+
+      LONG_TEMPLATE = <<-MESSAGE.freeze
         !!!
-        Source '%s' cannot be processed by Reek due to an encoding error in the source file.
+        %s
 
         This is a problem that is outside of Reek's scope and should be fixed by you, the
         user, in order for Reek being able to continue.
@@ -26,12 +28,15 @@ module Reek
         !!!
       MESSAGE
 
-      def initialize(origin:, original_exception:)
-        message = format(ENCODING_ERROR_TEMPLATE,
-                         origin,
-                         original_exception.inspect,
-                         original_exception.backtrace.join("\n\t"))
-        super message
+      def initialize(origin:)
+        super format(TEMPLATE, origin)
+      end
+
+      def long_message
+        format(LONG_TEMPLATE,
+               message,
+               cause.inspect,
+               cause.backtrace.join("\n\t"))
       end
     end
   end

--- a/lib/reek/errors/incomprehensible_source_error.rb
+++ b/lib/reek/errors/incomprehensible_source_error.rb
@@ -6,9 +6,11 @@ module Reek
   module Errors
     # Gets raised when Reek is unable to process the source
     class IncomprehensibleSourceError < BaseError
-      INCOMPREHENSIBLE_SOURCE_TEMPLATE = <<-MESSAGE.freeze
+      TEMPLATE = 'Source %s cannot be processed by Reek.'.freeze
+
+      LONG_TEMPLATE = <<-MESSAGE.freeze
         !!!
-        Source %s cannot be processed by Reek.
+        %s
 
         This is most likely a Reek bug.
 
@@ -29,12 +31,15 @@ module Reek
         !!!
       MESSAGE
 
-      def initialize(origin:, original_exception:)
-        message = format(INCOMPREHENSIBLE_SOURCE_TEMPLATE,
-                         origin,
-                         original_exception.inspect,
-                         original_exception.backtrace.join("\n\t"))
-        super message
+      def initialize(origin:)
+        super format(TEMPLATE, origin)
+      end
+
+      def long_message
+        format(LONG_TEMPLATE,
+               message,
+               cause.inspect,
+               cause.backtrace.join("\n\t"))
       end
     end
   end

--- a/lib/reek/logging_error_handler.rb
+++ b/lib/reek/logging_error_handler.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
+require_relative 'errors/base_error'
+
 module Reek
   # Handles errors by logging to stderr
   class LoggingErrorHandler
     def handle(exception)
-      warn exception
+      case exception
+      when Errors::BaseError
+        warn exception.long_message
+      else
+        warn exception
+      end
       true
     end
   end

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -53,11 +53,6 @@ module Reek
         end
       end
 
-      # @return [true|false] Returns true if parsed file does not have any syntax errors.
-      def valid_syntax?
-        diagnostics.none? { |diagnostic| [:error, :fatal].include?(diagnostic.level) }
-      end
-
       def diagnostics
         parse_if_needed
         @diagnostics
@@ -116,7 +111,7 @@ module Reek
         ast, comments = parser.parse_with_comments(buffer)
 
         # See https://whitequark.github.io/parser/Parser/Source/Comment/Associator.html
-        comment_map = Parser::Source::Comment.associate(ast, comments) if ast
+        comment_map = Parser::Source::Comment.associate(ast, comments)
         TreeDresser.new.dress(ast, comment_map)
       end
 

--- a/spec/reek/errors/base_error_spec.rb
+++ b/spec/reek/errors/base_error_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../spec_helper'
+
+require_lib 'reek/errors/base_error'
+
+RSpec.describe Reek::Errors::BaseError do
+  let(:error) { described_class.new }
+
+  describe '#long_message' do
+    it 'returns the message' do
+      expect(error.long_message).to eq error.message
+    end
+  end
+end

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -127,21 +127,25 @@ RSpec.describe Reek::Examiner do
 
       it 'explains the origin of the error' do
         origin = 'string'
-        expect { examiner.smells }.to raise_error.with_message(/#{origin}/)
+        expect { examiner.smells }.
+          to raise_error.with_message("Source #{origin} cannot be processed by Reek.")
       end
 
       it 'explains what to do' do
         explanation = 'It would be great if you could report this back to the Reek team'
-        expect { examiner.smells }.to raise_error.with_message(/#{explanation}/)
+        expect { examiner.smells }.
+          to raise_error { |it| expect(it.long_message).to match(/#{explanation}/) }
       end
 
       it 'contains the original error message' do
         original = 'Looks like bad source'
-        expect { examiner.smells }.to raise_error.with_message(/#{original}/)
+        expect { examiner.smells }.
+          to raise_error { |it| expect(it.long_message).to match(/#{original}/) }
       end
 
       it 'shows the original exception class' do
-        expect { examiner.smells }.to raise_error.with_message(/ArgumentError/)
+        expect { examiner.smells }.
+          to raise_error { |it| expect(it.long_message).to match(/ArgumentError/) }
       end
     end
   end
@@ -214,7 +218,8 @@ RSpec.describe Reek::Examiner do
     end
 
     it 'shows the original exception class' do
-      expect { examiner.smells }.to raise_error.with_message(/InvalidByteSequenceError/)
+      expect { examiner.smells }.
+        to raise_error { |it| expect(it.long_message).to match(/InvalidByteSequenceError/) }
     end
   end
 

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -41,11 +41,11 @@ RSpec.describe Reek::Source::SourceCode do
 
   context 'when the parser fails' do
     let(:source_name) { 'Test source' }
-    let(:src) { described_class.new(code: code, origin: source_name, **parser) }
+    let(:src) { described_class.new(code: code, origin: source_name, **options) }
 
     context 'with a Parser::SyntaxError' do
       let(:code) { '== Invalid Syntax ==' }
-      let(:parser) { {} }
+      let(:options) { {} }
 
       it 'adds a diagnostic' do
         expect(src.diagnostics.size).to eq 2
@@ -56,7 +56,7 @@ RSpec.describe Reek::Source::SourceCode do
       let(:code) { '' }
       let(:error_class) { RuntimeError }
       let(:error_message) { 'An error' }
-      let(:parser) do
+      let(:options) do
         parser = instance_double('Parser::Ruby24')
         allow(parser).to receive(:parse_with_comments).and_raise(error_class, error_message)
         {
@@ -65,7 +65,7 @@ RSpec.describe Reek::Source::SourceCode do
       end
 
       it 'raises the error' do
-        expect { src.valid_syntax? }.to raise_error error_class, error_message
+        expect { src.syntax_tree }.to raise_error error_class, error_message
       end
     end
   end


### PR DESCRIPTION
This changes the error processing in Examiner so that raise wrapping error classes pick up the original exception in their `cause` attribute.

This makes error reporting when the error is not handled (e.g., when running specs during development) more compact.