### PR TITLE
Unify node iterators

### DIFF
--- a/lib/reek/ast/reference_collector.rb
+++ b/lib/reek/ast/reference_collector.rb
@@ -12,7 +12,7 @@ module Reek
       end
 
       def num_refs_to_self
-        (explicit_self_calls + implicit_self_calls).size
+        (explicit_self_calls.to_a + implicit_self_calls.to_a).size
       end
 
       private
@@ -20,9 +20,7 @@ module Reek
       attr_reader :ast
 
       def explicit_self_calls
-        [:self, :super, :zsuper, :ivar, :ivasgn].flat_map do |node_type|
-          ast.each_node(node_type)
-        end
+        ast.each_node([:self, :super, :zsuper, :ivar, :ivasgn])
       end
 
       def implicit_self_calls

--- a/lib/reek/ast/sexp_extensions/case.rb
+++ b/lib/reek/ast/sexp_extensions/case.rb
@@ -10,7 +10,7 @@ module Reek
         end
 
         def body_nodes(type, ignoring = [])
-          children[1..-1].compact.flat_map { |child| child.find_nodes(type, ignoring) }
+          children[1..-1].compact.flat_map { |child| child.each_node(type, ignoring).to_a }
         end
 
         def else_body

--- a/lib/reek/ast/sexp_extensions/if.rb
+++ b/lib/reek/ast/sexp_extensions/if.rb
@@ -9,8 +9,15 @@ module Reek
           children.first
         end
 
+        # :reek:FeatureEnvy
         def body_nodes(type, ignoring = [])
-          children[1..-1].compact.flat_map { |child| child.find_nodes(type, ignoring) }
+          children[1..-1].compact.flat_map do |child|
+            if ignoring.include? child.type
+              []
+            else
+              child.each_node(type, ignoring).to_a
+            end
+          end
         end
       end
     end

--- a/lib/reek/ast/sexp_extensions/logical_operators.rb
+++ b/lib/reek/ast/sexp_extensions/logical_operators.rb
@@ -10,7 +10,7 @@ module Reek
         end
 
         def body_nodes(type, ignoring = [])
-          children[1].find_nodes type, ignoring
+          children[1].each_node type, ignoring
         end
       end
 

--- a/lib/reek/ast/sexp_extensions/methods.rb
+++ b/lib/reek/ast/sexp_extensions/methods.rb
@@ -30,11 +30,9 @@ module Reek
         end
 
         def body_nodes(types, ignoring = [])
-          if body
-            body.find_nodes(types, ignoring)
-          else
-            []
-          end
+          return [] unless body
+          return [] if ignoring.include?(body.type)
+          body.each_node(types, ignoring | types)
         end
       end
 

--- a/lib/reek/context/code_context.rb
+++ b/lib/reek/context/code_context.rb
@@ -44,7 +44,7 @@ module Reek
       end
 
       # Iterate over `self` and child contexts.
-      # The main difference (among others) to `each_node` is that we are traversing
+      # The main difference (among others) to `local_nodes` is that we are traversing
       # `CodeContexts` here, not AST nodes (see `Reek::AST::Node`).
       #
       # @yield block that is executed for every node.

--- a/lib/reek/context/method_context.rb
+++ b/lib/reek/context/method_context.rb
@@ -23,21 +23,16 @@ module Reek
       end
 
       def uses_param?(param)
-        # local_nodes(:lvasgn) catches:
-        #   def foo(bar); bar += 1; end
-        # In this example there is no `lvar` node present.
+        # :lvasgn catches:
         #
-        # local_nodes(:lvar) catches:
+        #   def foo(bar); bar += 1; end
+        #
+        # :lvar catches:
+        #
         #   def foo(bar); other(bar); end
         #   def foo(bar); tmp = other(bar); tmp[0]; end
         #
-        # Note that in the last example the `lvar` node for `bar` is part of an `lvasgn` node for `tmp`.
-        # This means that if we would just search for [:lvar, :lvasgn]
-        # (e.g. via Reek::AST::Node#find_nodes) this would fail for this example since we would
-        # stop at the `lvasgn` and not detect the contained `lvar`.
-        # Hence we first get all `lvar` nodes followed by all `lvasgn` nodes.
-        #
-        (local_nodes(:lvar) + local_nodes(:lvasgn)).find { |node| node.var_name == param.name }
+        local_nodes([:lvar, :lvasgn]).find { |node| node.var_name == param.name }
       end
 
       # :reek:FeatureEnvy

--- a/lib/reek/context/module_context.rb
+++ b/lib/reek/context/module_context.rb
@@ -59,7 +59,7 @@ module Reek
       # @deprecated use `defined_instance_methods` instead
       #
       def node_instance_methods
-        local_nodes(:def)
+        local_nodes(:def).to_a
       end
 
       def descriptively_commented?

--- a/lib/reek/smell_detectors/class_variable.rb
+++ b/lib/reek/smell_detectors/class_variable.rb
@@ -25,7 +25,8 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def sniff
-        class_variables_in_context.map do |variable, lines|
+        class_variables_in_context.map do |variable, occurences|
+          lines = occurences.map(&:line)
           smell_warning(
             context: context,
             lines: lines,
@@ -38,16 +39,8 @@ module Reek
       # Collects the names of the class variables declared and/or used
       # in the given module.
       #
-      # :reek:TooManyStatements: { max_statements: 7 }
       def class_variables_in_context
-        result = Hash.new { |hash, key| hash[key] = [] }
-        collector = proc do |cvar_node|
-          result[cvar_node.name].push(cvar_node.line)
-        end
-        [:cvar, :cvasgn, :cvdecl].each do |stmt_type|
-          expression.each_node(stmt_type, [:class, :module], &collector)
-        end
-        result
+        context.local_nodes([:cvar, :cvasgn, :cvdecl]).group_by(&:name)
       end
     end
   end

--- a/lib/reek/smell_detectors/instance_variable_assumption.rb
+++ b/lib/reek/smell_detectors/instance_variable_assumption.rb
@@ -55,16 +55,8 @@ module Reek
 
       def variables_from_context
         method_expressions.map do |method|
-          method.find_nodes(assumption_nodes, ignored_nodes).map(&:name)
+          method.each_node(:ivar, [:or_asgn]).map(&:name)
         end.flatten
-      end
-
-      def assumption_nodes
-        [:ivar]
-      end
-
-      def ignored_nodes
-        [:or_asgn]
       end
     end
   end

--- a/lib/reek/smell_detectors/nested_iterators.rb
+++ b/lib/reek/smell_detectors/nested_iterators.rb
@@ -97,7 +97,8 @@ module Reek
       # :reek:TooManyStatements: { max_statements: 6 }
       def scout(exp:, depth:)
         return [] unless exp
-        exp.find_nodes([:block]).flat_map do |iterator|
+        # Find all non-nested blocks in this expression
+        exp.each_node([:block], [:block]).flat_map do |iterator|
           new_depth = increment_depth(iterator, depth)
           # 1st case: we recurse down the given block of the iterator. In this case
           # we need to check if we should increment the depth.

--- a/lib/reek/smell_detectors/too_many_constants.rb
+++ b/lib/reek/smell_detectors/too_many_constants.rb
@@ -35,7 +35,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def sniff
-        count = context.local_nodes(:casgn).delete_if(&:defines_module?).length
+        count = context.local_nodes(:casgn).reject(&:defines_module?).length
 
         return [] if count <= max_allowed_constants
 

--- a/lib/reek/smell_detectors/uncommunicative_variable_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_variable_name.rb
@@ -92,11 +92,11 @@ module Reek
       end
 
       def find_assignment_variable_names(accumulator)
-        assignment_nodes = expression.each_node(:lvasgn, [:class, :module, :defs, :def])
+        assignment_nodes = expression.each_node(:lvasgn, [:class, :module, :defs, :def]).to_a
 
         case expression.type
         when :class, :module
-          assignment_nodes += expression.each_node(:ivasgn, [:class, :module])
+          assignment_nodes += expression.each_node(:ivasgn, [:class, :module]).to_a
         end
 
         assignment_nodes.each { |asgn| accumulator[asgn.children.first].push(asgn.line) }

--- a/lib/reek/smell_detectors/utility_function.rb
+++ b/lib/reek/smell_detectors/utility_function.rb
@@ -71,7 +71,7 @@ module Reek
       private
 
       def num_helper_methods
-        context.local_nodes(:send).length
+        context.local_nodes(:send).to_a.length
       end
 
       def ignore_method?

--- a/spec/reek/ast/node_spec.rb
+++ b/spec/reek/ast/node_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Reek::AST::Node do
         end
       end
 
-      it 'returns an empty array of ifs when no block is passed' do
-        expect(ast.each_node(:if, [])).to be_empty
+      it 'returns an enumerator when no block is passed' do
+        expect(ast.each_node(:if)).to be_instance_of Enumerator
       end
     end
 
@@ -37,14 +37,15 @@ RSpec.describe Reek::AST::Node do
       end
 
       it 'yields no ifs' do
-        ast.each_node(:if, []) { |exp| raise "#{exp} yielded by empty module!" }
+        ast.each_node(:if) { |exp| raise "#{exp} yielded by empty module!" }
       end
+
       it 'yields one module' do
-        expect(ast.each_node(:module, []).length).to eq(1)
+        expect(ast.each_node(:module).to_a.length).to eq(1)
       end
 
       it "yields the module's full AST" do
-        ast.each_node(:module, []) do |exp|
+        ast.each_node(:module) do |exp|
           expect(exp).to eq sexp(:module,
                                  sexp(:const, nil, :Loneliness),
                                  sexp(:def, :calloo,
@@ -54,7 +55,7 @@ RSpec.describe Reek::AST::Node do
       end
 
       it 'yields one method' do
-        expect(ast.each_node(:def, []).length).to eq(1)
+        expect(ast.each_node(:def).to_a.length).to eq(1)
       end
 
       it "yields the method's full AST" do
@@ -62,7 +63,7 @@ RSpec.describe Reek::AST::Node do
       end
 
       it 'ignores the call inside the method if the traversal is pruned' do
-        expect(ast.each_node(:send, [:def])).to be_empty
+        expect(ast.each_node(:send, [:def]).to_a).to be_empty
       end
     end
 
@@ -83,7 +84,7 @@ RSpec.describe Reek::AST::Node do
         end
       EOS
       ast = Reek::Source::SourceCode.from(src).syntax_tree
-      expect(ast.each_node(:if, []).length).to eq(3)
+      expect(ast.each_node(:if).to_a.length).to eq(3)
     end
   end
 

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Reek::AST::SexpExtensions::DefNode do
     end
 
     it 'finds nodes in the body with #body_nodes' do
-      expect(node.body_nodes([:first])).to eq [sexp(:first)]
+      expect(node.body_nodes([:first]).to_a).to eq [sexp(:first)]
     end
   end
 

--- a/spec/reek/smell_detectors/control_parameter_spec.rb
+++ b/spec/reek/smell_detectors/control_parameter_spec.rb
@@ -144,12 +144,42 @@ RSpec.describe Reek::SmellDetectors::ControlParameter do
       expect(src).to reek_of(:ControlParameter)
     end
 
-    it 'reports on nested if statements where the inner if is a control parameter' do
+    it 'reports on nested suffix if statements where the inner if is a control parameter' do
       src = <<-EOS
         def nested(bravo)
           if true
             charlie
             charlie if bravo
+          end
+        end
+      EOS
+
+      expect(src).to reek_of(:ControlParameter)
+    end
+
+    it 'reports on nested full if statements where the inner if is a control parameter' do
+      src = <<-EOS
+        def alfa(bravo)
+          if true
+            charlie
+          else
+            if bravo
+              delta
+            end
+          end
+        end
+      EOS
+
+      expect(src).to reek_of(:ControlParameter)
+    end
+
+    it 'reports on elsif statements' do
+      src = <<-EOS
+        def alfa(bravo)
+          if true
+            charlie
+          elsif bravo
+            delta
           end
         end
       EOS


### PR DESCRIPTION
This unifies `AST::Node#each_node` and `AST::Node#find_nodes`.

Fundamentally, each_node was recursive and never skipped root, while find_nodes was non-recursive and could skip root. These properties were not reflected in the method names.

The resulting `#each_node` has slightly more complex behavior than strictly desired. It is hoped that future refactoring can remedy this.