### PR TITLE
Bump RuboCop and fix new offences

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,7 +9,7 @@ plugins:
     config:
       languages:
         ruby:
-          mass_threshold: 29
+          mass_threshold: 35
 exclude_patterns:
   - coverage/
   - docs/

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ group :development do
   gem 'yard',          '~> 0.9.5'
 
   if RUBY_VERSION >= '2.3'
-    gem 'rubocop',       '~> 0.51.0'
-    gem 'rubocop-rspec', '~> 1.20.0'
+    gem 'rubocop',       '~> 0.52.0'
+    gem 'rubocop-rspec', '~> 1.20'
   end
 
   platforms :mri do

--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -20,8 +20,8 @@ module Reek
     module ConfigurationFileFinder
       TOO_MANY_CONFIGURATION_FILES_MESSAGE = <<-MESSAGE.freeze
 
-        Error: Found multiple configuration files %s
-        while scanning directory %s.
+        Error: Found multiple configuration files %<files>s
+        while scanning directory %<directory>s.
 
         Reek supports only one configuration file. You have 2 options now:
         1) Remove all offending files.
@@ -111,7 +111,7 @@ module Reek
         #
         def escalate_too_many_configuration_files(found, directory)
           offensive_files = found.map { |file| "'#{file.basename}'" }.join(', ')
-          warn format(TOO_MANY_CONFIGURATION_FILES_MESSAGE, offensive_files, directory)
+          warn format(TOO_MANY_CONFIGURATION_FILES_MESSAGE, files: offensive_files, directory: directory)
           exit 1
         end
       end

--- a/lib/reek/context/code_context.rb
+++ b/lib/reek/context/code_context.rb
@@ -118,9 +118,7 @@ module Reek
         line = exp.line
         case type
         when :lvar, :lvasgn
-          unless exp.object_creation_call?
-            refs.record_reference(name: receiver.name, line: line)
-          end
+          refs.record_reference(name: receiver.name, line: line) unless exp.object_creation_call?
         when :self
           refs.record_reference(name: :self, line: line)
         end

--- a/lib/reek/errors/bad_detector_configuration_key_in_comment_error.rb
+++ b/lib/reek/errors/bad_detector_configuration_key_in_comment_error.rb
@@ -9,12 +9,12 @@ module Reek
     class BadDetectorConfigurationKeyInCommentError < BaseError
       UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-MESSAGE.freeze
 
-        Error: You are trying to configure the smell detector '%s'
-        in one of your source code comments with the unknown option %s.
-        The source is '%s' and the comment belongs to the expression starting in line %d.
+        Error: You are trying to configure the smell detector '%<detector>s'
+        in one of your source code comments with the unknown option %<option>s.
+        The source is '%<source>s' and the comment belongs to the expression starting in line %<line>d.
         Here's the original comment:
 
-        %s
+        %<comment>s
 
         Please see the Reek docs for:
           * how to configure Reek via source code comments: https://github.com/troessner/reek/blob/master/docs/Smell-Suppression.md
@@ -26,11 +26,11 @@ module Reek
 
       def initialize(detector_name:, offensive_keys:, source:, line:, original_comment:)
         message = format(UNKNOWN_SMELL_DETECTOR_MESSAGE,
-                         detector_name,
-                         offensive_keys,
-                         source,
-                         line,
-                         original_comment)
+                         detector: detector_name,
+                         option: offensive_keys,
+                         source: source,
+                         line: line,
+                         comment: original_comment)
         super message
       end
     end

--- a/lib/reek/errors/bad_detector_in_comment_error.rb
+++ b/lib/reek/errors/bad_detector_in_comment_error.rb
@@ -10,12 +10,12 @@ module Reek
     class BadDetectorInCommentError < BaseError
       UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-MESSAGE.freeze
 
-        Error: You are trying to configure an unknown smell detector '%s' in one
+        Error: You are trying to configure an unknown smell detector '%<detector>s' in one
         of your source code comments.
-        The source is '%s' and the comment belongs to the expression starting in line %d.
+        The source is '%<source>s' and the comment belongs to the expression starting in line %<line>d.
         Here's the original comment:
 
-        %s
+        %<comment>s
 
         Please see the Reek docs for:
           * how to configure Reek via source code comments: https://github.com/troessner/reek/blob/master/docs/Smell-Suppression.md
@@ -26,10 +26,10 @@ module Reek
 
       def initialize(detector_name:, source:, line:, original_comment:)
         message = format(UNKNOWN_SMELL_DETECTOR_MESSAGE,
-                         detector_name,
-                         source,
-                         line,
-                         original_comment)
+                         detector: detector_name,
+                         source: source,
+                         line: line,
+                         comment: original_comment)
         super message
       end
     end

--- a/lib/reek/errors/encoding_error.rb
+++ b/lib/reek/errors/encoding_error.rb
@@ -6,11 +6,11 @@ module Reek
   module Errors
     # Gets raised when Reek is unable to process the source due to an EncodingError
     class EncodingError < BaseError
-      TEMPLATE = "Source '%s' cannot be processed by Reek due to an encoding error in the source file.".freeze
+      TEMPLATE = "Source '%<source>s' cannot be processed by Reek due to an encoding error in the source file.".freeze
 
       LONG_TEMPLATE = <<-MESSAGE.freeze
         !!!
-        %s
+        %<message>s
 
         This is a problem that is outside of Reek's scope and should be fixed by you, the
         user, in order for Reek being able to continue.
@@ -19,24 +19,24 @@ module Reek
 
         Exception message:
 
-        %s
+        %<exception>s
 
         Original backtrace:
 
-        %s
+        %<original>s
 
         !!!
       MESSAGE
 
       def initialize(origin:)
-        super format(TEMPLATE, origin)
+        super format(TEMPLATE, source: origin)
       end
 
       def long_message
         format(LONG_TEMPLATE,
-               message,
-               cause.inspect,
-               cause.backtrace.join("\n\t"))
+               message: message,
+               exception: cause.inspect,
+               original: cause.backtrace.join("\n\t"))
       end
     end
   end

--- a/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
+++ b/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
@@ -9,12 +9,12 @@ module Reek
     class GarbageDetectorConfigurationInCommentError < BaseError
       BAD_DETECTOR_CONFIGURATION_MESSAGE = <<-MESSAGE.freeze
 
-        Error: You are trying to configure the smell detector '%s'.
+        Error: You are trying to configure the smell detector '%<detector>s'.
         Unfortunately we cannot parse the configuration you have given.
-        The source is '%s' and the comment belongs to the expression starting in line %d.
+        The source is '%<source>s' and the comment belongs to the expression starting in line %<line>d.
         Here's the original comment:
 
-        %s
+        %<comment>s
 
         Please see the Reek docs for:
           * how to configure Reek via source code comments: https://github.com/troessner/reek/blob/master/docs/Smell-Suppression.md
@@ -25,10 +25,10 @@ module Reek
 
       def initialize(detector_name:, source:, line:, original_comment:)
         message = format(BAD_DETECTOR_CONFIGURATION_MESSAGE,
-                         detector_name,
-                         source,
-                         line,
-                         original_comment)
+                         detector: detector_name,
+                         source: source,
+                         line: line,
+                         comment: original_comment)
         super message
       end
     end

--- a/lib/reek/errors/incomprehensible_source_error.rb
+++ b/lib/reek/errors/incomprehensible_source_error.rb
@@ -6,11 +6,11 @@ module Reek
   module Errors
     # Gets raised when Reek is unable to process the source
     class IncomprehensibleSourceError < BaseError
-      TEMPLATE = 'Source %s cannot be processed by Reek.'.freeze
+      TEMPLATE = 'Source %<source>s cannot be processed by Reek.'.freeze
 
       LONG_TEMPLATE = <<-MESSAGE.freeze
         !!!
-        %s
+        %<message>s
 
         This is most likely a Reek bug.
 
@@ -22,24 +22,24 @@ module Reek
 
         Exception message:
 
-        %s
+        %<exception>s
 
         Original exception:
 
-        %s
+        %<original>s
 
         !!!
       MESSAGE
 
       def initialize(origin:)
-        super format(TEMPLATE, origin)
+        super format(TEMPLATE, source: origin)
       end
 
       def long_message
         format(LONG_TEMPLATE,
-               message,
-               cause.inspect,
-               cause.backtrace.join("\n\t"))
+               message: message,
+               exception: cause.inspect,
+               original: cause.backtrace.join("\n\t"))
       end
     end
   end


### PR DESCRIPTION
I’m partial to disabling IfUnlessModifier (at least in this case).

I’m also totally open to disabling FormatStringToken, but I think this actually adds to the readability and portability of the format strings (the `format` calls no longer need to maintain strict positional order of the template format sequences).