### PR TITLE
README fixes + Code Climate info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [Overview](#overview)
 - [Quickstart](#quickstart)
 - [Example](#example)
-- [Supported rubies](#supported-rubies)
+- [Supported Ruby versions](#supported-ruby-versions)
 - [Fixing Smell Warnings](#fixing-smell-warnings)
 - [Sources](#sources)
 - [Code smells](#code-smells)
@@ -93,16 +93,17 @@ demo.rb -- 2 warnings:
   [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y' [https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md]
 ```
 
-## Supported rubies
+## Supported Ruby versions
 
-Reek is officially running on the following MRI rubies:
+Reek is officially supported for the following CRuby versions:
 
   - 2.1
   - 2.2
   - 2.3
   - 2.4
+  - 2.5
 
-Other rubies like Rubinius or JRuby are not officially supported but should work as well.
+Other Ruby implementations (like Rubinius or JRuby) are not officially supported but should work as well.
 
 ## Fixing Smell Warnings
 

--- a/README.md
+++ b/README.md
@@ -529,6 +529,20 @@ If you don't feel like getting your hands dirty with code there are still other 
 * Open up an [issue](https://github.com/troessner/reek/issues) and report bugs
 * Suggest other improvements like additional smells for instance
 
+### Running Code Climate locally
+
+If you run into Code Climate issues (e.g., go over code duplication
+threshold) you might want to be able to run Code Climate against
+the Reek codebase locally. To do this, you need to do the following:
+
+* [install Docker CE](https://docs.docker.com/engine/installation/)
+* [install Code Climate CLI](https://github.com/codeclimate/codeclimate#installation)
+* `gem install codeclimate`
+* `codeclimate engines:install`
+
+Now you can run various Code Climate engines,
+e.g., `codeclimate analyze -e duplication`
+
 ## Output formats
 
 Reek supports 5 output formats:


### PR DESCRIPTION
Updates README with Ruby 2.5 support and running Code Climate locally, as per [this thread](https://github.com/troessner/reek/pull/1282#issuecomment-353969514).