### PR TITLE
Ensure all expressions have a default #name method

### DIFF
--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -33,6 +33,10 @@ module Reek
         loc && loc.line
       end
 
+      def name
+        to_s
+      end
+
       #
       # Carries out a depth-first traversal of this syntax tree, yielding every
       # Sexp of the searched for type or types. The traversal stops at any node

--- a/spec/reek/ast/node_spec.rb
+++ b/spec/reek/ast/node_spec.rb
@@ -201,4 +201,11 @@ RSpec.describe Reek::AST::Node do
       end
     end
   end
+
+  describe '#name' do
+    it 'returns #to_s if no override is present' do
+      ast = sexp(:foo)
+      expect(ast.name).to eq ast.to_s
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1292.