### PR TITLE
Support Ruby 2.5

### DIFF
--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -2,7 +2,7 @@
 
 require_relative '../cli/silencer'
 Reek::CLI::Silencer.silently do
-  require 'parser/ruby24'
+  require 'parser/ruby25'
 end
 require_relative '../tree_dresser'
 require_relative '../ast/node'
@@ -99,7 +99,7 @@ module Reek
       # where each node is possibly adorned with our SexpExtensions (see ast/ast_node_class_map
       # and ast/sexp_extensions for details).
       #
-      # @param parser [Parser::Ruby24]
+      # @param parser [Parser::Ruby25]
       # @param source [String] - Ruby code
       # @return [Anonymous subclass of Reek::AST::Node] the AST presentation
       #         for the given source
@@ -118,7 +118,7 @@ module Reek
       # :reek:TooManyStatements: { max_statements: 6 }
       # :reek:FeatureEnvy
       def default_parser
-        Parser::Ruby24.new(AST::Builder.new).tap do |parser|
+        Parser::Ruby25.new(AST::Builder.new).tap do |parser|
           diagnostics = parser.diagnostics
           diagnostics.all_errors_are_fatal = false
           diagnostics.ignore_warnings      = false

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.summary = 'Code smell detector for Ruby'
 
   s.add_runtime_dependency 'codeclimate-engine-rb', '~> 0.4.0'
-  s.add_runtime_dependency 'parser',                '< 2.5', '>= 2.4.0.0'
+  s.add_runtime_dependency 'parser',                '< 2.6', '>= 2.5.0.0'
   s.add_runtime_dependency 'rainbow',               '~> 3.0'
 end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     source 'dummy_file'
     lines [42]
     message 'smell warning message'
-    parameters { {} }
+    parameters({})
 
     initialize_with do
       new(smell_detector,

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Reek::Source::SourceCode do
       let(:error_class) { RuntimeError }
       let(:error_message) { 'An error' }
       let(:options) do
-        parser = instance_double('Parser::Ruby24')
+        parser = instance_double('Parser::Ruby25')
         allow(parser).to receive(:parse_with_comments).and_raise(error_class, error_message)
         {
           parser: parser


### PR DESCRIPTION
Fix #1294 

Changes
===

- Use Ruby 2.5 parser
- Update parser gem


Note
==


If Reek user can select parser version (like RuboCop's TargetRubyVersion), I think it is better.
https://github.com/bbatsov/rubocop/blob/b0ef6b4a3a3455eb40b20c9b0d32982dedb043c1/lib/rubocop/processed_source.rb#L164-L184