### PR TITLE
Update dependencies and fix new offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,11 @@ group :development do
   gem 'factory_bot',   '~> 4.0'
   gem 'rake',          '~> 12.0'
   gem 'rspec',         '~> 3.0'
-  gem 'simplecov',     '~> 0.15.0'
+  gem 'simplecov',     '~> 0.16.1'
   gem 'yard',          '~> 0.9.5'
 
   if RUBY_VERSION >= '2.3'
-    gem 'rubocop',       '~> 0.52.0'
+    gem 'rubocop',       '~> 0.53.0'
     gem 'rubocop-rspec', '~> 1.20'
   end
 

--- a/lib/reek/cli/command/todo_list_command.rb
+++ b/lib/reek/cli/command/todo_list_command.rb
@@ -14,12 +14,11 @@ module Reek
         FILE_NAME = '.todo.reek'.freeze
 
         def execute
-          smells = scan_for_smells
           if smells.empty?
             puts "\n'.todo.reek' not generated because "\
                     'there were no smells found!'
           else
-            File.write FILE_NAME, groups_for(smells).to_yaml
+            File.write FILE_NAME, groups.to_yaml
             puts "\n'.todo.reek' generated! You can now use "\
                     'this as a starting point for your configuration.'
           end
@@ -28,14 +27,13 @@ module Reek
 
         private
 
-        def scan_for_smells
-          sources.map do |source|
-            Examiner.new(source,
-                         filter_by_smells: smell_names)
+        def smells
+          @smells ||= sources.map do |source|
+            Examiner.new(source, filter_by_smells: smell_names)
           end.map(&:smells).flatten
         end
 
-        def groups_for(smells)
+        def groups
           @groups ||=
             begin
               todos = smells.group_by(&:smell_class).map do |smell_class, smells_for_class|

--- a/lib/reek/context_builder.rb
+++ b/lib/reek/context_builder.rb
@@ -206,7 +206,7 @@ module Reek
     #
     #   def self.foo; end
     #
-    def process_self(_, _parent)
+    def process_self(_exp, _parent)
       current_context.record_use_of_self
     end
 
@@ -226,7 +226,7 @@ module Reek
     #
     # We record one reference to `self`.
     #
-    def process_zsuper(_, _parent)
+    def process_zsuper(_exp, _parent)
       current_context.record_use_of_self
     end
 

--- a/lib/reek/report/code_climate/code_climate_configuration.rb
+++ b/lib/reek/report/code_climate/code_climate_configuration.rb
@@ -5,7 +5,7 @@ module Reek
     # loads the smell type metadata to present in Code Climate
     module CodeClimateConfiguration
       def self.load
-        config_file = File.expand_path('../code_climate_configuration.yml', __FILE__)
+        config_file = File.expand_path('code_climate_configuration.yml', __dir__)
         YAML.load_file config_file
       end
     end

--- a/lib/reek/smell_detectors/base_detector.rb
+++ b/lib/reek/smell_detectors/base_detector.rb
@@ -59,7 +59,7 @@ module Reek
       end
 
       def source_line
-        @line ||= expression.line
+        @source_line ||= expression.line
       end
 
       def exception?

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -17,6 +17,21 @@ module Reek
     # A +Source+ object represents a chunk of Ruby source code.
     #
     class SourceCode
+      # Consume and store parser diagnostics
+      class DiagnosticsConsumer
+        def initialize
+          @diagnostics = []
+        end
+
+        def call(item)
+          @diagnostics << item
+        end
+
+        def result
+          @diagnostics
+        end
+      end
+
       IO_IDENTIFIER     = 'STDIN'.freeze
       STRING_IDENTIFIER = 'string'.freeze
 
@@ -26,11 +41,11 @@ module Reek
       #
       # code   - Ruby code as String
       # origin - 'STDIN', 'string' or a filepath as String
-      # parser - the parser to use for generating AST's out of the given source
-      def initialize(code:, origin:, parser: default_parser)
+      # parser - the parser to use for generating AST's out of the given code
+      def initialize(code:, origin:, parser: self.class.default_parser)
         @origin = origin
-        @diagnostics = []
         @parser = parser
+        code.force_encoding(Encoding::UTF_8)
         @code = code
       end
 
@@ -54,23 +69,32 @@ module Reek
       end
 
       def diagnostics
-        parse_if_needed
-        @diagnostics
+        parse_result.last
       end
 
       def syntax_tree
-        parse_if_needed
+        parse_result.first
+      end
+
+      def self.default_parser
+        Parser::Ruby25.new(AST::Builder.new).tap do |parser|
+          diagnostics = parser.diagnostics
+          diagnostics.all_errors_are_fatal = false
+          diagnostics.ignore_warnings      = false
+          diagnostics.consumer = DiagnosticsConsumer.new
+        end
       end
 
       private
 
-      def parse_if_needed
-        @syntax_tree ||= parse(@parser, @code)
+      def parse_result
+        @parse_result ||= parse
       end
 
-      attr_reader :source
+      attr_reader :code
+      attr_reader :parser
 
-      # Parses the given source into an AST and associates the source code comments with it.
+      # Parses the given code into an AST and associates the source code comments with it.
       # This AST is then traversed by a TreeDresser which adorns the nodes in the AST
       # with our SexpExtensions.
       # Finally this AST is returned where each node is an anonymous subclass of Reek::AST::Node
@@ -78,7 +102,7 @@ module Reek
       # Important to note is that Reek will not fail on unparseable files but rather register a
       # parse error to @diagnostics and then just continue.
       #
-      # Given this @source:
+      # Given this @code:
       #
       #   # comment about C
       #   class C
@@ -99,33 +123,16 @@ module Reek
       # where each node is possibly adorned with our SexpExtensions (see ast/ast_node_class_map
       # and ast/sexp_extensions for details).
       #
-      # @param parser [Parser::Ruby25]
-      # @param source [String] - Ruby code
-      # @return [Anonymous subclass of Reek::AST::Node] the AST presentation
-      #         for the given source
-      # :reek:TooManyStatements { max_statements: 6 }
-      def parse(parser, source)
+      # @return [Anonymous subclass of Reek::AST::Node, Array] the AST presentation
+      #         for the given code, List of diagnostics messages
+      def parse
         buffer = Parser::Source::Buffer.new(origin, 1)
-        source.force_encoding(Encoding::UTF_8)
-        buffer.source = source
+        buffer.source = code
         ast, comments = parser.parse_with_comments(buffer)
 
         # See https://whitequark.github.io/parser/Parser/Source/Comment/Associator.html
         comment_map = Parser::Source::Comment.associate(ast, comments)
-        TreeDresser.new.dress(ast, comment_map)
-      end
-
-      # :reek:TooManyStatements: { max_statements: 6 }
-      # :reek:FeatureEnvy
-      def default_parser
-        Parser::Ruby25.new(AST::Builder.new).tap do |parser|
-          diagnostics = parser.diagnostics
-          diagnostics.all_errors_are_fatal = false
-          diagnostics.ignore_warnings      = false
-          diagnostics.consumer = lambda do |diagnostic|
-            @diagnostics << diagnostic
-          end
-        end
+        [TreeDresser.new.dress(ast, comment_map), parser.diagnostics.consumer.result]
       end
     end
   end


### PR DESCRIPTION
- Update rubocop and simplecov to their latest versions
- Correct Naming/MemoizedInstanceVariableName
- Correct Style/ExpandPathArguments
- Correct Naming/UncommunicativeMethodParamName