### PR TITLE
Loosen dependency on rainbow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 dist: trusty
 cache: bundler
 language: ruby
-before_install: gem update --system
+before_install:
+  - gem update --system
+  - gem install bundler
 bundler_args: --without debugging
 script: bundle exec rake ci
 rvm:

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'codeclimate-engine-rb', '~> 0.4.0'
   s.add_runtime_dependency 'parser',                '< 2.6', '>= 2.5.0.0'
-  s.add_runtime_dependency 'rainbow',               '~> 3.0'
+  s.add_runtime_dependency 'rainbow',               '>= 2.0', '< 4.0'
 end


### PR DESCRIPTION
Reek works fine with rainbow 2.x. This change resolves a conflict with
dependencies of pronto.