### PR TITLE
Drop legacy code comment separator.

### DIFF
--- a/lib/reek/code_comment.rb
+++ b/lib/reek/code_comment.rb
@@ -17,7 +17,6 @@ module Reek
                           :reek: # prefix
                           (\w+)  # smell detector e.g.: UncommunicativeVariableName
                           (
-                            :? # legacy separator
                             \s*
                             (\{.*?\}) # optional details in hash style e.g.: { max_methods: 30 }
                           )?
@@ -25,7 +24,6 @@ module Reek
     SANITIZE_REGEX                 = /(#|\n|\s)+/ # Matches '#', newlines and > 1 whitespaces.
     DISABLE_DETECTOR_CONFIGURATION = '{ enabled: false }'.freeze
     MINIMUM_CONTENT_LENGTH         = 2
-    LEGACY_SEPARATOR               = ':'.freeze
 
     attr_reader :config
 

--- a/spec/reek/context/code_context_spec.rb
+++ b/spec/reek/context/code_context_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Reek::Context::CodeContext do
   describe '#config_for' do
     let(:src) do
       <<-EOS
-        # :reek:DuplicateMethodCall: { allow_calls: [ puts ] }')
+        # :reek:DuplicateMethodCall { allow_calls: [ puts ] }')
         def repeated_greeting
           puts 'Hello!'
           puts 'Hello!'

--- a/spec/reek/smell_detectors/unused_private_method_spec.rb
+++ b/spec/reek/smell_detectors/unused_private_method_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Reek::SmellDetectors::UnusedPrivateMethod do
   context 'when the detector is configured via a source code comment' do
     it 'does not report methods we excluded' do
       source = <<-EOF
-        # :reek:UnusedPrivateMethod: { exclude: [ bravo ] }
+        # :reek:UnusedPrivateMethod { exclude: [ bravo ] }
         class Alfa
           private
           def bravo; end


### PR DESCRIPTION
Fixes #1237 