### PR TITLE
Update AppConfiguration API

### DIFF
--- a/lib/reek/spec.rb
+++ b/lib/reek/spec.rb
@@ -114,7 +114,7 @@ module Reek
     # @public
     #
     # :reek:UtilityFunction
-    def reek(configuration = Configuration::AppConfiguration.from_path)
+    def reek(configuration = Configuration::AppConfiguration.from_default_path)
       ShouldReek.new(configuration: configuration)
     end
   end


### PR DESCRIPTION
For #1248. This fixes the API as envisioned there.

There are some remaining issues are with this code:

- AppConfiguration has a hard-coded dependency on ConfigurationFileFinder. This is hard to break since we want to be able to easily say 'use the default configuration given the current working directory'.
- ConfigurationFileFinder.find smells of ControlParameter.

However, these are internal issues that don't affect the public API, so they can be picked up later.