### PR TITLE
Remove Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@
 * [![Gem Version](https://badge.fury.io/rb/reek.svg)](https://badge.fury.io/rb/reek)
 * ![](http://img.shields.io/github/tag/troessner/reek.svg)
 * ![](http://img.shields.io/badge/license-MIT-brightgreen.svg)
-* [![Dependency Status](https://gemnasium.com/badges/github.com/troessner/reek.svg)](https://gemnasium.com/github.com/troessner/reek)
 * [![Inline docs](https://inch-ci.org/github/troessner/reek.png)](https://inch-ci.org/github/troessner/reek)
 * [![Code Climate](https://codeclimate.com/github/troessner/reek/badges/gpa.svg)](https://codeclimate.com/github/troessner/reek)
 * [![codebeat](https://codebeat.co/badges/42fed4ff-3e55-4aed-8ecc-409b4aa539b3)](https://codebeat.co/projects/github-com-troessner-reek)


### PR DESCRIPTION
Notices this:

<img width="226" alt="screen shot 2018-05-25 at 09 28 10" src="https://user-images.githubusercontent.com/5259935/40521401-fa3f7c48-5ffd-11e8-9942-04075caee5bd.png">

Then this:

> Gemnasium has been acquired by GitLab in January 2018. Since May 15, 2018, the services provided by Gemnasium are no longer available.

😞 