### PR TITLE
Update RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,11 +49,6 @@ Lint/HandleExceptions:
   Exclude:
     - 'spec/reek/configuration/configuration_file_finder_spec.rb'
 
-# Rubocop 0.56 gives false positives for this cop.
-# See https://github.com/bbatsov/rubocop/issues/5887
-Lint/SplatKeywordArguments:
-  Enabled: false
-
 # Spec blocks can be any size
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development do
   gem 'yard',          '~> 0.9.5'
 
   if RUBY_VERSION >= '2.3'
-    gem 'rubocop',       '~> 0.56.0'
+    gem 'rubocop',       '~> 0.57.1'
     gem 'rubocop-rspec', '~> 1.20'
   end
 

--- a/spec/reek/smell_detectors/feature_envy_spec.rb
+++ b/spec/reek/smell_detectors/feature_envy_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Reek::SmellDetectors::FeatureEnvy do
         delta += bravo.foxtrot
         delta *= 1.15
       end
-      EOS
+    EOS
 
     expect(src).
       to reek_of(:FeatureEnvy, name: 'delta').
@@ -145,7 +145,7 @@ RSpec.describe Reek::SmellDetectors::FeatureEnvy do
         delta += bravo.echo
         delta += bravo.foxtrot
       end
-      EOS
+    EOS
 
     expect(src).
       to reek_of(:FeatureEnvy, name: 'delta').


### PR DESCRIPTION
- Update to new RuboCop version 0.57.1
- Remove configuration for removed Lint/SplatKeywordArguments cop
- Autocorrect Layout/ClosingHeredocIndentation offenses