### PR TITLE
Replace `wiki-links` flag with `documentation` flag.

### DIFF
--- a/bin/reek
+++ b/bin/reek
@@ -3,9 +3,7 @@
 
 #
 # Reek examines Ruby source code for smells.
-# Visit https://wiki.github.com/troessner/reek for docs etc.
-#
-# Author: Kevin Rutherford
+# Visit https://github.com/troessner/reek for docs etc.
 #
 
 require_relative '../lib/reek'

--- a/docs/Command-Line-Options.md
+++ b/docs/Command-Line-Options.md
@@ -91,10 +91,10 @@ mess.rb -- 2 warnings:
   [2]:x has the name 'x' (UncommunicativeMethodName)
 ```
 
-### Enable the ultra-verbose mode
+### Enable the verbose mode
 
-_reek_ has a ultra-verbose mode which you might find helpful as a beginner. "ultra-verbose" just means that behind each warning a helpful link will be displayed which leads directly to the corresponding _reek_ wiki page.
-This mode can be enabled via the "-U" or "--ultra-verbose" flag.
+_reek_ has a verbose mode which you might find helpful as a beginner. "verbose" just means that behind each warning a helpful link will be displayed which leads directly to the corresponding _reek_ documentation page.
+This mode can be enabled via the "-U" or "--documentation" flag.
 
 So for instance, if your test file would smell of _ClassVariable_, this is what the _reek_ output would look like:
 
@@ -103,7 +103,7 @@ reek -U test.rb
 ```
 ```
 test.rb -- 1 warning:
-  [2]:Dummy declares the class variable @@class_variable (ClassVariable) [https://github.com/troessner/reek/wiki/Class-Variable]
+  [2]:Dummy declares the class variable @@class_variable (ClassVariable) [https://github.com/troessner/reek/blob/master/docs/Class-Variable.md]
 ```
 
 Note the link at the end.

--- a/docs/Reek-Driven-Development.md
+++ b/docs/Reek-Driven-Development.md
@@ -14,7 +14,7 @@ Reek::Rake::Task.new do |t|
 end
 ```
 
-Now the command `reek` will run Reek on your source code (and in this case, it fails if it finds any smells). For more detailed information about Reek's integration with Rake, see [Rake Task](Rake-Task.md) in this wiki.
+Now the command `reek` will run Reek on your source code (and in this case, it fails if it finds any smells). For more detailed information about Reek's integration with Rake, see [Rake Task](Rake-Task.md).
 
 ## reek/spec
 

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -37,7 +37,7 @@ Feature: Reek can be controlled using command-line options
       reek -s lib
       cat my_class.rb | reek
 
-      See https://wiki.github.com/troessner/reek for detailed help.
+      See https://github.com/troessner/reek for detailed help.
 
       Configuration:
           -c, --config FILE                Read configuration options from FILE
@@ -60,7 +60,7 @@ Feature: Reek can be controlled using command-line options
       Text format options:
               --[no-]color                 Use colors for the output (default: true)
           -V, --[no-]empty-headings        Show headings for smell-free source files (default: false)
-          -U, --[no-]wiki-links            Show link to related wiki page for each smell (default: true)
+          -U, --[no-]documentation         Show link to related documentation page for each smell (default: true)
           -n, --[no-]line-numbers          Show line numbers in the output (default: true)
           -s, --single-line                Show location in editor-compatible single-line-per-smell format
           -P, --[no-]progress              Show progress of each source as it is examined (default: true)

--- a/features/reports/json.feature
+++ b/features/reports/json.feature
@@ -24,7 +24,7 @@ Feature: Report smells using simple JSON layout
               "context": "Smelly#x",
               "lines": [ 4 ],
               "message": "has the name 'x'",
-              "wiki_link": "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md",
+              "documentation_link": "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md",
               "name": "x"
           },
           {
@@ -33,7 +33,7 @@ Feature: Report smells using simple JSON layout
               "context": "Smelly#x",
               "lines": [ 5 ],
               "message": "has the variable name 'y'",
-              "wiki_link": "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md",
+              "documentation_link": "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md",
               "name": "y"
           }
       ]
@@ -53,7 +53,7 @@ Feature: Report smells using simple JSON layout
                   1
               ],
               "message": "has no descriptive comment",
-              "wiki_link": "https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md"
+              "documentation_link": "https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md"
           }
       ]
       """

--- a/features/reports/reports.feature
+++ b/features/reports/reports.feature
@@ -175,7 +175,7 @@ Feature: Correctly formatted reports
       | smelly/ |
       | smelly  |
 
-  Scenario Outline: -U or --wiki-links adds helpful links to smell warnings
+  Scenario Outline: -U or --documentation adds helpful links to smell warnings
     Given the smelly file 'smelly.rb'
     When I run reek <option> smelly.rb
     Then the exit status indicates smells
@@ -187,13 +187,13 @@ Feature: Correctly formatted reports
       """
 
     Examples:
-      | option        |
-      | -U            |
-      | --wiki-links  |
+      | option           |
+      | -U               |
+      | --documentation  |
 
-  Scenario: --no-wiki-links drops links from smell warnings
+  Scenario: --no-documentation drops links from smell warnings
     Given the smelly file 'smelly.rb'
-    When I run reek --no-wiki-links smelly.rb
+    When I run reek --no-documentation smelly.rb
     Then the exit status indicates smells
     And it reports:
       """
@@ -202,7 +202,7 @@ Feature: Correctly formatted reports
         [5]:UncommunicativeVariableName: Smelly#x has the variable name 'y'
       """
 
-  Scenario Outline: --wiki-links is independent of --line-numbers
+  Scenario Outline: --documentation is independent of --line-numbers
     Given the smelly file 'smelly.rb'
     When I run reek <option> smelly.rb
     Then the exit status indicates smells
@@ -216,4 +216,4 @@ Feature: Correctly formatted reports
     Examples:
       | option                             |
       | --no-line-numbers -U               |
-      | --no-line-numbers --wiki-links  |
+      | --no-line-numbers --documentation  |

--- a/features/reports/yaml.feature
+++ b/features/reports/yaml.feature
@@ -25,7 +25,7 @@ Feature: Report smells using simple YAML layout
         smell_type: UncommunicativeMethodName
         source: smelly.rb
         name: x
-        wiki_link: https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md
+        documentation_link: https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Method-Name.md
       - context: Smelly#x
         lines:
         - 5
@@ -33,7 +33,7 @@ Feature: Report smells using simple YAML layout
         smell_type: UncommunicativeVariableName
         source: smelly.rb
         name: y
-        wiki_link: https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md
+        documentation_link: https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md
       """
 
   Scenario: Indicate smells and print them as yaml when using STDIN
@@ -48,5 +48,5 @@ Feature: Report smells using simple YAML layout
         lines:
         - 1
         message: has no descriptive comment
-        wiki_link: https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md
+        documentation_link: https://github.com/troessner/reek/blob/master/docs/Irresponsible-Module.md
       """

--- a/lib/reek/cli/command/report_command.rb
+++ b/lib/reek/cli/command/report_command.rb
@@ -53,7 +53,7 @@ module Reek
         end
 
         def warning_formatter_class
-          Report.warning_formatter_class(options.show_links ? :wiki_links : :simple)
+          Report.warning_formatter_class(options.show_links ? :documentation_links : :simple)
         end
 
         def location_formatter

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -92,7 +92,7 @@ module Reek
           #{program_name} -s lib
           cat my_class.rb | #{program_name}
 
-          See https://wiki.github.com/troessner/reek for detailed help.
+          See https://github.com/troessner/reek for detailed help.
 
         BANNER
       end
@@ -151,8 +151,8 @@ module Reek
                   'Show headings for smell-free source files (default: false)') do |show_empty|
           self.show_empty = show_empty
         end
-        parser.on('-U', '--[no-]wiki-links',
-                  'Show link to related wiki page for each smell (default: true)') do |show_links|
+        parser.on('-U', '--[no-]documentation',
+                  'Show link to related documentation page for each smell (default: true)') do |show_links|
           self.show_links = show_links
         end
       end

--- a/lib/reek/report.rb
+++ b/lib/reek/report.rb
@@ -37,7 +37,7 @@ module Reek
     }.freeze
 
     WARNING_FORMATTER_CLASSES = {
-      wiki_links: Formatter::WikiLinkWarningFormatter,
+      documentation_links: Formatter::DocumentationLinkWarningFormatter,
       simple: Formatter::SimpleWarningFormatter
     }.freeze
 

--- a/lib/reek/report/formatter.rb
+++ b/lib/reek/report/formatter.rb
@@ -5,7 +5,7 @@ require_relative 'formatter/heading_formatter'
 require_relative 'formatter/location_formatter'
 require_relative 'formatter/progress_formatter'
 require_relative 'formatter/simple_warning_formatter'
-require_relative 'formatter/wiki_link_warning_formatter'
+require_relative 'formatter/documentation_link_warning_formatter'
 
 module Reek
   module Report

--- a/lib/reek/report/formatter/documentation_link_warning_formatter.rb
+++ b/lib/reek/report/formatter/documentation_link_warning_formatter.rb
@@ -6,10 +6,10 @@ module Reek
   module Report
     module Formatter
       #
-      # Formatter that adds a link to the wiki to the basic message from
+      # Formatter that adds a link to the docs to the basic message from
       # SimpleWarningFormatter.
       #
-      class WikiLinkWarningFormatter < SimpleWarningFormatter
+      class DocumentationLinkWarningFormatter < SimpleWarningFormatter
         BASE_URL_FOR_HELP_LINK = 'https://github.com/troessner/reek/blob/master/docs/'.freeze
 
         def format(warning)
@@ -17,7 +17,7 @@ module Reek
         end
 
         def format_hash(warning)
-          super.merge('wiki_link' => explanatory_link(warning))
+          super.merge('documentation_link' => explanatory_link(warning))
         end
 
         private

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['CHANGELOG.md', 'License.txt']
   s.files = `git ls-files -z`.split("\0")
   s.executables = s.files.grep(%r{^bin/}).map { |path| File.basename(path) }
-  s.homepage = 'https://github.com/troessner/reek/wiki'
+  s.homepage = 'https://github.com/troessner/reek'
   s.rdoc_options = %w(--main README.md -x assets/|bin/|config/|features/|spec/|tasks/)
   s.required_ruby_version = '>= 2.2.0'
   s.summary = 'Code smell detector for Ruby'

--- a/spec/reek/report/json_report_spec.rb
+++ b/spec/reek/report/json_report_spec.rb
@@ -34,19 +34,19 @@ RSpec.describe Reek::Report::JSONReport do
       expected = JSON.parse <<-EOS
         [
           {
-            "context":        "simple",
-            "lines":          [1],
-            "message":        "has the parameter name 'a'",
-            "smell_type":     "UncommunicativeParameterName",
-            "source":         "string",
-            "name":           "a"
+            "context":    "simple",
+            "lines":      [1],
+            "message":    "has the parameter name 'a'",
+            "smell_type": "UncommunicativeParameterName",
+            "source":     "string",
+            "name":       "a"
           },
           {
-            "context":        "simple",
-            "lines":          [1],
-            "message":        "doesn't depend on instance state (maybe move it to another class?)",
-            "smell_type":     "UtilityFunction",
-            "source":         "string"
+            "context":    "simple",
+            "lines":      [1],
+            "message":    "doesn't depend on instance state (maybe move it to another class?)",
+            "smell_type": "UtilityFunction",
+            "source":     "string"
           }
         ]
       EOS
@@ -55,7 +55,7 @@ RSpec.describe Reek::Report::JSONReport do
     end
 
     context 'with link formatter' do
-      let(:options) { { warning_formatter: Reek::Report::Formatter::WikiLinkWarningFormatter.new } }
+      let(:options) { { warning_formatter: Reek::Report::Formatter::DocumentationLinkWarningFormatter.new } }
 
       it 'prints documentation links' do
         out = StringIO.new
@@ -65,21 +65,21 @@ RSpec.describe Reek::Report::JSONReport do
         expected = JSON.parse <<-EOS
           [
             {
-              "context":        "simple",
-              "lines":          [1],
-              "message":        "has the parameter name 'a'",
-              "smell_type":     "UncommunicativeParameterName",
-              "source":         "string",
-              "name":           "a",
-              "wiki_link":      "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md"
+              "context":            "simple",
+              "lines":              [1],
+              "message":            "has the parameter name 'a'",
+              "smell_type":         "UncommunicativeParameterName",
+              "source":             "string",
+              "name":               "a",
+              "documentation_link": "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md"
             },
             {
-              "context":        "simple",
-              "lines":          [1],
-              "message":        "doesn't depend on instance state (maybe move it to another class?)",
-              "smell_type":     "UtilityFunction",
-              "source":         "string",
-              "wiki_link":      "https://github.com/troessner/reek/blob/master/docs/Utility-Function.md"
+              "context":            "simple",
+              "lines":              [1],
+              "message":            "doesn't depend on instance state (maybe move it to another class?)",
+              "smell_type":         "UtilityFunction",
+              "source":             "string",
+              "documentation_link": "https://github.com/troessner/reek/blob/master/docs/Utility-Function.md"
             }
           ]
         EOS

--- a/spec/reek/report/yaml_report_spec.rb
+++ b/spec/reek/report/yaml_report_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Reek::Report::YAMLReport do
       expect(result).to eq expected
     end
     context 'with link formatter' do
-      let(:options) { { warning_formatter: Reek::Report::Formatter::WikiLinkWarningFormatter.new } }
+      let(:options) { { warning_formatter: Reek::Report::Formatter::DocumentationLinkWarningFormatter.new } }
 
       it 'prints documentation links' do
         out = StringIO.new
@@ -63,18 +63,18 @@ RSpec.describe Reek::Report::YAMLReport do
           - context:        "simple"
             lines:
             - 1
-            message:        "has the parameter name 'a'"
-            smell_type:     "UncommunicativeParameterName"
-            source:         "string"
-            name:           "a"
-            wiki_link:      "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md"
+            message:            "has the parameter name 'a'"
+            smell_type:         "UncommunicativeParameterName"
+            source:             "string"
+            name:               "a"
+            documentation_link: "https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Parameter-Name.md"
           - context:        "simple"
             lines:
             - 1
-            message:        "doesn't depend on instance state (maybe move it to another class?)"
-            smell_type:     "UtilityFunction"
-            source:         "string"
-            wiki_link:      "https://github.com/troessner/reek/blob/master/docs/Utility-Function.md"
+            message:            "doesn't depend on instance state (maybe move it to another class?)"
+            smell_type:         "UtilityFunction"
+            source:             "string"
+            documentation_link: "https://github.com/troessner/reek/blob/master/docs/Utility-Function.md"
         EOS
 
         expect(result).to eq expected


### PR DESCRIPTION
Fixes #1331 