### PR TITLE
Allow only .reek.yml, not any file ending in .reek.yml

### DIFF
--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -11,9 +11,9 @@ module Reek
     #
     # There are 3 ways of passing `reek` a configuration file:
     # 1. Using the cli "-c" switch
-    # 2. Having a file ending with .reek.yml either in your current working
+    # 2. Having a file .reek.yml either in your current working
     #    directory or in a parent directory
-    # 3. Having a file ending with .reek.yml in your HOME directory
+    # 3. Having a file .reek.yml in your HOME directory
     #
     # The order in which ConfigurationFileFinder tries to find such a
     # configuration file is exactly like above.
@@ -87,7 +87,7 @@ module Reek
         #
         # :reek:FeatureEnvy
         def find_in_dir(dir)
-          dir.children.detect { |item| item.file? && item.to_s.end_with?(DEFAULT_FILE_NAME) }
+          dir.children.detect { |item| item.file? && item.basename.to_s == DEFAULT_FILE_NAME }
         end
       end
     end

--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -29,6 +29,16 @@ RSpec.describe Reek::Configuration::ConfigurationFileFinder do
       end
     end
 
+    it 'skips files ending in .reek.yml in current dir' do
+      Dir.mktmpdir(nil, SAMPLES_PATH) do |tempdir|
+        current = Pathname.new(tempdir)
+        bad_config = current.join('ignoreme.reek.yml')
+        FileUtils.touch bad_config
+        found = described_class.find(current: Pathname.new(tempdir))
+        expect(found).to eq(SAMPLES_PATH.join('.reek.yml'))
+      end
+    end
+
     it 'returns the file in home if traversing from the current dir fails' do
       skip_if_a_config_in_tempdir
 


### PR DESCRIPTION
Fixes #1363.