### PR TITLE
Improve silently

### DIFF
--- a/lib/reek/ast/node.rb
+++ b/lib/reek/ast/node.rb
@@ -2,9 +2,7 @@
 
 require_relative '../cli/silencer'
 
-Reek::CLI::Silencer.silently do
-  require 'parser'
-end
+require 'parser'
 
 module Reek
   module AST

--- a/lib/reek/cli/silencer.rb
+++ b/lib/reek/cli/silencer.rb
@@ -8,17 +8,20 @@ module Reek
     module Silencer
       module_function
 
-      # :reek:TooManyStatements { max_statements: 7 }
+      # :reek:TooManyStatements { max_statements: 9 }
       def silently
         old_verbose = $VERBOSE
+        old_stderr = $stderr
+        old_stdout = $stdout
+
         $VERBOSE = false
         $stderr = StringIO.new
         $stdout = StringIO.new
         yield
       ensure
         $VERBOSE = old_verbose
-        $stderr = STDERR
-        $stdout = STDOUT
+        $stderr = old_stderr
+        $stdout = old_stdout
       end
     end
   end

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 require_relative '../cli/silencer'
-Reek::CLI::Silencer.silently do
-  require 'parser/ruby25'
-end
+require 'parser/ruby25'
 require_relative '../tree_dresser'
 require_relative '../ast/node'
 require_relative '../ast/builder'

--- a/spec/reek/cli/silencer_spec.rb
+++ b/spec/reek/cli/silencer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Reek::CLI::Silencer do
       end.to output("there!\n").to_stdout
     end
 
-    it 'blocks output on $stderr after the block' do
+    it 'restores output on $stderr after the block' do
       expect do
         described_class.silently { warn 'Hi!' }
         warn 'there!'

--- a/spec/reek/cli/silencer_spec.rb
+++ b/spec/reek/cli/silencer_spec.rb
@@ -1,0 +1,28 @@
+require_relative '../../spec_helper'
+require_lib 'reek/cli/silencer'
+
+RSpec.describe Reek::CLI::Silencer do
+  describe '.silently' do
+    it 'blocks output from the block on $stdout' do
+      expect { described_class.silently { puts 'Hi!' } }.not_to output.to_stdout
+    end
+
+    it 'blocks output from the block on $stderr' do
+      expect { described_class.silently { warn 'Hi!' } }.not_to output.to_stderr
+    end
+
+    it 'restores output on $stdout after the block' do
+      expect do
+        described_class.silently { puts 'Hi!' }
+        puts 'there!'
+      end.to output("there!\n").to_stdout
+    end
+
+    it 'blocks output on $stderr after the block' do
+      expect do
+        described_class.silently { warn 'Hi!' }
+        warn 'there!'
+      end.to output("there!\n").to_stderr
+    end
+  end
+end

--- a/spec/reek/configuration/directory_directives_spec.rb
+++ b/spec/reek/configuration/directory_directives_spec.rb
@@ -36,9 +36,7 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
       let(:file_as_path) { SAMPLES_DIR.join('smelly_source').join('inline.rb') }
 
       it 'raises an error' do
-        Reek::CLI::Silencer.silently do
-          expect { directives.add(file_as_path => nil) }.to raise_error(Reek::Errors::ConfigFileError)
-        end
+        expect { directives.add(file_as_path => nil) }.to raise_error(Reek::Errors::ConfigFileError)
       end
     end
   end

--- a/spec/reek/configuration/excluded_paths_spec.rb
+++ b/spec/reek/configuration/excluded_paths_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe Reek::Configuration::ExcludedPaths do
       let(:paths) { [smelly_source_dir, file_as_path] }
 
       it 'raises an error if one of the given paths is a file' do
-        Reek::CLI::Silencer.silently do
-          expect { exclusions.add(paths) }.to raise_error(Reek::Errors::ConfigFileError)
-        end
+        expect { exclusions.add(paths) }.to raise_error(Reek::Errors::ConfigFileError)
       end
     end
   end

--- a/spec/reek/tree_dresser_spec.rb
+++ b/spec/reek/tree_dresser_spec.rb
@@ -1,7 +1,4 @@
-require_lib 'reek/cli/silencer'
-Reek::CLI::Silencer.silently do
-  require 'parser/ruby22'
-end
+require 'parser/ruby25'
 
 require_relative '../spec_helper'
 require_lib 'reek/tree_dresser'
@@ -10,7 +7,7 @@ RSpec.describe Reek::TreeDresser do
   describe '#dress' do
     let(:dresser) { described_class.new }
     let(:sexp) do
-      Parser::Ruby22.parse('class Klazz; def meth(argument); argument.call_me; end; end')
+      Parser::Ruby25.parse('class Klazz; def meth(argument); argument.call_me; end; end')
     end
     let(:dressed_ast) { dresser.dress(sexp, {}) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,11 +8,9 @@ require_relative '../lib/reek/configuration/app_configuration'
 
 require_relative '../samples/paths'
 
-Reek::CLI::Silencer.silently do
-  begin
-    require 'pry-byebug'
-  rescue LoadError # rubocop:disable Lint/HandleExceptions
-  end
+begin
+  require 'pry-byebug'
+rescue LoadError # rubocop:disable Lint/HandleExceptions
 end
 
 require 'factory_bot'


### PR DESCRIPTION
This does two things:
* Make `Silencer.silently` correctly restore the original situation.
* Removes use of `Silencer.silently` where it seems no longer necessary.