### PR TITLE
Make SourceCode the source of truth for origin

### DIFF
--- a/lib/reek/cli/application.rb
+++ b/lib/reek/cli/application.rb
@@ -89,7 +89,7 @@ module Reek
       end
 
       def source_from_pipe
-        [$stdin]
+        [Source::SourceCode.from($stdin, origin: options.stdin_filename)]
       end
 
       def disable_progress_output_unless_verbose

--- a/lib/reek/cli/command/report_command.rb
+++ b/lib/reek/cli/command/report_command.rb
@@ -23,8 +23,7 @@ module Reek
 
         def populate_reporter_with_smells
           sources.each do |source|
-            reporter.add_examiner Examiner.new(Source::SourceCode.from(source),
-                                               origin: options.stdin_filename,
+            reporter.add_examiner Examiner.new(source,
                                                filter_by_smells: smell_names,
                                                configuration: configuration,
                                                error_handler: LoggingErrorHandler.new)

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -115,7 +115,7 @@ module Reek
         parser.on('--stdin-filename FILE',
                   'When passing code in via pipe, assume this filename when '\
                   'checking file or directory rules in the config.') do |file|
-          self.stdin_filename = Pathname.new(file)
+          self.stdin_filename = file
         end
       end
 

--- a/lib/reek/examiner.rb
+++ b/lib/reek/examiner.rb
@@ -34,16 +34,13 @@ module Reek
     #   The configuration for this Examiner.
     #
     # @public
-    # :reek:ControlParameter
-    # :reek:LongParameterList { max_params: 6 }
     def initialize(source,
-                   origin: nil,
                    filter_by_smells: [],
                    configuration: Configuration::AppConfiguration.default,
                    detector_repository_class: DetectorRepository,
                    error_handler: NullHandler.new)
       @source              = Source::SourceCode.from(source)
-      @origin              = origin || @source.origin
+      @origin              = @source.origin
       @smell_types         = detector_repository_class.eligible_smell_types(filter_by_smells)
       @detector_repository = detector_repository_class.new(smell_types: @smell_types,
                                                            configuration: configuration.directive_for(@origin))

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -14,7 +14,7 @@ Reek::AST::Builder.emit_lambda = true
 module Reek
   module Source
     #
-    # A +Source+ object represents a chunk of Ruby source code.
+    # A +SourceCode+ object represents a chunk of Ruby source code.
     #
     class SourceCode
       # Consume and store parser diagnostics
@@ -35,37 +35,33 @@ module Reek
       IO_IDENTIFIER     = 'STDIN'.freeze
       STRING_IDENTIFIER = 'string'.freeze
 
-      attr_reader :origin
-
       # Initializer.
       #
-      # code   - Ruby code as String
-      # origin - 'STDIN', 'string' or a filepath as String
-      # parser - the parser to use for generating AST's out of the given code
-      def initialize(code:, origin:, parser: self.class.default_parser)
+      # @param source [File|Pathname|IO|String] Ruby source code
+      # @param origin [String] Origin of the source code. Will be determined
+      #   automatically if left blank.
+      # @param parser the parser to use for generating AST's out of the given code
+      def initialize(source:, origin: nil, parser: self.class.default_parser)
         @origin = origin
         @parser = parser
-        code.force_encoding(Encoding::UTF_8)
-        @code = code
+        @source = source
       end
 
       # Initializes an instance of SourceCode given a source.
-      # This source can come via 4 different ways:
+      # This source can come via several different ways:
       # - from Files or Pathnames a la `reek lib/reek/`
       # - from IO (STDIN) a la `echo "class Foo; end" | reek`
       # - from String via our rspec matchers a la `expect("class Foo; end").to reek`
+      # - from an existing SourceCode object. This is passed through unchanged
       #
-      # @param source [File|IO|String] - the given source
+      # @param source [SourceCode|File|Pathname|IO|String] the given source
+      # @param origin [String|nil]
       #
       # @return an instance of SourceCode
-      # :reek:DuplicateMethodCall { max_calls: 2 }
-      def self.from(source)
+      def self.from(source, origin: nil)
         case source
-        when self     then source
-        when File     then new(code: source.read,           origin: source.path)
-        when IO       then new(code: source.readlines.join, origin: IO_IDENTIFIER)
-        when Pathname then new(code: source.read,           origin: source.to_s)
-        when String   then new(code: source,                origin: STRING_IDENTIFIER)
+        when self then source
+        else new(source: source, origin: origin)
         end
       end
 
@@ -86,14 +82,32 @@ module Reek
         end
       end
 
+      def origin
+        @origin ||=
+          case source
+          when File     then source.path
+          when IO       then IO_IDENTIFIER
+          when Pathname then source.to_s
+          when String   then STRING_IDENTIFIER
+          end
+      end
+
       private
 
       def parse_result
         @parse_result ||= parse
       end
 
-      attr_reader :code
-      attr_reader :parser
+      def code
+        @code ||=
+          case source
+          when File, Pathname then source.read
+          when IO             then source.readlines.join
+          when String         then source
+          end.force_encoding(Encoding::UTF_8)
+      end
+
+      attr_reader :parser, :source
 
       # Parses the given code into an AST and associates the source code comments with it.
       # This AST is then traversed by a TreeDresser which adorns the nodes in the AST

--- a/spec/reek/cli/application_spec.rb
+++ b/spec/reek/cli/application_spec.rb
@@ -37,10 +37,11 @@ RSpec.describe Reek::CLI::Application do
         allow_any_instance_of(IO).to receive(:tty?).and_return(false)
       end
 
-      it 'uses source form pipe' do
+      it 'uses source from pipe' do
+        expected_sources = a_collection_containing_exactly(have_attributes(origin: 'STDIN'))
         app.execute
         expect(Reek::CLI::Command::ReportCommand).to have_received(:new).
-          with(sources: [$stdin],
+          with(sources: expected_sources,
                configuration: Reek::Configuration::AppConfiguration,
                options: Reek::CLI::Options)
       end
@@ -49,9 +50,10 @@ RSpec.describe Reek::CLI::Application do
         let(:app) { described_class.new ['--stdin-filename', 'foo.rb'] }
 
         it 'assumes that filename' do
+          expected_sources = a_collection_containing_exactly(have_attributes(origin: 'foo.rb'))
           app.execute
           expect(Reek::CLI::Command::ReportCommand).to have_received(:new).
-            with(sources: [$stdin],
+            with(sources: expected_sources,
                  configuration: Reek::Configuration::AppConfiguration,
                  options: Reek::CLI::Options)
         end

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -6,34 +6,34 @@ RSpec.describe Reek::Source::SourceCode do
   describe '#syntax_tree' do
     it 'associates comments with the AST' do
       source = "# this is\n# a comment\ndef foo; end"
-      source_code = described_class.new(code: source, origin: '(string)')
+      source_code = described_class.new(source: source, origin: '(string)')
       result = source_code.syntax_tree
       expect(result.leading_comment).to eq "# this is\n# a comment"
     end
 
     it 'cleanly processes empty source' do
-      source_code = described_class.new(code: '', origin: '(string)')
+      source_code = described_class.new(source: '', origin: '(string)')
       result = source_code.syntax_tree
       expect(result).to be_nil
     end
 
     it 'cleanly processes empty source with comments' do
       source = "# this is\n# a comment\n"
-      source_code = described_class.new(code: source, origin: '(string)')
+      source_code = described_class.new(source: source, origin: '(string)')
       result = source_code.syntax_tree
       expect(result).to be_nil
     end
 
     it 'does not crash with sequences incompatible with UTF-8' do
       source = '"\xFF"'
-      source_code = described_class.new(code: source, origin: '(string)')
+      source_code = described_class.new(source: source, origin: '(string)')
       result = source_code.syntax_tree
       expect(result.children.first).to eq "\xFF"
     end
 
     it 'returns a :lambda node for lambda expressions' do
       source = '->() { }'
-      source_code = described_class.new(code: source, origin: '(string)')
+      source_code = described_class.new(source: source, origin: '(string)')
       result = source_code.syntax_tree
       expect(result.children.first.type).to eq :lambda
     end
@@ -41,7 +41,7 @@ RSpec.describe Reek::Source::SourceCode do
 
   context 'when the parser fails' do
     let(:source_name) { 'Test source' }
-    let(:src) { described_class.new(code: code, origin: source_name, **options) }
+    let(:src) { described_class.new(source: code, origin: source_name, **options) }
 
     context 'with a Parser::SyntaxError' do
       let(:code) { '== Invalid Syntax ==' }


### PR DESCRIPTION
Cleans up interface of `Examiner.new` by pushing up setting of source code origin for stdin.