### PR TITLE
Remove support for Ruby 2.2.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
     - 'samples/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 # Place . on the previous line
 Layout/DotPosition:
@@ -59,6 +59,11 @@ Metrics/ClassLength:
   Exclude:
     - lib/reek/context_builder.rb
     - lib/reek/cli/options.rb
+
+Style/SafeNavigation:
+  Exclude:
+    - lib/reek/ast/node.rb
+    - lib/reek/ast/sexp_extensions/module.rb
 
 # FIXME: Lower the method length by fixing the biggest offenders
 Metrics/MethodLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: ruby
 bundler_args: --without debugging
 script: bundle exec rake ci
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/lib/reek/ast/sexp_extensions/methods.rb
+++ b/lib/reek/ast/sexp_extensions/methods.rb
@@ -57,7 +57,7 @@ module Reek
         end
 
         def depends_on_instance?
-          ReferenceCollector.new(self).num_refs_to_self > 0
+          ReferenceCollector.new(self).num_refs_to_self.positive?
         end
       end
 

--- a/lib/reek/cli/command/todo_list_command.rb
+++ b/lib/reek/cli/command/todo_list_command.rb
@@ -12,7 +12,7 @@ module Reek
       # file that can serve as a todo list.
       #
       class TodoListCommand < BaseCommand
-        FILE_NAME = '.todo.reek'.freeze
+        FILE_NAME = '.todo.reek'
 
         def execute
           if smells.empty?

--- a/lib/reek/code_comment.rb
+++ b/lib/reek/code_comment.rb
@@ -22,7 +22,7 @@ module Reek
                           )?
                          /x
     SANITIZE_REGEX                 = /(#|\n|\s)+/ # Matches '#', newlines and > 1 whitespaces.
-    DISABLE_DETECTOR_CONFIGURATION = '{ enabled: false }'.freeze
+    DISABLE_DETECTOR_CONFIGURATION = '{ enabled: false }'
     MINIMUM_CONTENT_LENGTH         = 2
 
     attr_reader :config

--- a/lib/reek/configuration/app_configuration.rb
+++ b/lib/reek/configuration/app_configuration.rb
@@ -15,9 +15,9 @@ module Reek
     # @public
     class AppConfiguration
       include ConfigurationValidator
-      EXCLUDE_PATHS_KEY = 'exclude_paths'.freeze
-      DIRECTORIES_KEY = 'directories'.freeze
-      DETECTORS_KEY = 'detectors'.freeze
+      EXCLUDE_PATHS_KEY = 'exclude_paths'
+      DIRECTORIES_KEY = 'directories'
+      DETECTORS_KEY = 'detectors'
 
       # Instantiate a configuration via the given path.
       #

--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -19,7 +19,7 @@ module Reek
     # The order in which ConfigurationFileFinder tries to find such a
     # configuration file is exactly like above.
     module ConfigurationFileFinder
-      DEFAULT_FILE_NAME = '.reek.yml'.freeze
+      DEFAULT_FILE_NAME = '.reek.yml'
 
       class << self
         include ConfigurationValidator

--- a/lib/reek/documentation_link.rb
+++ b/lib/reek/documentation_link.rb
@@ -3,7 +3,7 @@
 module Reek
   # Generate versioned links to our documentation
   module DocumentationLink
-    HELP_LINK_TEMPLATE = 'https://github.com/troessner/reek/blob/v%<version>s/docs/%<item>s.md'.freeze
+    HELP_LINK_TEMPLATE = 'https://github.com/troessner/reek/blob/v%<version>s/docs/%<item>s.md'
 
     module_function
 

--- a/lib/reek/errors/bad_detector_configuration_key_in_comment_error.rb
+++ b/lib/reek/errors/bad_detector_configuration_key_in_comment_error.rb
@@ -8,7 +8,7 @@ module Reek
     # Gets raised when trying to configure a detector with an option
     # which is unknown to it.
     class BadDetectorConfigurationKeyInCommentError < BaseError
-      UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-MESSAGE.freeze
+      UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-MESSAGE
 
         Error: You are trying to configure the smell detector '%<detector>s'
         in one of your source code comments with the unknown option %<option>s.

--- a/lib/reek/errors/bad_detector_in_comment_error.rb
+++ b/lib/reek/errors/bad_detector_in_comment_error.rb
@@ -9,7 +9,7 @@ module Reek
     # This might happen for multiple reasons. The users might have a typo in
     # his comment or he might use a detector that does not exist anymore.
     class BadDetectorInCommentError < BaseError
-      UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-MESSAGE.freeze
+      UNKNOWN_SMELL_DETECTOR_MESSAGE = <<-MESSAGE
 
         Error: You are trying to configure an unknown smell detector '%<detector>s' in one
         of your source code comments.

--- a/lib/reek/errors/encoding_error.rb
+++ b/lib/reek/errors/encoding_error.rb
@@ -6,9 +6,9 @@ module Reek
   module Errors
     # Gets raised when Reek is unable to process the source due to an EncodingError
     class EncodingError < BaseError
-      TEMPLATE = "Source '%<source>s' cannot be processed by Reek due to an encoding error in the source file.".freeze
+      TEMPLATE = "Source '%<source>s' cannot be processed by Reek due to an encoding error in the source file."
 
-      LONG_TEMPLATE = <<-MESSAGE.freeze
+      LONG_TEMPLATE = <<-MESSAGE
         !!!
         %<message>s
 

--- a/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
+++ b/lib/reek/errors/garbage_detector_configuration_in_comment_error.rb
@@ -8,7 +8,7 @@ module Reek
     # Gets raised when trying to use a configuration for a detector
     # that can't be parsed into a hash.
     class GarbageDetectorConfigurationInCommentError < BaseError
-      BAD_DETECTOR_CONFIGURATION_MESSAGE = <<-MESSAGE.freeze
+      BAD_DETECTOR_CONFIGURATION_MESSAGE = <<-MESSAGE
 
         Error: You are trying to configure the smell detector '%<detector>s'.
         Unfortunately we cannot parse the configuration you have given.

--- a/lib/reek/errors/incomprehensible_source_error.rb
+++ b/lib/reek/errors/incomprehensible_source_error.rb
@@ -6,9 +6,9 @@ module Reek
   module Errors
     # Gets raised when Reek is unable to process the source
     class IncomprehensibleSourceError < BaseError
-      TEMPLATE = 'Source %<source>s cannot be processed by Reek.'.freeze
+      TEMPLATE = 'Source %<source>s cannot be processed by Reek.'
 
-      LONG_TEMPLATE = <<-MESSAGE.freeze
+      LONG_TEMPLATE = <<-MESSAGE
         !!!
         %<message>s
 

--- a/lib/reek/errors/syntax_error.rb
+++ b/lib/reek/errors/syntax_error.rb
@@ -6,9 +6,9 @@ module Reek
   module Errors
     # Gets raised when Reek is unable to process the source due to a SyntaxError
     class SyntaxError < BaseError
-      TEMPLATE = "Source '%<source>s' cannot be processed by Reek due to a syntax error in the source file.".freeze
+      TEMPLATE = "Source '%<source>s' cannot be processed by Reek due to a syntax error in the source file."
 
-      LONG_TEMPLATE = <<-MESSAGE.freeze
+      LONG_TEMPLATE = <<-MESSAGE
         !!!
         %<message>s
 

--- a/lib/reek/report/base_report.rb
+++ b/lib/reek/report/base_report.rb
@@ -54,7 +54,7 @@ module Reek
       end
 
       def smells?
-        total_smell_count > 0
+        total_smell_count.positive?
       end
 
       def smells

--- a/lib/reek/smell_configuration.rb
+++ b/lib/reek/smell_configuration.rb
@@ -7,11 +7,11 @@ module Reek
   class SmellConfiguration
     # The name of the config field that specifies whether a smell is
     # enabled. Set to +true+ or +false+.
-    ENABLED_KEY = 'enabled'.freeze
+    ENABLED_KEY = 'enabled'
 
     # The name of the config field that sets scope-specific overrides
     # for other values in the current smell detector's configuration.
-    OVERRIDES_KEY = 'overrides'.freeze
+    OVERRIDES_KEY = 'overrides'
 
     def initialize(hash)
       @options = hash

--- a/lib/reek/smell_detectors/base_detector.rb
+++ b/lib/reek/smell_detectors/base_detector.rb
@@ -22,7 +22,7 @@ module Reek
       # The name of the config field that lists the names of code contexts
       # that should not be checked. Add this field to the config for each
       # smell that should ignore this code element.
-      EXCLUDE_KEY = 'exclude'.freeze
+      EXCLUDE_KEY = 'exclude'
 
       # The default value for the +EXCLUDE_KEY+ if it isn't specified
       # in any configuration file.

--- a/lib/reek/smell_detectors/data_clump.rb
+++ b/lib/reek/smell_detectors/data_clump.rb
@@ -24,7 +24,7 @@ module Reek
       # reported as a DataClump unless there are more than this many
       # methods containing those parameters.
       #
-      MAX_COPIES_KEY = 'max_copies'.freeze
+      MAX_COPIES_KEY = 'max_copies'
       DEFAULT_MAX_COPIES = 2
 
       #
@@ -32,7 +32,7 @@ module Reek
       # size. No group of common parameters will be reported as
       # a DataClump unless it contains at least this many parameters.
       #
-      MIN_CLUMP_SIZE_KEY = 'min_clump_size'.freeze
+      MIN_CLUMP_SIZE_KEY = 'min_clump_size'
       DEFAULT_MIN_CLUMP_SIZE = 2
 
       def self.contexts # :nodoc:

--- a/lib/reek/smell_detectors/duplicate_method_call.rb
+++ b/lib/reek/smell_detectors/duplicate_method_call.rb
@@ -21,13 +21,13 @@ module Reek
     class DuplicateMethodCall < BaseDetector
       # The name of the config field that sets the maximum number of
       # identical calls to be permitted within any single method.
-      MAX_ALLOWED_CALLS_KEY = 'max_calls'.freeze
+      MAX_ALLOWED_CALLS_KEY = 'max_calls'
       DEFAULT_MAX_CALLS = 1
 
       # The name of the config field that sets the names of any
       # methods for which identical calls should be to be permitted
       # within any single method.
-      ALLOW_CALLS_KEY = 'allow_calls'.freeze
+      ALLOW_CALLS_KEY = 'allow_calls'
       DEFAULT_ALLOW_CALLS = [].freeze
 
       def self.default_config

--- a/lib/reek/smell_detectors/long_parameter_list.rb
+++ b/lib/reek/smell_detectors/long_parameter_list.rb
@@ -16,7 +16,7 @@ module Reek
     class LongParameterList < BaseDetector
       # The name of the config field that sets the maximum number of
       # parameters permitted in any method or block.
-      MAX_ALLOWED_PARAMS_KEY = 'max_params'.freeze
+      MAX_ALLOWED_PARAMS_KEY = 'max_params'
       DEFAULT_MAX_ALLOWED_PARAMS = 3
 
       def self.default_config

--- a/lib/reek/smell_detectors/long_yield_list.rb
+++ b/lib/reek/smell_detectors/long_yield_list.rb
@@ -12,7 +12,7 @@ module Reek
     class LongYieldList < BaseDetector
       # The name of the config field that sets the maximum number of
       # parameters permitted in any method or block.
-      MAX_ALLOWED_PARAMS_KEY = 'max_params'.freeze
+      MAX_ALLOWED_PARAMS_KEY = 'max_params'
       DEFAULT_MAX_ALLOWED_PARAMS = 3
 
       def self.default_config

--- a/lib/reek/smell_detectors/manual_dispatch.rb
+++ b/lib/reek/smell_detectors/manual_dispatch.rb
@@ -12,7 +12,7 @@ module Reek
     #
     # See {file:docs/Manual-Dispatch.md} for details.
     class ManualDispatch < BaseDetector
-      MESSAGE = 'manually dispatches method call'.freeze
+      MESSAGE = 'manually dispatches method call'
 
       #
       # Checks for +respond_to?+ usage within the given method

--- a/lib/reek/smell_detectors/nested_iterators.rb
+++ b/lib/reek/smell_detectors/nested_iterators.rb
@@ -20,12 +20,12 @@ module Reek
 
       # The name of the config field that sets the maximum depth
       # of nested iterators to be permitted within any single method.
-      MAX_ALLOWED_NESTING_KEY = 'max_allowed_nesting'.freeze
+      MAX_ALLOWED_NESTING_KEY = 'max_allowed_nesting'
       DEFAULT_MAX_ALLOWED_NESTING = 1
 
       # The name of the config field that sets the names of any
       # methods for which nesting should not be considered
-      IGNORE_ITERATORS_KEY = 'ignore_iterators'.freeze
+      IGNORE_ITERATORS_KEY = 'ignore_iterators'
       DEFAULT_IGNORE_ITERATORS = ['tap'].freeze
 
       def self.default_config

--- a/lib/reek/smell_detectors/repeated_conditional.rb
+++ b/lib/reek/smell_detectors/repeated_conditional.rb
@@ -28,7 +28,7 @@ module Reek
     class RepeatedConditional < BaseDetector
       # The name of the config field that sets the maximum number of
       # identical conditionals permitted within any single class.
-      MAX_IDENTICAL_IFS_KEY = 'max_ifs'.freeze
+      MAX_IDENTICAL_IFS_KEY = 'max_ifs'
       DEFAULT_MAX_IFS = 2
 
       BLOCK_GIVEN_CONDITION = ::Parser::AST::Node.new(:send, [nil, :block_given?])

--- a/lib/reek/smell_detectors/too_many_constants.rb
+++ b/lib/reek/smell_detectors/too_many_constants.rb
@@ -15,7 +15,7 @@ module Reek
     class TooManyConstants < BaseDetector
       # The name of the config field that sets the maximum number
       # of constants permitted in a class.
-      MAX_ALLOWED_CONSTANTS_KEY = 'max_constants'.freeze
+      MAX_ALLOWED_CONSTANTS_KEY = 'max_constants'
       DEFAULT_MAX_CONSTANTS = 5
       IGNORED_NODES = [:module, :class].freeze
 

--- a/lib/reek/smell_detectors/too_many_instance_variables.rb
+++ b/lib/reek/smell_detectors/too_many_instance_variables.rb
@@ -15,7 +15,7 @@ module Reek
     class TooManyInstanceVariables < BaseDetector
       # The name of the config field that sets the maximum number of instance
       # variables permitted in a class.
-      MAX_ALLOWED_IVARS_KEY = 'max_instance_variables'.freeze
+      MAX_ALLOWED_IVARS_KEY = 'max_instance_variables'
       DEFAULT_MAX_IVARS = 4
 
       def self.contexts

--- a/lib/reek/smell_detectors/too_many_methods.rb
+++ b/lib/reek/smell_detectors/too_many_methods.rb
@@ -17,7 +17,7 @@ module Reek
     class TooManyMethods < BaseDetector
       # The name of the config field that sets the maximum number of methods
       # permitted in a class.
-      MAX_ALLOWED_METHODS_KEY = 'max_methods'.freeze
+      MAX_ALLOWED_METHODS_KEY = 'max_methods'
       DEFAULT_MAX_METHODS = 15
 
       def self.contexts

--- a/lib/reek/smell_detectors/too_many_statements.rb
+++ b/lib/reek/smell_detectors/too_many_statements.rb
@@ -13,7 +13,7 @@ module Reek
     class TooManyStatements < BaseDetector
       # The name of the config field that sets the maximum number of
       # statements permitted in any method.
-      MAX_ALLOWED_STATEMENTS_KEY = 'max_statements'.freeze
+      MAX_ALLOWED_STATEMENTS_KEY = 'max_statements'
       DEFAULT_MAX_STATEMENTS = 5
 
       def self.default_config

--- a/lib/reek/smell_detectors/uncommunicative_method_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_method_name.rb
@@ -20,8 +20,8 @@ module Reek
     #
     # See {file:docs/Uncommunicative-Method-Name.md} for details.
     class UncommunicativeMethodName < BaseDetector
-      REJECT_KEY = 'reject'.freeze
-      ACCEPT_KEY = 'accept'.freeze
+      REJECT_KEY = 'reject'
+      ACCEPT_KEY = 'accept'
       DEFAULT_REJECT_PATTERNS = [/^[a-z]$/, /[0-9]$/, /[A-Z]/].freeze
       DEFAULT_ACCEPT_PATTERNS = [].freeze
 

--- a/lib/reek/smell_detectors/uncommunicative_module_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_module_name.rb
@@ -21,13 +21,13 @@ module Reek
     class UncommunicativeModuleName < BaseDetector
       # The name of the config field that lists the regexps of
       # smelly names to be reported.
-      REJECT_KEY = 'reject'.freeze
+      REJECT_KEY = 'reject'
       DEFAULT_REJECT_PATTERNS = [/^.$/, /[0-9]$/].freeze
 
       # The name of the config field that lists the specific names that are
       # to be treated as exceptions; these names will not be reported as
       # uncommunicative.
-      ACCEPT_KEY = 'accept'.freeze
+      ACCEPT_KEY = 'accept'
       DEFAULT_ACCEPT_PATTERNS = [].freeze
 
       def self.default_config

--- a/lib/reek/smell_detectors/uncommunicative_parameter_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_parameter_name.rb
@@ -21,10 +21,10 @@ module Reek
     #
     # See {file:docs/Uncommunicative-Parameter-Name.md} for details.
     class UncommunicativeParameterName < BaseDetector
-      REJECT_KEY = 'reject'.freeze
+      REJECT_KEY = 'reject'
       DEFAULT_REJECT_PATTERNS = [/^.$/, /[0-9]$/, /[A-Z]/, /^_/].freeze
 
-      ACCEPT_KEY = 'accept'.freeze
+      ACCEPT_KEY = 'accept'
       DEFAULT_ACCEPT_PATTERNS = [].freeze
 
       def self.default_config

--- a/lib/reek/smell_detectors/uncommunicative_variable_name.rb
+++ b/lib/reek/smell_detectors/uncommunicative_variable_name.rb
@@ -24,7 +24,7 @@ module Reek
     class UncommunicativeVariableName < BaseDetector
       # The name of the config field that lists the regexps of
       # smelly names to be reported.
-      REJECT_KEY = 'reject'.freeze
+      REJECT_KEY = 'reject'
       DEFAULT_REJECT_SET = [
         /^.$/, # single-character names
         /[0-9]$/,  # any name ending with a number
@@ -34,7 +34,7 @@ module Reek
       # The name of the config field that lists the specific names that are
       # to be treated as exceptions; these names will not be reported as
       # uncommunicative.
-      ACCEPT_KEY = 'accept'.freeze
+      ACCEPT_KEY = 'accept'
       DEFAULT_ACCEPT_SET = [/^_$/].freeze
 
       def self.default_config

--- a/lib/reek/smell_detectors/utility_function.rb
+++ b/lib/reek/smell_detectors/utility_function.rb
@@ -38,7 +38,7 @@ module Reek
     #
     # See {file:docs/Utility-Function.md} for details.
     class UtilityFunction < BaseDetector
-      PUBLIC_METHODS_ONLY_KEY     = 'public_methods_only'.freeze
+      PUBLIC_METHODS_ONLY_KEY     = 'public_methods_only'
       PUBLIC_METHODS_ONLY_DEFAULT = false
 
       def self.default_config

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -15,8 +15,8 @@ module Reek
     # A +SourceCode+ object represents a chunk of Ruby source code.
     #
     class SourceCode
-      IO_IDENTIFIER     = 'STDIN'.freeze
-      STRING_IDENTIFIER = 'string'.freeze
+      IO_IDENTIFIER     = 'STDIN'
+      STRING_IDENTIFIER = 'string'
 
       # Initializer.
       #

--- a/lib/reek/version.rb
+++ b/lib/reek/version.rb
@@ -8,6 +8,6 @@ module Reek
   # @public
   module Version
     # @public
-    STRING = '4.8.1'.freeze
+    STRING = '4.8.1'
   end
 end

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^bin/}).map { |path| File.basename(path) }
   s.homepage = 'https://github.com/troessner/reek'
   s.rdoc_options = %w(--main README.md -x assets/|bin/|config/|features/|spec/|tasks/)
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.3.0'
   s.summary = 'Code smell detector for Ruby'
 
   s.add_runtime_dependency 'codeclimate-engine-rb', '~> 0.4.0'


### PR DESCRIPTION
Source: [click](https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/)

I have *not* yet updated our [supported ruby versions](https://github.com/troessner/reek/blob/master/README.md#supported-ruby-versions) yet, I'll do this in the scope of #1324 