### PR TITLE
Parser 2.5.1.1 seems broken. Disallow it.

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'codeclimate-engine-rb', '~> 0.4.0'
   s.add_runtime_dependency 'kwalify',               '~> 0.7.0'
-  s.add_runtime_dependency 'parser',                '< 2.6', '>= 2.5.0.0'
+  s.add_runtime_dependency 'parser',                '< 2.6', '>= 2.5.0.0', '!= 2.5.1.1'
   s.add_runtime_dependency 'rainbow',               '>= 2.0', '< 4.0'
 end


### PR DESCRIPTION
See https://github.com/whitequark/parser/issues/518 and https://github.com/rubocop-hq/rubocop/issues/6092.