### PR TITLE
Improve error messages

### DIFF
--- a/lib/reek/errors/incomprehensible_source_error.rb
+++ b/lib/reek/errors/incomprehensible_source_error.rb
@@ -17,8 +17,8 @@ module Reek
         It would be great if you could report this back to the Reek team by opening a
         corresponding issue at https://github.com/troessner/reek/issues.
 
-        Please make sure to include the source in question, the Reek version and the
-        original exception below.
+        Please make sure to include the source in question, the Reek version,
+        and this entire error message, including the original exception below.
 
         Exception message:
 

--- a/lib/reek/errors/syntax_error.rb
+++ b/lib/reek/errors/syntax_error.rb
@@ -15,6 +15,10 @@ module Reek
         This is a problem that is outside of Reek's scope and should be fixed by you, the
         user, in order for Reek being able to continue.
 
+        Things you can try:
+        - Check the syntax of the problematic file
+        - If the file is not in fact a Ruby file, exclude it in your .reek.yml file
+
         Exception message:
 
         %<exception>s


### PR DESCRIPTION
Fixes #1404.

* Tell users to paste the entire exception message in case of IncomprehensibleSourceError.
* Give hints on what to do with a syntax error.