### PR TITLE
Clean up debugging group in our bundle.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,11 +24,8 @@ group :development do
 end
 
 group :debugging do
-  # Fixing https://github.com/guard/guard/wiki/Add-Readline-support-to-Ruby-on-Mac-OS-X#option-4-using-a-pure-ruby-readline-implementation
   gem 'pry'
-  gem 'rb-readline', '~> 0.5.3'
   platforms :mri do
     gem 'pry-byebug'
-    gem 'pry-stack_explorer'
   end
 end


### PR DESCRIPTION
I used pry and its debugging functionality in #1408 extensively with the changes in this pull request applied there as well and everything worked well for me. Seems like rb-readline is not necessary anymore and i'm not 100% sure why we had pry-stack_explorer in the first place.