### PR TITLE
Update kramdown to 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,17 +5,18 @@ gemspec
 ruby RUBY_VERSION
 
 group :development do
-  gem 'aruba',           '~> 0.14.0'
-  gem 'cucumber',        '~> 3.0'
-  gem 'factory_bot',     '~> 4.0'
-  gem 'kramdown',        '~> 1.17'
-  gem 'rake',            '~> 12.0'
-  gem 'rspec',           '~> 3.0'
-  gem 'rspec-benchmark', '~> 0.4.0'
-  gem 'rubocop',         '~> 0.63.0'
-  gem 'rubocop-rspec',   '~> 1.31.0'
-  gem 'simplecov',       '~> 0.16.1'
-  gem 'yard',            '~> 0.9.5'
+  gem 'aruba',               '~> 0.14.0'
+  gem 'cucumber',            '~> 3.0'
+  gem 'factory_bot',         '~> 4.0'
+  gem 'kramdown',            '~> 2.1'
+  gem 'kramdown-parser-gfm', '~> 1.0'
+  gem 'rake',                '~> 12.0'
+  gem 'rspec',               '~> 3.0'
+  gem 'rspec-benchmark',     '~> 0.4.0'
+  gem 'rubocop',             '~> 0.63.0'
+  gem 'rubocop-rspec',       '~> 1.31.0'
+  gem 'simplecov',           '~> 0.16.1'
+  gem 'yard',                '~> 0.9.5'
 
   platforms :mri do
     gem 'redcarpet', '~> 3.4.0'


### PR DESCRIPTION
Staring from version 2.0, kramdown's GFM parser has been extracted to a separate gem, kramdown-parser-gfm.