### PR TITLE
[WIP] Added html and markdown url to documentation_link

### DIFF
--- a/features/reports/json.feature
+++ b/features/reports/json.feature
@@ -24,7 +24,10 @@ Feature: Report smells using simple JSON layout
               "context": "Smelly#x",
               "lines": [ 4 ],
               "message": "has the name 'x'",
-              "documentation_link": "https://github.com/troessner/reek/blob/v5.3.1/docs/Uncommunicative-Method-Name.md",
+              "documentation_link": {
+                "html": "https://github.com/troessner/reek/blob/v5.3.1/docs/Uncommunicative-Method-Name.md",
+                "markdown": "https://raw.githubusercontent.com/troessner/reek/v5.3.1/docs/Uncommunicative-Method-Name.md"
+              },
               "name": "x"
           },
           {
@@ -33,7 +36,10 @@ Feature: Report smells using simple JSON layout
               "context": "Smelly#x",
               "lines": [ 5 ],
               "message": "has the variable name 'y'",
-              "documentation_link": "https://github.com/troessner/reek/blob/v5.3.1/docs/Uncommunicative-Variable-Name.md",
+              "documentation_link": {
+                "html": "https://github.com/troessner/reek/blob/v5.3.1/docs/Uncommunicative-Variable-Name.md",
+                "markdown": "https://raw.githubusercontent.com/troessner/reek/v5.3.1/docs/Uncommunicative-Variable-Name.md"
+              },
               "name": "y"
           }
       ]
@@ -53,7 +59,10 @@ Feature: Report smells using simple JSON layout
                   1
               ],
               "message": "has no descriptive comment",
-              "documentation_link": "https://github.com/troessner/reek/blob/v5.3.1/docs/Irresponsible-Module.md"
+              "documentation_link": {
+                "html": "https://github.com/troessner/reek/blob/v5.3.1/docs/Irresponsible-Module.md",
+                "markdown": "https://raw.githubusercontent.com/troessner/reek/v5.3.1/docs/Irresponsible-Module.md"
+              }        
           }
       ]
       """

--- a/features/reports/yaml.feature
+++ b/features/reports/yaml.feature
@@ -25,7 +25,9 @@ Feature: Report smells using simple YAML layout
         smell_type: UncommunicativeMethodName
         source: smelly.rb
         name: x
-        documentation_link: https://github.com/troessner/reek/blob/v5.3.1/docs/Uncommunicative-Method-Name.md
+        documentation_link:
+          :html: https://github.com/troessner/reek/blob/v5.3.1/docs/Uncommunicative-Method-Name.md
+          :markdown: https://raw.githubusercontent.com/troessner/reek/v5.3.1/docs/Uncommunicative-Method-Name.md
       - context: Smelly#x
         lines:
         - 5
@@ -33,7 +35,9 @@ Feature: Report smells using simple YAML layout
         smell_type: UncommunicativeVariableName
         source: smelly.rb
         name: y
-        documentation_link: https://github.com/troessner/reek/blob/v5.3.1/docs/Uncommunicative-Variable-Name.md
+        documentation_link:
+          :html: https://github.com/troessner/reek/blob/v5.3.1/docs/Uncommunicative-Variable-Name.md
+          :markdown: https://raw.githubusercontent.com/troessner/reek/v5.3.1/docs/Uncommunicative-Variable-Name.md
       """
 
   Scenario: Indicate smells and print them as yaml when using STDIN
@@ -48,5 +52,7 @@ Feature: Report smells using simple YAML layout
         lines:
         - 1
         message: has no descriptive comment
-        documentation_link: https://github.com/troessner/reek/blob/v5.3.1/docs/Irresponsible-Module.md
+        documentation_link:
+          :html: https://github.com/troessner/reek/blob/v5.3.1/docs/Irresponsible-Module.md
+          :markdown: https://raw.githubusercontent.com/troessner/reek/v5.3.1/docs/Irresponsible-Module.md
       """

--- a/features/step_definitions/reek_steps.rb
+++ b/features/step_definitions/reek_steps.rb
@@ -46,8 +46,8 @@ Then /^it reports:$/ do |report|
 end
 
 Then /^it reports this yaml:$/ do |expected_yaml|
-  expected_warnings = YAML.safe_load(expected_yaml.chomp)
-  actual_warnings = YAML.safe_load(last_command_started.stdout)
+  expected_warnings = YAML.safe_load(expected_yaml.chomp, permitted_classes: [Symbol])
+  actual_warnings = YAML.safe_load(last_command_started.stdout, permitted_classes: [Symbol])
   expect(actual_warnings).to eq expected_warnings
 end
 

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -110,7 +110,7 @@ module Reek
         parser.on('--smell SMELL',
                   'Only look for a specific smell.',
                   'Call it like this: reek --smell MissingSafeMethod source.rb',
-                  "Check out #{DocumentationLink.build('Code Smells')} "\
+                  "Check out #{DocumentationLink.build('Code Smells')[:html]} "\
                   'for a list of smells') do |smell|
           smells_to_detect << smell
         end

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -231,7 +231,7 @@ module Reek
         parser.on_tail('-l', '--list', 'List all available smell detectors') do
           puts "All available smell detectors:\n\n"
           puts DetectorRepository.available_detector_names
-          puts "\nCheck out #{DocumentationLink.build('Code Smells')} "\
+          puts "\nCheck out #{DocumentationLink.build('Code Smells')[:html]} "\
                   'for a details on each detector'
           exit
         end

--- a/lib/reek/documentation_link.rb
+++ b/lib/reek/documentation_link.rb
@@ -17,7 +17,7 @@ module Reek
     # and the full URL for markdown documentation
     def build(subject)
       item = name_to_param(subject)
-      { html: Kernel.format(HELP_LINK_TEMPLATE, version: Version::STRING, item: item),
+      { html:     Kernel.format(HELP_LINK_TEMPLATE, version: Version::STRING, item: item),
         markdown: Kernel.format(RAW_HELP_LINK_TEMPLATE, version: Version::STRING, item: item) }
     end
 

--- a/lib/reek/documentation_link.rb
+++ b/lib/reek/documentation_link.rb
@@ -4,17 +4,21 @@ module Reek
   # Generate versioned links to our documentation
   module DocumentationLink
     HELP_LINK_TEMPLATE = 'https://github.com/troessner/reek/blob/v%<version>s/docs/%<item>s.md'
+    RAW_HELP_LINK_TEMPLATE = 'https://raw.githubusercontent.com/troessner/reek/v%<version>s/docs/%<item>s.md'
 
     module_function
 
-    # Build link to the documentation about the given subject for the current
+    # Build documentation links about the given subject for the current
     # version of Reek. The subject can be either a smell type like
     # 'FeatureEnvy' or a general subject like 'Rake Task'.
     #
     # @param subject [String]
-    # @return [String] the full URL for the relevant documentation
+    # @return [Hash{Symbol => String, Symbol => String}] with the full URL for the relevant documentation
+    # and the full URL for markdown documentation
     def build(subject)
-      Kernel.format(HELP_LINK_TEMPLATE, version: Version::STRING, item: name_to_param(subject))
+      item = name_to_param(subject)
+      { html: Kernel.format(HELP_LINK_TEMPLATE, version: Version::STRING, item: item),
+        markdown: Kernel.format(RAW_HELP_LINK_TEMPLATE, version: Version::STRING, item: item) }
     end
 
     # Convert the given subject name to a form that is acceptable in a URL.

--- a/lib/reek/report/documentation_link_warning_formatter.rb
+++ b/lib/reek/report/documentation_link_warning_formatter.rb
@@ -10,7 +10,7 @@ module Reek
     #
     class DocumentationLinkWarningFormatter < SimpleWarningFormatter
       def format(warning)
-        "#{super} [#{warning.explanatory_link}]"
+        "#{super} [#{warning.explanatory_link[:html]}]"
       end
     end
   end

--- a/spec/reek/documentation_link_spec.rb
+++ b/spec/reek/documentation_link_spec.rb
@@ -4,17 +4,20 @@ RSpec.describe Reek::DocumentationLink do
   describe '.build' do
     it 'returns the correct link for a smell type' do
       expect(described_class.build('FeatureEnvy')).
-        to eq "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Feature-Envy.md"
+        to include(:html => "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Feature-Envy.md",
+                   :markdown => "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/Feature-Envy.md")
     end
 
     it 'returns the correct link for general documentation' do
       expect(described_class.build('Rake Task')).
-        to eq "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Rake-Task.md"
+        to include(:html => "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Rake-Task.md",
+                   :markdown => "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/Rake-Task.md")
     end
 
     it 'returns the correct link for subjects with abbreviations' do
       expect(described_class.build('YAML Report')).
-        to eq "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/YAML-Report.md"
+        to include(:html => "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/YAML-Report.md",
+                   :markdown => "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/YAML-Report.md")
     end
   end
 end

--- a/spec/reek/documentation_link_spec.rb
+++ b/spec/reek/documentation_link_spec.rb
@@ -4,20 +4,23 @@ RSpec.describe Reek::DocumentationLink do
   describe '.build' do
     it 'returns the correct link for a smell type' do
       expect(described_class.build('FeatureEnvy')).
-        to include(:html => "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Feature-Envy.md",
-                   :markdown => "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/Feature-Envy.md")
+        to include(
+          html: "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Feature-Envy.md",
+          markdown: "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/Feature-Envy.md")
     end
 
     it 'returns the correct link for general documentation' do
       expect(described_class.build('Rake Task')).
-        to include(:html => "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Rake-Task.md",
-                   :markdown => "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/Rake-Task.md")
+        to include(
+          html: "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Rake-Task.md",
+          markdown: "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/Rake-Task.md")
     end
 
     it 'returns the correct link for subjects with abbreviations' do
       expect(described_class.build('YAML Report')).
-        to include(:html => "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/YAML-Report.md",
-                   :markdown => "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/YAML-Report.md")
+        to include(
+          html: "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/YAML-Report.md",
+          markdown: "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/YAML-Report.md")
     end
   end
 end

--- a/spec/reek/report/json_report_spec.rb
+++ b/spec/reek/report/json_report_spec.rb
@@ -39,7 +39,10 @@ RSpec.describe Reek::Report::JSONReport do
             "smell_type":         "UncommunicativeParameterName",
             "source":             "string",
             "name":               "a",
-            "documentation_link": "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Uncommunicative-Parameter-Name.md"
+            "documentation_link": {
+              "html": "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Uncommunicative-Parameter-Name.md",
+              "markdown": "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/Uncommunicative-Parameter-Name.md"
+            }
           },
           {
             "context":            "simple",
@@ -47,7 +50,10 @@ RSpec.describe Reek::Report::JSONReport do
             "message":            "doesn't depend on instance state (maybe move it to another class?)",
             "smell_type":         "UtilityFunction",
             "source":             "string",
-            "documentation_link": "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Utility-Function.md"
+            "documentation_link": {
+              "html": "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Utility-Function.md",
+              "markdown": "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/Utility-Function.md"
+            }
           }
         ]
       EOS

--- a/spec/reek/report/yaml_report_spec.rb
+++ b/spec/reek/report/yaml_report_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Reek::Report::YAMLReport do
       out = StringIO.new
       instance.show(out)
       out.rewind
-      result = YAML.safe_load(out.read)
-      expected = YAML.safe_load <<~YAML
+      result = YAML.safe_load(out.read, permitted_classes: [Symbol])
+      expected = <<~YAML
         ---
         - context:        "simple"
           lines:
@@ -39,15 +39,21 @@ RSpec.describe Reek::Report::YAMLReport do
           smell_type:         "UncommunicativeParameterName"
           source:             "string"
           name:               "a"
-          documentation_link: "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Uncommunicative-Parameter-Name.md"
+          documentation_link:
+           :html: "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Uncommunicative-Parameter-Name.md"
+           :markdown: "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/Uncommunicative-Parameter-Name.md"
         - context:        "simple"
           lines:
           - 1
           message:            "doesn't depend on instance state (maybe move it to another class?)"
           smell_type:         "UtilityFunction"
           source:             "string"
-          documentation_link: "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Utility-Function.md"
+          documentation_link:
+           :html: "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Utility-Function.md"
+           :markdown: "https://raw.githubusercontent.com/troessner/reek/v#{Reek::Version::STRING}/docs/Utility-Function.md"
+
       YAML
+      expected = YAML.safe_load(expected, permitted_classes: [Symbol])
 
       expect(result).to eq expected
     end


### PR DESCRIPTION
The html and markdown url should be useful to visit the documentation in a browser or to parse the markdown and extract information about the rule (with some linters, etc...).