### PR TITLE
Enable regex for directory directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,12 +309,18 @@ detectors:
 # You can configure smells on a per-directory base.
 # E.g. the classic Rails case: controllers smell of NestedIterators (see /docs/Nested-Iterators.md) and
 # helpers smell of UtilityFunction (see docs/Utility-Function.md)
-# Note that we only allow configuration on a directory level, not a file level, so all paths have to point to directories.
+#
+# Note that we only allow configuration on a directory level, not a file level,
+# so all paths have to point to directories.
+# A Dir.glob pattern can be used.
 directories:
   "web_app/app/controllers":
     NestedIterators:
       enabled: false
-  "web_app/app/helpers":
+  "web_app/app/helpers**:
+    UtilityFunction:
+      enabled: false
+  "web_app/lib/**/test/**":
     UtilityFunction:
       enabled: false
 

--- a/lib/reek/configuration/directory_directives.rb
+++ b/lib/reek/configuration/directory_directives.rb
@@ -74,6 +74,7 @@ module Reek
                      gsub(%r{/\*\*$}, '<<to_eol_wildcards>>').
                      gsub('**', '<<to_wildcards>>').
                      gsub('*', '[^/]*').
+                     gsub('.', '\.').
                      gsub('<<to_eol_wildcards>>', '.*').
                      gsub('<<to_wildcards>>', '.*')
                  else

--- a/lib/reek/configuration/directory_directives.rb
+++ b/lib/reek/configuration/directory_directives.rb
@@ -53,7 +53,7 @@ module Reek
       # @quality :reek:FeatureEnvy
       def best_match_for(source_base_dir)
         keys.
-          select { |pathname| source_base_dir.to_s.match(/#{Regexp.escape(pathname.to_s)}/) }.
+          select { |pathname| source_base_dir.to_s.match(/#{pathname.to_s}/) }.
           max_by { |pathname| pathname.to_s.length }
       end
 

--- a/spec/reek/configuration/directory_directives_spec.rb
+++ b/spec/reek/configuration/directory_directives_spec.rb
@@ -44,11 +44,12 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
   describe '#best_match_for' do
     let(:directives) do
       {
-        Pathname.new('foo/bar/baz')    => {},
-        Pathname.new('foo/bar')        => {},
-        Pathname.new('bar/boo')        => {},
-        Pathname.new('bar/**/test/**') => {},
-        Pathname.new('bar/**/spec/*')  => {}
+        Pathname.new('foo/bar/baz')     => {},
+        Pathname.new('foo/bar')         => {},
+        Pathname.new('bar/boo')         => {},
+        Pathname.new('bar/**/test/**')  => {},
+        Pathname.new('bar/**/spec/*')   => {},
+        Pathname.new('bar/**/.spec/*')  => {}
       }.extend(described_class)
     end
 
@@ -80,6 +81,18 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
       source_base_dir = 'bar/something/spec/direct'
       hit = directives.send :best_match_for, source_base_dir
       expect(hit.to_s).to eq('bar/**/spec/*')
+    end
+
+    it 'returns the corresponding directory when source_base_dir contains a . character' do
+      source_base_dir = 'bar/something/.spec/direct'
+      hit = directives.send :best_match_for, source_base_dir
+      expect(hit.to_s).to eq('bar/**/.spec/*')
+    end
+
+    it 'does not match an arbitrary directory when source_base_dir contains a character that could match the .' do
+      source_base_dir = 'bar/something/aspec/direct'
+      hit = directives.send :best_match_for, source_base_dir
+      expect(hit.to_s).to eq('')
     end
 
     it 'returns nil when source_base_dir is a not direct leaf of the Dir.glob one-folder pattern' do

--- a/spec/reek/configuration/directory_directives_spec.rb
+++ b/spec/reek/configuration/directory_directives_spec.rb
@@ -44,9 +44,11 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
   describe '#best_match_for' do
     let(:directives) do
       {
-        Pathname.new('foo/bar/baz') => {},
-        Pathname.new('foo/bar')     => {},
-        Pathname.new('bar/boo')     => {}
+        Pathname.new('foo/bar/baz')    => {},
+        Pathname.new('foo/bar')        => {},
+        Pathname.new('bar/boo')        => {},
+        Pathname.new('bar/**/test/**') => {},
+        Pathname.new('bar/**/spec/*')  => {}
       }.extend(described_class)
     end
 
@@ -60,6 +62,30 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
       source_base_dir = 'foo/bar'
       hit = directives.send :best_match_for, source_base_dir
       expect(hit.to_s).to eq('foo/bar')
+    end
+
+    it 'returns the corresponding directory when source_base_dir matches the Dir.glob like pattern' do
+      source_base_dir = 'bar/something/test'
+      hit = directives.send :best_match_for, source_base_dir
+      expect(hit.to_s).to eq('bar/**/test/**')
+    end
+
+    it 'returns the corresponding directory when source_base_dir is a leaf of the Dir.glob like pattern' do
+      source_base_dir = 'bar/something/test/with/some/subdirectory'
+      hit = directives.send :best_match_for, source_base_dir
+      expect(hit.to_s).to eq('bar/**/test/**')
+    end
+
+    it 'returns the corresponding directory when source_base_dir is a direct leaf of the Dir.glob like pattern' do
+      source_base_dir = 'bar/something/spec/direct'
+      hit = directives.send :best_match_for, source_base_dir
+      expect(hit.to_s).to eq('bar/**/spec/*')
+    end
+
+    it 'returns nil when source_base_dir is a not direct leaf of the Dir.glob one-folder pattern' do
+      source_base_dir = 'bar/something/spec/with/some/subdirectory'
+      hit = directives.send :best_match_for, source_base_dir
+      expect(hit).to be_nil
     end
 
     it 'returns nil we are on top of the tree and all other directories are below' do

--- a/spec/reek/configuration/directory_directives_spec.rb
+++ b/spec/reek/configuration/directory_directives_spec.rb
@@ -44,12 +44,12 @@ RSpec.describe Reek::Configuration::DirectoryDirectives do
   describe '#best_match_for' do
     let(:directives) do
       {
-        Pathname.new('foo/bar/baz')     => {},
-        Pathname.new('foo/bar')         => {},
-        Pathname.new('bar/boo')         => {},
-        Pathname.new('bar/**/test/**')  => {},
-        Pathname.new('bar/**/spec/*')   => {},
-        Pathname.new('bar/**/.spec/*')  => {}
+        Pathname.new('foo/bar/baz')    => {},
+        Pathname.new('foo/bar')        => {},
+        Pathname.new('bar/boo')        => {},
+        Pathname.new('bar/**/test/**') => {},
+        Pathname.new('bar/**/spec/*')  => {},
+        Pathname.new('bar/**/.spec/*') => {}
       }.extend(described_class)
     end
 


### PR DESCRIPTION
The code was already ready for that but escaped the potential regexp declared in the reek configuration, actually disabling regexp.

This commit fixes this by removing the call to escape.

This allows this kind of declaration in the configuration file:

\# .reek.yml
```yaml
---
[...]
  "engines/.*/test/.*":
    InstanceVariableAssumption:
      enabled: false
    UncommunicativeVariableName:
      enabled: false
```

If this PR is accepted, I'll update the documentation to show this _feature_.