### PR TITLE
[doc] Reek-Driven Development: Simplify English; update

### DIFF
--- a/docs/Reek-Driven-Development.md
+++ b/docs/Reek-Driven-Development.md
@@ -16,7 +16,7 @@ Reek::Rake::Task.new do |t|
 end
 ```
 
-Now, `rake reek` will run Reek on your source code. Aand, in this case, it fails if it finds any smells.
+Now, `rake reek` will run Reek on your source code. And, in this case, it fails if it finds any smells.
 
 For more detailed information about Reek's integration with Rake, see [Rake Task].
 

--- a/docs/Reek-Driven-Development.md
+++ b/docs/Reek-Driven-Development.md
@@ -6,7 +6,7 @@ One way to drive quality into your code from the very beginning of a project is 
 
 You can add a [Rake Task] to your Rakefile, which will run Reek on all your source files.
 
-```ruby
+```Ruby
 require 'reek/rake/task'
 
 Reek::Rake::Task.new do |t|
@@ -28,7 +28,7 @@ You can add Reek expectations directly into your RSpec specs.
 
 This example is from Reek's own source code:
 
-```ruby
+```Ruby
 require 'reek/spec'
 
 it 'contains no code smells' do

--- a/docs/Reek-Driven-Development.md
+++ b/docs/Reek-Driven-Development.md
@@ -1,10 +1,12 @@
-# Reek Driven Development
+# Reek-Driven Development
 
-## rake
+One way to drive quality into your code from the very beginning of a project is to run Reek as a part of your testing process.
 
-One way to drive quality into your code from the very beginning of a project is to run Reek as a part of your testing process. For example, you could do that by adding a [Rake Task](Rake-Task.md) to your rakefile, which will make it easy to run Reek on all your source files whenever you need to.
+## Rake: `Reek::Rake::Task`
 
-```Ruby
+You can add a [Rake Task] to your Rakefile, which will run Reek on all your source files.
+
+```ruby
 require 'reek/rake/task'
 
 Reek::Rake::Task.new do |t|
@@ -14,13 +16,21 @@ Reek::Rake::Task.new do |t|
 end
 ```
 
-Now the command `reek` will run Reek on your source code (and in this case, it fails if it finds any smells). For more detailed information about Reek's integration with Rake, see [Rake Task](Rake-Task.md).
+Now, `rake reek` will run Reek on your source code. Aand, in this case, it fails if it finds any smells.
 
-## reek/spec
+For more detailed information about Reek's integration with Rake, see [Rake Task].
 
-But there's another way; a much more effective "Reek-driven" approach: add Reek expectations directly into your Rspec specs. Here's an example taken directly from Reek's own source code:
+[Rake Task]: Rake-Task.md
 
-```Ruby
+## RSpec: `reek/spec`
+
+You can add Reek expectations directly into your RSpec specs.
+
+This example is from Reek's own source code:
+
+```ruby
+require 'reek/spec'
+
 it 'contains no code smells' do
   Pathname.glob('lib/**/*.rb').each do |file|
     expect(file).not_to reek
@@ -28,12 +38,9 @@ it 'contains no code smells' do
 end
 ```
 
-By requiring [`reek/spec`](../lib/reek/spec.rb) you gain access to the `reek` matcher, which returns true if and only if Reek finds smells in your code. And if the test fails, the matcher produces an error message that includes details of all the smells it found.
+By requiring [`reek/spec`] you gain access to the `reek` matcher.
 
-## assert
+The `reek` matcher returns true if and only if Reek finds smells in your code. If the test fails, the matcher produces an error message that includes details of all the smells it found.
 
-If you're not yet into BDD with Rspec, you can still gain the benefits of Reek-driven development using assertions:
+[`reek/spec`]: ../lib/reek/spec.rb
 
-```Ruby
-assert !Dir['lib/**/*.rb'].to_source.smelly?
-```


### PR DESCRIPTION
Hi, again.

I updated the text of this article to be easier to scan. Sentences are shorter.

I also removed the section on Test::Unit assert support - it was no longer current.

---

  - the section on assert referred to to_source -  this commit removed `#to_source` - https://github.com/troessner/reek/commit/6b8af4b50fae56a004cc936063e633f238d62755 - and the #sniff methods in core_extras were also removed
  - I conclude the Test::Unit-style support is lower, these days