### PR TITLE
CI: Use jruby-9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ rvm:
   - 2.5
   - 2.6
   - jruby-9.1.17.0
-  - jruby-9.2.5.0
+  - jruby-9.2.6.0
   - jruby-head
   - ruby-head
   - rubinius-3


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)