### PR TITLE
Travis: Drop outdated setting "sudo: false"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 dist: trusty
 cache: bundler
 language: ruby


### PR DESCRIPTION
This setting now does nothing, see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration