### PR TITLE
Bump base image to a more recent ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Build and run via:
 #   docker build -t codeclimate/codeclimate-reek . && docker run codeclimate/codeclimate-reek
 
-FROM ruby:2.3.3-alpine
+FROM ruby:2.6.0-alpine
 
 MAINTAINER The Reek core team
 


### PR DESCRIPTION
`docker build` is failing on `master`, updating ruby version fix the problem:

```
Step 13/16 : RUN bundle install --without debugging development
 ---> Running in 714c4e374354
fatal: Not a git repository (or any of the parent directories): .git
Warning: the running version of Bundler (1.14.6) is older than the version that created the lockfile (1.17.2). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Fetching gem metadata from https://rubygems.org/........
Fetching version metadata from https://rubygems.org/.
Resolving dependencies...
Installing ast 2.4.0
Installing thread_safe 0.3.6
Installing ice_nine 0.11.2
Installing equalizer 0.0.11
Installing kwalify 0.7.2
Installing psych 3.1.0 with native extensions
Installing rainbow 3.0.0
Using bundler 1.14.6
Installing parser 2.6.5.0
Installing descendants_tracker 0.0.4
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/psych-3.1.0/ext/psych
/usr/local/bin/ruby -r ./siteconf20191112-7-1fgmpkt.rb extconf.rb
checking for yaml.h... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/local/bin/$(RUBY_BASE_NAME)
	--with-libyaml-dir
	--without-libyaml-dir
	--with-libyaml-include
	--without-libyaml-include=${libyaml-dir}/include
	--with-libyaml-lib
	--without-libyaml-lib=${libyaml-dir}/lib
	--enable-bundled-libyaml
	--disable-bundled-libyaml
/usr/local/lib/ruby/2.3.0/mkmf.rb:456:in `try_do': The compiler failed to
generate an executable file. (RuntimeError)
You have to install development tools first.
	from /usr/local/lib/ruby/2.3.0/mkmf.rb:587:in `try_cpp'
	from /usr/local/lib/ruby/2.3.0/mkmf.rb:1144:in `block in find_header'
	from /usr/local/lib/ruby/2.3.0/mkmf.rb:942:in `block in checking_for'
	from /usr/local/lib/ruby/2.3.0/mkmf.rb:350:in `block (2 levels) in postpone'
	from /usr/local/lib/ruby/2.3.0/mkmf.rb:320:in `open'
	from /usr/local/lib/ruby/2.3.0/mkmf.rb:350:in `block in postpone'
	from /usr/local/lib/ruby/2.3.0/mkmf.rb:320:in `open'
	from /usr/local/lib/ruby/2.3.0/mkmf.rb:346:in `postpone'
	from /usr/local/lib/ruby/2.3.0/mkmf.rb:941:in `checking_for'
	from /usr/local/lib/ruby/2.3.0/mkmf.rb:1143:in `find_header'
	from extconf.rb:10:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can
be found here:

  /usr/local/bundle/extensions/x86_64-linux/2.3.0/psych-3.1.0/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /usr/local/bundle/gems/psych-3.1.0 for
inspection.
Results logged to
/usr/local/bundle/extensions/x86_64-linux/2.3.0/psych-3.1.0/gem_make.out

An error occurred while installing psych (3.1.0), and Bundler cannot continue.
Make sure that `gem install psych -v '3.1.0'` succeeds before bundling.
The command '/bin/sh -c bundle install --without debugging development' returned a non-zero code: 5
```

Once this is merged I can complete the CodeClimate plugin update.