### PR TITLE
Update RuboCop dependencies and fix offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
   TargetRubyVersion: 2.3
 
 # Tables are nice
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedColonStyle: table
   EnforcedHashRocketStyle: table
   EnforcedLastArgumentHashStyle: ignore_implicit

--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,9 @@ group :development do
   gem 'rake',                '~> 13.0'
   gem 'rspec',               '~> 3.0'
   gem 'rspec-benchmark',     '~> 0.5.0'
-  gem 'rubocop',             '~> 0.75.0'
+  gem 'rubocop',             '~> 0.77.0'
   gem 'rubocop-performance', '~> 1.5.0'
-  gem 'rubocop-rspec',       '~> 1.36.0'
+  gem 'rubocop-rspec',       '~> 1.37.0'
   gem 'simplecov',           '~> 0.17.0'
   gem 'yard',                '~> 0.9.5'
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,7 +5,7 @@ require 'active_support/core_ext/string/strip'
 
 begin
   require 'pry-byebug'
-rescue LoadError # rubocop:disable Lint/HandleExceptions
+rescue LoadError # rubocop:disable Lint/SuppressedException
 end
 
 #

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -4,7 +4,7 @@ require_relative '../../lib/reek/smell_warning'
 require_relative '../../lib/reek/cli/options'
 
 FactoryBot.define do
-  factory :smell_warning, class: Reek::SmellWarning do
+  factory :smell_warning, class: 'Reek::SmellWarning' do
     skip_create
 
     smell_type { 'FeatureEnvy' }
@@ -24,7 +24,7 @@ FactoryBot.define do
     end
   end
 
-  factory :code_comment, class: Reek::CodeComment do
+  factory :code_comment, class: 'Reek::CodeComment' do
     comment { '' }
     line { 1 }
     source { 'string' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ require_relative '../samples/paths'
 
 begin
   Reek::CLI::Silencer.without_warnings { require 'pry-byebug' }
-rescue LoadError # rubocop:disable Lint/HandleExceptions
+rescue LoadError # rubocop:disable Lint/SuppressedException
 end
 
 require 'factory_bot'


### PR DESCRIPTION
- Update rubocop to 0.77.0
- Update rubocop-rspec to 1.37.0
- Update RuboCop cop names in config and suppression comments
- Autocorrect FactoryBot/FactoryClassName offenses