### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - 'samples/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 # Tables are nice
 Layout/HashAlignment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,19 @@ before_script:
   - unset _JAVA_OPTIONS
 script: bundle exec rake ci
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
   - 2.7
-  - jruby-9.1.17.0
-  - jruby-9.2.6.0
+  - jruby-9.2
   - jruby-head
   - ruby-head
-  - rubinius-3
+  - rubinius-4
 matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
-    - rvm: rubinius-3
+    - rvm: rubinius-4
   fast_finish: true
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ demo.rb -- 2 warnings:
 
 ## Supported Ruby versions
 
-Reek is officially supported for CRuby 2.3 to 2.6 and for JRuby 9.1 and 9.2.
+Reek is officially supported for CRuby 2.4 to 2.7 and for JRuby 9.2.
 Other Ruby implementations (like Rubinius) are not officially supported but
 should work as well.
 

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^bin/}).map { |path| File.basename(path) }
   s.homepage = 'https://github.com/troessner/reek'
   s.rdoc_options = %w(--main README.md -x assets/|bin/|config/|features/|spec/|tasks/)
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.4.0'
   s.summary = 'Code smell detector for Ruby'
 
   s.add_runtime_dependency 'kwalify', '~> 0.7.0'


### PR DESCRIPTION
- Require 2.4 in gemspec
- Make RuboCop target 2.4
- Stop building on 2.3 and jruby 9.1 on Travis
- Build on rubinius-4 for good measure
- Update README