### PR TITLE
Refactor data clump detector

### DIFF
--- a/lib/reek/smell_detectors/data_clump.rb
+++ b/lib/reek/smell_detectors/data_clump.rb
@@ -80,9 +80,7 @@ module Reek
       end
 
       def candidate_methods
-        @candidate_methods ||= context.node_instance_methods.map do |defn_node|
-          CandidateMethod.new(defn_node)
-        end
+        @candidate_methods ||= context.node_instance_methods
       end
 
       def candidate_clumps
@@ -95,7 +93,7 @@ module Reek
 
       # @quality :reek:UtilityFunction
       def common_argument_names_for(methods)
-        methods.map(&:arg_names).inject(:&)
+        methods.map(&:arg_names).inject(:&).compact.sort
       end
 
       def methods_containing_clump(clump)
@@ -108,26 +106,5 @@ module Reek
         end
       end
     end
-  end
-
-  # A method definition and a copy of its parameters
-  # @private
-  class CandidateMethod
-    extend Forwardable
-
-    def_delegators :defn, :line, :name
-
-    def initialize(defn_node)
-      @defn = defn_node
-    end
-
-    def arg_names
-      # TODO: Is all this sorting still needed?
-      @arg_names ||= defn.arg_names.compact.sort
-    end
-
-    private
-
-    attr_reader :defn
   end
 end

--- a/spec/reek/smell_detectors/data_clump_spec.rb
+++ b/spec/reek/smell_detectors/data_clump_spec.rb
@@ -76,6 +76,20 @@ RSpec.describe Reek::SmellDetectors::DataClump do
                              parameters: ['echo', 'foxtrot'])
     end
 
+    it 'reports arguments in alphabetical order even if they are never used that way' do
+      src = <<-RUBY
+        #{scope} Alfa
+          def bravo  (foxtrot, echo); end
+          def charlie(foxtrot, echo); end
+          def delta  (foxtrot, echo); end
+        end
+      RUBY
+
+      expect(src).to reek_of(:DataClump,
+                             count: 3,
+                             parameters: ['echo', 'foxtrot'])
+    end
+
     it 'reports parameter sets that are > 2' do
       src = <<-RUBY
         #{scope} Alfa


### PR DESCRIPTION
Because each detector now detects one context we don't need the extra classes anymore.