### PR TITLE
Avoid conflict between pry and pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,5 @@ group :development do
 end
 
 group :debugging do
-  gem 'pry'
-  platforms :mri do
-    gem 'pry-byebug'
-  end
+  gem 'pry', '~> 0.13.0'
 end


### PR DESCRIPTION
The current released version of pry-byebug is incompatible with the latest version of pry. Drop pry-byebug for now and avoid silent incompatible updates in the future by setting a required version.