### PR TITLE
Add node for forward_args

### DIFF
--- a/lib/reek/ast/sexp_extensions/arguments.rb
+++ b/lib/reek/ast/sexp_extensions/arguments.rb
@@ -93,6 +93,17 @@ module Reek
       module ShadowargNode
         include ArgNodeBase
       end
+
+      # Utility methods for :forward_args nodes.
+      # rubocop:disable Naming/ClassAndModuleCamelCase
+      module Forward_ArgsNode
+        include ArgNodeBase
+
+        def anonymous_splat?
+          true
+        end
+      end
+      # rubocop:enable Naming/ClassAndModuleCamelCase
     end
   end
 end

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -62,5 +62,18 @@ RSpec.describe Reek::Source::SourceCode do
         expect { src.syntax_tree }.to raise_error error_class, error_message
       end
     end
+
+    if RUBY_VERSION >= '2.7'
+      context 'with ruby 2.7 syntax' do
+        context 'with forward_args (`...`)' do
+          let(:source_code) { described_class.new(source: 'def alpha(...) bravo(...); end') }
+
+          it 'returns a :forward_args node' do
+            result = source_code.syntax_tree
+            expect(result.children[1].type).to eq(:forward_args)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Hello! 

Recently I had a problem using reek with files with new ruby 2.7 features, namely forward all syntax (`...`). 

If you run reek against file like this:
```ruby
class Something
  def self.call(...)
    new(...).call
  end
  # ...
end
```
it will fail with error
```
Source {file} cannot be processed by Reek
...
Exception message:
#<NoMethodError: undefined method `components' for s(:forward_args):#<Class:0x0000560b0d368210>>
Original exception:
/usr/local/bundle/gems/reek-5.6.0/lib/reek/ast/sexp_extensions/methods.rb:17:in `parameters'
/usr/local/bundle/gems/reek-5.6.0/lib/reek/context/method_context.rb:53:in `default_assignments'
/usr/local/bundle/gems/reek-5.6.0/lib/reek/smell_detectors/boolean_parameter.rb:23:in `sniff'
/usr/local/bundle/gems/reek-5.6.0/lib/reek/smell_detectors/base_detector.rb:44:in `run'
/usr/local/bundle/gems/reek-5.6.0/lib/reek/detector_repository.rb:44:in `block in examine'
...
```
As i found it happens because there is no node mixin for `:forward_args`.

So, here is a fix, but I don't know will it be sufficient. WDYT?