### PR TITLE
Remove FactoryBot and ActiveSupport dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ gemspec
 ruby RUBY_VERSION
 
 group :development do
+  gem 'activesupport',         '~> 6.0'
   gem 'aruba',                 '~> 1.0'
   gem 'codeclimate-engine-rb', '~> 0.4.0'
   gem 'cucumber',              '~> 3.0'
-  gem 'factory_bot',           '~> 5.0', '!= 5.1.0'
   gem 'kramdown',              '~> 2.1'
   gem 'kramdown-parser-gfm',   '~> 1.0'
   gem 'rake',                  '~> 13.0'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 ruby RUBY_VERSION
 
 group :development do
-  gem 'activesupport',         '~> 6.0'
   gem 'aruba',                 '~> 1.0'
   gem 'codeclimate-engine-rb', '~> 0.4.0'
   gem 'cucumber',              '~> 3.0'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,7 +1,6 @@
 require_relative '../../lib/reek'
 require_relative '../../lib/reek/cli/application'
 require 'aruba/cucumber'
-require 'active_support/core_ext/string/strip'
 
 begin
   require 'pry-byebug'

--- a/lib/reek/spec/smell_matcher.rb
+++ b/lib/reek/spec/smell_matcher.rb
@@ -43,8 +43,9 @@ module Reek
         raise ArgumentError, "The attribute '#{extra_keys.first}' is not available for comparison"
       end
 
+      # :reek:FeatureEnvy
       def common_parameters_equal?(other_parameters)
-        smell_warning.parameters.slice(*other_parameters.keys) == other_parameters
+        smell_warning.parameters.values_at(*other_parameters.keys) == other_parameters.values
       end
 
       def common_attributes_equal?(attributes)

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -1,7 +1,0 @@
-require_relative '../../lib/reek/smell_detectors'
-require_relative '../../lib/reek/smell_detectors/base_detector'
-require_relative '../../lib/reek/smell_warning'
-require_relative '../../lib/reek/cli/options'
-
-FactoryBot.define do
-end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -4,26 +4,6 @@ require_relative '../../lib/reek/smell_warning'
 require_relative '../../lib/reek/cli/options'
 
 FactoryBot.define do
-  factory :smell_warning, class: 'Reek::SmellWarning' do
-    skip_create
-
-    smell_type { 'FeatureEnvy' }
-    source { 'dummy_file' }
-    lines { [42] }
-    message { 'smell warning message' }
-    parameters { {} }
-    context { 'self' }
-
-    initialize_with do
-      new(smell_type,
-          source: source,
-          context: context,
-          lines: lines,
-          message: message,
-          parameters: parameters)
-    end
-  end
-
   factory :code_comment, class: 'Reek::CodeComment' do
     comment { '' }
     line { 1 }

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -4,14 +4,4 @@ require_relative '../../lib/reek/smell_warning'
 require_relative '../../lib/reek/cli/options'
 
 FactoryBot.define do
-  factory :code_comment, class: 'Reek::CodeComment' do
-    comment { '' }
-    line { 1 }
-    source { 'string' }
-    initialize_with do
-      new comment: comment,
-          line: line,
-          source: source
-    end
-  end
 end

--- a/spec/reek/code_comment_spec.rb
+++ b/spec/reek/code_comment_spec.rb
@@ -3,7 +3,7 @@ require_lib 'reek/code_comment'
 
 RSpec.describe Reek::CodeComment do
   context 'with an empty comment' do
-    let(:comment) { build(:code_comment, comment: '') }
+    let(:comment) { build_code_comment(comment: '') }
 
     it 'is not descriptive' do
       expect(comment).not_to be_descriptive
@@ -16,22 +16,22 @@ RSpec.describe Reek::CodeComment do
 
   describe '#descriptive' do
     it 'rejects an empty comment' do
-      comment = build(:code_comment, comment: '#')
+      comment = build_code_comment(comment: '#')
       expect(comment).not_to be_descriptive
     end
 
     it 'rejects a 1-word comment' do
-      comment = build(:code_comment, comment: "# alpha\n#  ")
+      comment = build_code_comment(comment: "# alpha\n#  ")
       expect(comment).not_to be_descriptive
     end
 
     it 'accepts a 2-word comment' do
-      comment = build(:code_comment, comment: '# alpha bravo  ')
+      comment = build_code_comment(comment: '# alpha bravo  ')
       expect(comment).to be_descriptive
     end
 
     it 'accepts a multi-word comment' do
-      comment = build(:code_comment, comment: "# alpha bravo \n# charlie \n   # delta ")
+      comment = build_code_comment(comment: "# alpha bravo \n# charlie \n   # delta ")
       expect(comment).to be_descriptive
     end
   end
@@ -39,8 +39,7 @@ RSpec.describe Reek::CodeComment do
   describe 'good comment config' do
     it 'parses hashed options' do
       comment = '# :reek:DuplicateMethodCall { max_calls: 3 }'
-      config = build(:code_comment,
-                     comment: comment).config
+      config = build_code_comment(comment: comment).config
 
       expect(config).to include('DuplicateMethodCall')
       expect(config['DuplicateMethodCall']).to have_key 'max_calls'
@@ -52,7 +51,7 @@ RSpec.describe Reek::CodeComment do
         # :reek:DuplicateMethodCall { max_calls: 3 }
         # :reek:NestedIterators { enabled: true }
       RUBY
-      config = build(:code_comment, comment: comment).config
+      config = build_code_comment(comment: comment).config
 
       expect(config).to include('DuplicateMethodCall', 'NestedIterators')
       expect(config['DuplicateMethodCall']['max_calls']).to eq 3
@@ -63,7 +62,7 @@ RSpec.describe Reek::CodeComment do
       comment = <<-RUBY
         #:reek:DuplicateMethodCall { max_calls: 3 } and :reek:NestedIterators { enabled: true }
       RUBY
-      config = build(:code_comment, comment: comment).config
+      config = build_code_comment(comment: comment).config
 
       expect(config).to include('DuplicateMethodCall', 'NestedIterators')
       expect(config['DuplicateMethodCall']['max_calls']).to eq 3
@@ -73,7 +72,7 @@ RSpec.describe Reek::CodeComment do
 
     it 'parses multiple unhashed options on the same line' do
       comment = '# :reek:DuplicateMethodCall and :reek:NestedIterators'
-      config = build(:code_comment, comment: comment).config
+      config = build_code_comment(comment: comment).config
 
       expect(config).to include('DuplicateMethodCall', 'NestedIterators')
       expect(config['DuplicateMethodCall']).to include('enabled')
@@ -84,7 +83,7 @@ RSpec.describe Reek::CodeComment do
 
     it 'disables the smell if no options are specifed' do
       comment = '# :reek:DuplicateMethodCall'
-      config = build(:code_comment, comment: comment).config
+      config = build_code_comment(comment: comment).config
 
       expect(config).to include('DuplicateMethodCall')
       expect(config['DuplicateMethodCall']).to include('enabled')
@@ -93,14 +92,13 @@ RSpec.describe Reek::CodeComment do
 
     it 'does not disable the smell if options are specifed' do
       comment = '# :reek:DuplicateMethodCall { max_calls: 3 }'
-      config = build(:code_comment, comment: comment).config
+      config = build_code_comment(comment: comment).config
 
       expect(config['DuplicateMethodCall']).not_to include('enabled')
     end
 
     it 'ignores smells after a space' do
-      config = build(:code_comment,
-                     comment: '# :reek: DuplicateMethodCall').config
+      config = build_code_comment(comment: '# :reek: DuplicateMethodCall').config
       expect(config).not_to include('DuplicateMethodCall')
     end
 
@@ -111,7 +109,7 @@ RSpec.describe Reek::CodeComment do
         # :reek:NestedIterators { enabled: true }
         # comment
       RUBY
-      comment = build(:code_comment, comment: original_comment)
+      comment = build_code_comment(comment: original_comment)
 
       expect(comment.send(:sanitized_comment)).to eq('Actual comment')
     end
@@ -122,8 +120,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
   context 'when the comment contains an unknown detector name' do
     it 'raises BadDetectorInCommentError' do
       expect do
-        build(:code_comment,
-              comment: '# :reek:DoesNotExist')
+        build_code_comment(comment: '# :reek:DoesNotExist')
       end.to raise_error(Reek::Errors::BadDetectorInCommentError)
     end
   end
@@ -132,7 +129,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
     it 'raises GarbageDetectorConfigurationInCommentError' do
       expect do
         comment = '# :reek:UncommunicativeMethodName { thats: a: bad: config }'
-        build(:code_comment, comment: comment)
+        build_code_comment(comment: comment)
       end.to raise_error(Reek::Errors::GarbageDetectorConfigurationInCommentError)
     end
   end
@@ -140,7 +137,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
   context 'when the legacy comment format was used' do
     it 'raises LegacyCommentSeparatorError' do
       comment = '# :reek:DuplicateMethodCall:'
-      expect { build(:code_comment, comment: comment) }.
+      expect { build_code_comment(comment: comment) }.
         to raise_error Reek::Errors::LegacyCommentSeparatorError
     end
   end
@@ -151,7 +148,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
         expect do
           # exclude -> exlude and enabled -> nabled
           comment = '# :reek:UncommunicativeMethodName { exlude: alfa, nabled: true }'
-          build(:code_comment, comment: comment)
+          build_code_comment(comment: comment)
         end.to raise_error(Reek::Errors::BadDetectorConfigurationKeyInCommentError)
       end
     end
@@ -160,7 +157,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
       it 'does not raise' do
         expect do
           comment = '# :reek:UncommunicativeMethodName { exclude: alfa, enabled: true }'
-          build(:code_comment, comment: comment)
+          build_code_comment(comment: comment)
         end.not_to raise_error
       end
     end
@@ -170,7 +167,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
         expect do
           # max_copies -> mx_copies and min_clump_size -> mn_clump_size
           comment = '# :reek:DataClump { mx_copies: 4, mn_clump_size: 3 }'
-          build(:code_comment, comment: comment)
+          build_code_comment(comment: comment)
         end.to raise_error(Reek::Errors::BadDetectorConfigurationKeyInCommentError)
       end
     end
@@ -179,7 +176,7 @@ RSpec.describe Reek::CodeComment::CodeCommentValidator do
       it 'does not raise' do
         expect do
           comment = '# :reek:DataClump { max_copies: 4, min_clump_size: 3 }'
-          build(:code_comment, comment: comment)
+          build_code_comment(comment: comment)
         end.not_to raise_error
       end
     end

--- a/spec/reek/report/code_climate/code_climate_configuration_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_configuration_spec.rb
@@ -1,3 +1,4 @@
+require 'active_support/inflector'
 require_relative '../../../spec_helper'
 require_lib 'reek/report/code_climate/code_climate_configuration'
 

--- a/spec/reek/report/code_climate/code_climate_configuration_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_configuration_spec.rb
@@ -1,12 +1,9 @@
-require 'active_support/inflector'
 require_relative '../../../spec_helper'
 require_lib 'reek/report/code_climate/code_climate_configuration'
 
 RSpec.describe Reek::Report::CodeClimateConfiguration do
   yml = described_class.load
-  smell_types = Reek::SmellDetectors::BaseDetector.descendants.map do |descendant|
-    descendant.name.demodulize
-  end
+  smell_types = Reek::SmellDetectors::BaseDetector.descendants.map(&:smell_type)
 
   smell_types.each do |name|
     config = yml.fetch(name)

--- a/spec/reek/report/code_climate/code_climate_fingerprint_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_fingerprint_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
     context 'when fingerprinting a warning with no parameters' do
       let(:expected_fingerprint) { 'e68badd29db51c92363a7c6a2438d722' }
       let(:warning) do
-        build(:smell_warning,
-              smell_type: 'UtilityFunction',
-              context:    'alfa',
-              message:    "doesn't depend on instance state (maybe move it to another class?)",
-              lines:      lines,
-              source:     'a/ruby/source/file.rb')
+        Reek::SmellWarning.new(
+          'UtilityFunction',
+          context:    'alfa',
+          message:    "doesn't depend on instance state (maybe move it to another class?)",
+          lines:      lines,
+          source:     'a/ruby/source/file.rb')
       end
 
       context 'with code at a specific location' do
@@ -35,12 +35,12 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
 
     context 'when the fingerprint should not be computed' do
       let(:warning) do
-        build(:smell_warning,
-              smell_type: 'ManualDispatch',
-              context:    'Alfa#bravo',
-              message:    'manually dispatches method call',
-              lines:      [4],
-              source:     'a/ruby/source/file.rb')
+        Reek::SmellWarning.new(
+          'ManualDispatch',
+          context:    'Alfa#bravo',
+          message:    'manually dispatches method call',
+          lines:      [4],
+          source:     'a/ruby/source/file.rb')
       end
 
       it 'returns nil' do
@@ -50,13 +50,13 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
 
     context 'when the smell warning has only identifying parameters' do
       let(:warning) do
-        build(:smell_warning,
-              smell_type: 'ClassVariable',
-              context:    'Alfa',
-              message:    "declares the class variable '@@#{name}'",
-              lines:      [4],
-              parameters: { name: "@@#{name}" },
-              source:     'a/ruby/source/file.rb')
+        Reek::SmellWarning.new(
+          'ClassVariable',
+          context:    'Alfa',
+          message:    "declares the class variable '@@#{name}'",
+          lines:      [4],
+          parameters: { name: "@@#{name}" },
+          source:     'a/ruby/source/file.rb')
       end
 
       context 'when the name is one thing' do
@@ -80,13 +80,13 @@ RSpec.describe Reek::Report::CodeClimateFingerprint do
 
     context 'when the smell warning has identifying and non-identifying parameters' do
       let(:warning) do
-        build(:smell_warning,
-              smell_type: 'DuplicateMethodCall',
-              context:    "Alfa##{name}",
-              message:    "calls '#{name}' #{count} times",
-              lines:      lines,
-              parameters: { name: "@@#{name}", count: count },
-              source:     'a/ruby/source/file.rb')
+        Reek::SmellWarning.new(
+          'DuplicateMethodCall',
+          context:    "Alfa##{name}",
+          message:    "calls '#{name}' #{count} times",
+          lines:      lines,
+          parameters: { name: "@@#{name}", count: count },
+          source:     'a/ruby/source/file.rb')
       end
 
       context 'when the parameters are provided' do

--- a/spec/reek/report/code_climate/code_climate_formatter_spec.rb
+++ b/spec/reek/report/code_climate/code_climate_formatter_spec.rb
@@ -4,12 +4,12 @@ require_lib 'reek/report/code_climate/code_climate_formatter'
 RSpec.describe Reek::Report::CodeClimateFormatter do
   describe '#render' do
     let(:warning) do
-      build(:smell_warning,
-            smell_type: 'UtilityFunction',
-            context:    'context foo',
-            message:    'message bar',
-            lines:      [1, 2],
-            source:     'a/ruby/source/file.rb')
+      Reek::SmellWarning.new(
+        'UtilityFunction',
+        context:    'context foo',
+          message:    'message bar',
+          lines:      [1, 2],
+          source:     'a/ruby/source/file.rb')
     end
     let(:rendered) { described_class.new(warning).render }
     let(:json) { JSON.parse rendered.chop }

--- a/spec/reek/report/location_formatter_spec.rb
+++ b/spec/reek/report/location_formatter_spec.rb
@@ -2,7 +2,7 @@ require_relative '../../spec_helper'
 require_lib 'reek/report/location_formatter'
 
 RSpec.describe Reek::Report::BlankLocationFormatter do
-  let(:warning) { build(:smell_warning, lines: [11, 9, 250, 100]) }
+  let(:warning) { build_smell_warning(lines: [11, 9, 250, 100]) }
 
   describe '.format' do
     it 'returns a blank String regardless of the warning' do
@@ -12,7 +12,7 @@ RSpec.describe Reek::Report::BlankLocationFormatter do
 end
 
 RSpec.describe Reek::Report::DefaultLocationFormatter do
-  let(:warning) { build(:smell_warning, lines: [11, 9, 250, 100]) }
+  let(:warning) { build_smell_warning(lines: [11, 9, 250, 100]) }
 
   describe '.format' do
     it 'returns a prefix with sorted line numbers' do
@@ -22,7 +22,7 @@ RSpec.describe Reek::Report::DefaultLocationFormatter do
 end
 
 RSpec.describe Reek::Report::SingleLineLocationFormatter do
-  let(:warning) { build(:smell_warning, lines: [11, 9, 250, 100]) }
+  let(:warning) { build_smell_warning(lines: [11, 9, 250, 100]) }
 
   describe '.format' do
     it 'returns the first line where the smell was found' do

--- a/spec/reek/smell_detectors/base_detector_spec.rb
+++ b/spec/reek/smell_detectors/base_detector_spec.rb
@@ -5,13 +5,13 @@ require_lib 'reek/smell_detectors/duplicate_method_call'
 RSpec.describe Reek::SmellDetectors::BaseDetector do
   describe '.todo_configuration_for' do
     it 'returns exclusion configuration for the given smells' do
-      smell = create(:smell_warning, smell_type: 'Foo', context: 'Foo#bar')
+      smell = build_smell_warning(smell_type: 'Foo', context: 'Foo#bar')
       result = described_class.todo_configuration_for([smell])
       expect(result).to eq('BaseDetector' => { 'exclude' => ['Foo#bar'] })
     end
 
     it 'merges identical contexts' do
-      smell = create(:smell_warning, smell_type: 'Foo', context: 'Foo#bar')
+      smell = build_smell_warning(smell_type: 'Foo', context: 'Foo#bar')
       result = described_class.todo_configuration_for([smell, smell])
       expect(result).to eq('BaseDetector' => { 'exclude' => ['Foo#bar'] })
     end
@@ -20,7 +20,7 @@ RSpec.describe Reek::SmellDetectors::BaseDetector do
       let(:subclass) { Reek::SmellDetectors::TooManyStatements }
 
       it 'includes default exclusions' do
-        smell = create(:smell_warning, smell_type: 'TooManyStatements', context: 'Foo#bar')
+        smell = build_smell_warning(smell_type: 'TooManyStatements', context: 'Foo#bar')
         result = subclass.todo_configuration_for([smell])
 
         aggregate_failures do

--- a/spec/reek/smell_warning_spec.rb
+++ b/spec/reek/smell_warning_spec.rb
@@ -24,23 +24,23 @@ RSpec.describe Reek::SmellWarning do
     end
 
     context 'when smells differ only by detector' do
-      let(:first) { build(:smell_warning, smell_type: 'DuplicateMethodCall') }
-      let(:second) { build(:smell_warning, smell_type: 'FeatureEnvy') }
+      let(:first) { build_smell_warning(smell_type: 'DuplicateMethodCall') }
+      let(:second) { build_smell_warning(smell_type: 'FeatureEnvy') }
 
       it_behaves_like 'first sorts ahead of second'
     end
 
     context 'when smells differ only by lines' do
-      let(:first) { build(:smell_warning, smell_type: 'FeatureEnvy', lines: [2]) }
-      let(:second) { build(:smell_warning, smell_type: 'FeatureEnvy', lines: [3]) }
+      let(:first) { build_smell_warning(smell_type: 'FeatureEnvy', lines: [2]) }
+      let(:second) { build_smell_warning(smell_type: 'FeatureEnvy', lines: [3]) }
 
       it_behaves_like 'first sorts ahead of second'
     end
 
     context 'when smells differ only by context' do
-      let(:first) { build(:smell_warning, smell_type: 'DuplicateMethodCall', context: 'first') }
+      let(:first) { build_smell_warning(smell_type: 'DuplicateMethodCall', context: 'first') }
       let(:second) do
-        build(:smell_warning, smell_type: 'DuplicateMethodCall', context: 'second')
+        build_smell_warning(smell_type: 'DuplicateMethodCall', context: 'second')
       end
 
       it_behaves_like 'first sorts ahead of second'
@@ -48,11 +48,11 @@ RSpec.describe Reek::SmellWarning do
 
     context 'when smells differ only by message' do
       let(:first) do
-        build(:smell_warning, smell_type: 'DuplicateMethodCall',
+        build_smell_warning(smell_type: 'DuplicateMethodCall',
                               context: 'ctx', message: 'first message')
       end
       let(:second) do
-        build(:smell_warning, smell_type: 'DuplicateMethodCall',
+        build_smell_warning(smell_type: 'DuplicateMethodCall',
                               context: 'ctx', message: 'second message')
       end
 
@@ -61,10 +61,10 @@ RSpec.describe Reek::SmellWarning do
 
     context 'when smells differ by name and message' do
       let(:first) do
-        build(:smell_warning, smell_type: 'FeatureEnvy', message: 'second message')
+        build_smell_warning(smell_type: 'FeatureEnvy', message: 'second message')
       end
       let(:second) do
-        build(:smell_warning, smell_type: 'UtilityFunction', message: 'first message')
+        build_smell_warning(smell_type: 'UtilityFunction', message: 'first message')
       end
 
       it_behaves_like 'first sorts ahead of second'
@@ -72,13 +72,13 @@ RSpec.describe Reek::SmellWarning do
 
     context 'when smells differ everywhere' do
       let(:first) do
-        build(:smell_warning, smell_type: 'DuplicateMethodCall',
+        build_smell_warning(smell_type: 'DuplicateMethodCall',
                               context: 'Dirty#a',
                               message: 'calls @s.title twice')
       end
 
       let(:second) do
-        build(:smell_warning, smell_type: 'UncommunicativeVariableName',
+        build_smell_warning(smell_type: 'UncommunicativeVariableName',
                               context: 'Dirty',
                               message: "has the variable name '@s'")
       end

--- a/spec/reek/spec/should_reek_of_spec.rb
+++ b/spec/reek/spec/should_reek_of_spec.rb
@@ -1,7 +1,6 @@
 require 'pathname'
 require_relative '../../spec_helper'
 require_lib 'reek/spec'
-require 'active_support/core_ext/hash/except'
 
 RSpec.describe Reek::Spec::ShouldReekOf do
   describe 'smell type selection' do

--- a/spec/reek/spec/should_reek_only_of_spec.rb
+++ b/spec/reek/spec/should_reek_only_of_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Reek::Spec::ShouldReekOnlyOf do
   end
 
   context 'with 1 non-matching smell' do
-    let(:smells) { [build(:smell_warning, smell_type: 'ControlParameter')] }
+    let(:smells) { [build_smell_warning(smell_type: 'ControlParameter')] }
 
     it_behaves_like 'no match'
   end
@@ -48,8 +48,8 @@ RSpec.describe Reek::Spec::ShouldReekOnlyOf do
   context 'with 2 non-matching smells' do
     let(:smells) do
       [
-        build(:smell_warning, smell_type: 'ControlParameter'),
-        build(:smell_warning, smell_type: 'FeatureEnvy')
+        build_smell_warning(smell_type: 'ControlParameter'),
+        build_smell_warning(smell_type: 'FeatureEnvy')
       ]
     end
 
@@ -59,8 +59,8 @@ RSpec.describe Reek::Spec::ShouldReekOnlyOf do
   context 'with 1 non-matching and 1 matching smell' do
     let(:smells) do
       [
-        build(:smell_warning, smell_type: 'ControlParameter'),
-        build(:smell_warning, smell_type: expected_smell_type.to_s,
+        build_smell_warning(smell_type: 'ControlParameter'),
+        build_smell_warning(smell_type: expected_smell_type.to_s,
                               message: "message mentioning #{expected_context_name}")
       ]
     end
@@ -70,7 +70,7 @@ RSpec.describe Reek::Spec::ShouldReekOnlyOf do
 
   context 'with 1 matching smell' do
     let(:smells) do
-      [build(:smell_warning, smell_type: expected_smell_type.to_s,
+      [build_smell_warning(smell_type: expected_smell_type.to_s,
                              message: "message mentioning #{expected_context_name}")]
     end
 

--- a/spec/reek/spec/smell_matcher_spec.rb
+++ b/spec/reek/spec/smell_matcher_spec.rb
@@ -3,7 +3,7 @@ require_lib 'reek/spec/smell_matcher'
 
 RSpec.describe Reek::Spec::SmellMatcher do
   let(:smell_warning) do
-    build(:smell_warning, smell_type: 'UncommunicativeVariableName',
+    build_smell_warning(smell_type: 'UncommunicativeVariableName',
                           message: "has the variable name '@s'",
                           parameters: { test: 'something' })
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,6 +70,20 @@ module Helpers
     @klass_map ||= Reek::AST::ASTNodeClassMap.new
     @klass_map.klass_for(type).new(type, children)
   end
+
+  def build_smell_warning(smell_type: 'FeatureEnvy',
+                          context: 'self',
+                          lines: [42],
+                          message: 'smell warning message',
+                          source: 'dummy_file',
+                          parameters: {})
+    Reek::SmellWarning.new(smell_type,
+                           context: context,
+                           lines: lines,
+                           message: message,
+                           source: source,
+                           parameters: parameters)
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,9 +14,6 @@ begin
 rescue LoadError # rubocop:disable Lint/SuppressedException
 end
 
-require 'factory_bot'
-FactoryBot.find_definitions
-
 # Simple helpers for our specs.
 module Helpers
   def test_configuration_for(config)
@@ -93,7 +90,6 @@ end
 RSpec.configure do |config|
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
-  config.include FactoryBot::Syntax::Methods
   config.include Helpers
   config.include RSpec::Benchmark::Matchers
   config.example_status_persistence_file_path = 'spec/examples.txt'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'pathname'
 require 'timeout'
-require 'active_support/core_ext/string/strip'
 require 'rspec-benchmark'
 require_relative '../lib/reek'
 require_relative '../lib/reek/spec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,6 +84,10 @@ module Helpers
                            source: source,
                            parameters: parameters)
   end
+
+  def build_code_comment(comment: '', line: 1, source: 'string')
+    Reek::CodeComment.new(comment: comment, line: line, source: source)
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This replaces our FactoryBot factories with simple methods. This allows us to drop dependency on FactoryBot, and, finally, after one minor change, on ActiveSupport.

The reason to do this now is that FactoryBot does not work on Ruby 2.8.0-dev, due to the existing warnings becoming errors.

The reason to do this at all rather than wait for FactoryBot to catch up, is that I've long disliked the development dependency on ActiveSupport, which causes methods to be available on core classes that may not be available to Reek at runtime. This can cause Reek to break without our tests catching it. By removing ActiveSupport as a dependency, we take away one source of such problems.