### PR TITLE
Set link metadata in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,7 @@ Lint/BooleanSymbol:
 # Spec blocks can be any size
 Metrics/BlockLength:
   Exclude:
+    - '**/*.gemspec'
     - 'spec/**/*'
 
 # Keyword arguments make long parameter lists readable

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -19,6 +19,14 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4.0'
   s.summary = 'Code smell detector for Ruby'
 
+  s.metadata = {
+    'homepage_uri'      => 'https://github.com/troessner/reek',
+    'source_code_uri'   => 'https://github.com/troessner/reek',
+    'bug_tracker_uri'   => 'https://github.com/troessner/reek/issues',
+    'changelog_uri'     => 'https://github.com/troessner/reek/CHANGELOG.md',
+    'documentation_uri' => 'https://www.rubydoc.info/gems/reek'
+  }
+
   s.add_runtime_dependency 'kwalify', '~> 0.7.0'
   s.add_runtime_dependency 'parser',  '< 2.8', '>= 2.5.0.0', '!= 2.5.1.1'
   s.add_runtime_dependency 'psych',   '~> 3.1.0'


### PR DESCRIPTION
It is no longer possible to set these via the rubygems.org interface. Instead, these should now be set in the gemspec. Wiki and mailing list are omitted since the former is disabled and the latter hasn't seen
activity since 2012.

See https://blog.rubygems.org/2019/03/08/and-then-there-was-one-metadata-links.html for more info on the metadata UI removal.

Fixes #1536.