### PR TITLE
docs("Boolean Parameter" smell): fix typo

### DIFF
--- a/docs/Boolean-Parameter.md
+++ b/docs/Boolean-Parameter.md
@@ -38,7 +38,7 @@ Note that both smells are reported, _Boolean Parameter_ and _Control Parameter_.
 
 ## Getting rid of the smell
 
-This is highly dependant on your exact architecture, but looking at the example above what you could do is:
+This is highly dependent on your exact architecture, but looking at the example above what you could do is:
 
 * Move everything in the `if` branch into a separate method
 * Move everything in the `else` branch into a separate method

--- a/lib/reek/report/code_climate/code_climate_configuration.yml
+++ b/lib/reek/report/code_climate/code_climate_configuration.yml
@@ -59,7 +59,7 @@ BooleanParameter:
 
     ## Getting rid of the smell
 
-    This is highly dependant on your exact architecture, but looking at the example above what you could do is:
+    This is highly dependent on your exact architecture, but looking at the example above what you could do is:
 
     * Move everything in the `if` branch into a separate method
     * Move everything in the `else` branch into a separate method


### PR DESCRIPTION
Reek caught this smell in my code, so I figured I'd pay it back with a
contribution!