### PR TITLE
Loosen dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby RUBY_VERSION
 group :development do
   gem 'aruba',                 '~> 1.0'
   gem 'codeclimate-engine-rb', '~> 0.4.0'
-  gem 'cucumber',              '~> 4.0'
+  gem 'cucumber',              ['>= 4.0', '< 6.0']
   gem 'kramdown',              '~> 2.1'
   gem 'kramdown-parser-gfm',   '~> 1.0'
   gem 'rake',                  '~> 13.0'
@@ -16,7 +16,7 @@ group :development do
   gem 'rubocop',               '~> 0.89.1'
   gem 'rubocop-performance',   '~> 1.7.1'
   gem 'rubocop-rspec',         '~> 1.43.1'
-  gem 'simplecov',             '~> 0.18.1'
+  gem 'simplecov',             ['>= 0.18.0', '< 0.20.0']
   gem 'yard',                  '~> 0.9.5'
 
   platforms :mri do

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'kwalify', '~> 0.7.0'
   s.add_runtime_dependency 'parser',  '< 2.8', '>= 2.5.0.0', '!= 2.5.1.1'
-  s.add_runtime_dependency 'psych',   '~> 3.1.0'
+  s.add_runtime_dependency 'psych',   '~> 3.1'
   s.add_runtime_dependency 'rainbow', '>= 2.0', '< 4.0'
 end


### PR DESCRIPTION
This loosens dependencies on cucumber and simplecov so we use the most recent versions on Ruby 2.5 and up, but can still run the build on Ruby 2.4.

Additionally, the runtime dependency on psych is loosened to allow the latest version but not force users to upgrade.