### PR TITLE
Override TravisCI's default JRUBY_OPTS environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,7 @@ notifications:
 branches:
   only:
     - master
+
+env:
+  global:
+    - JRUBY_OPTS="--dev"


### PR DESCRIPTION
- Silences warnings about deprecated --client flag
- Improves startup time by using development mode