### PR TITLE
Update RuboCop and fix detected problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,8 @@ group :development do
   gem 'rake',                  '~> 13.0'
   gem 'rspec',                 '~> 3.0'
   gem 'rspec-benchmark',       '~> 0.6.0'
-  gem 'rubocop',               '~> 0.89.1'
-  gem 'rubocop-performance',   '~> 1.7.1'
+  gem 'rubocop',               '~> 0.91.0'
+  gem 'rubocop-performance',   '~> 1.8.0'
   gem 'rubocop-rspec',         '~> 1.43.1'
   gem 'simplecov',             ['>= 0.18.0', '< 0.20.0']
   gem 'yard',                  '~> 0.9.5'

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ are documented in the corresponding smell type /docs page (if you want to get a 
 configurations you can also check out [the `defaults.reek.yml` file in this repository](docs/defaults.reek.yml).
 
 Note that you do not need a configuration file at all.
-If you're fine with all the [defaults.reek.yml](docs/defaults.reek.yml) we set you can skip this completely.
+If you're fine with all the [defaults](docs/defaults.reek.yml) we set you can skip this completely.
 
 Don't worry about introducing a mistake in your configuration file that might go unnoticed - Reek uses a
 schema to validate your configuration against on start up and will faily loudly in case you

--- a/features/configuration_files/schema_validation.feature
+++ b/features/configuration_files/schema_validation.feature
@@ -6,7 +6,7 @@ Feature: Validate schema
   Scenario: Our generated default configuration
     Given our default configuration file
     And the clean file "clean.rb"
-    When I run reek -c defaults.reek clean.rb
+    When I run reek -c defaults.reek.yml clean.rb
     Then it succeeds
     And it reports nothing
 

--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -44,7 +44,7 @@ Given(/^a configuration file '(.+)'$/) do |filename|
 end
 
 Given(/^our default configuration file$/) do
-  default_configuration = File.read SAMPLES_DIR.join('..').join('docs').join('defaults.reek.yml')
+  default_configuration = File.read Reek::DEFAULT_SMELL_CONFIGURATION
   write_file('defaults.reek.yml', default_configuration)
 end
 

--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -45,7 +45,7 @@ end
 
 Given(/^our default configuration file$/) do
   default_configuration = File.read SAMPLES_DIR.join('..').join('docs').join('defaults.reek.yml')
-  write_file('defaults.reek', default_configuration)
+  write_file('defaults.reek.yml', default_configuration)
 end
 
 When(/^I run "reek (.*?)" in a subdirectory$/) do |args|

--- a/lib/reek.rb
+++ b/lib/reek.rb
@@ -8,6 +8,7 @@ require_relative 'reek/examiner'
 require_relative 'reek/report'
 
 module Reek
+  DEFAULT_SMELL_CONFIGURATION = File.join(__dir__, '../docs/defaults.reek.yml').freeze
   DEFAULT_CONFIGURATION_FILE_NAME = '.reek.yml'
   DETECTORS_KEY = 'detectors'
   EXCLUDE_PATHS_KEY = 'exclude_paths'

--- a/lib/reek/configuration/directory_directives.rb
+++ b/lib/reek/configuration/directory_directives.rb
@@ -92,7 +92,7 @@ module Reek
 
       def error_message_for_invalid_smell_type(klass)
         "You are trying to configure smell type #{klass} but we can't find one with that name.\n" \
-          "Please make sure you spelled it right. (See 'docs/defaults.reek' in the Reek\n" \
+          "Please make sure you spelled it right. (See 'docs/defaults.reek.yml' in the Reek\n" \
           'repository for a list of all available smell types.)'
       end
     end

--- a/lib/reek/context/module_context.rb
+++ b/lib/reek/context/module_context.rb
@@ -66,6 +66,8 @@ module Reek
         CodeComment.new(comment: exp.leading_comment).descriptive?
       end
 
+      CONSTANT_SEXP_TYPES = [:casgn, :class, :module].freeze
+
       # A namespace module is a module (or class) that is only there for namespacing
       # purposes, and thus contains only nested constants, modules or classes.
       #
@@ -78,7 +80,7 @@ module Reek
         return false if exp.type == :casgn
 
         children = exp.direct_children
-        children.any? && children.all? { |child| [:casgn, :class, :module].include? child.type }
+        children.any? && children.all? { |child| CONSTANT_SEXP_TYPES.include? child.type }
       end
 
       def track_visibility(visibility, names)

--- a/lib/reek/smell_detectors/boolean_parameter.rb
+++ b/lib/reek/smell_detectors/boolean_parameter.rb
@@ -14,6 +14,8 @@ module Reek
     #
     # See {file:docs/Boolean-Parameter.md} for details.
     class BooleanParameter < BaseDetector
+      BOOLEAN_VALUES = [:true, :false].freeze
+
       #
       # Checks whether the given method has any Boolean parameters.
       #
@@ -21,7 +23,7 @@ module Reek
       #
       def sniff
         context.default_assignments.select do |_parameter, value|
-          [:true, :false].include?(value.type)
+          BOOLEAN_VALUES.include?(value.type)
         end.map do |parameter, _value|
           smell_warning(
             lines: [source_line],

--- a/lib/reek/smell_warning.rb
+++ b/lib/reek/smell_warning.rb
@@ -31,8 +31,7 @@ module Reek
     #   public API.
     #
     # @quality :reek:LongParameterList { max_params: 6 }
-    def initialize(smell_type, context: '', lines:, message:,
-                   source:, parameters: {})
+    def initialize(smell_type, lines:, message:, source:, context: '', parameters: {})
       @smell_type = smell_type
       @source     = source
       @context    = context.to_s

--- a/spec/performance/reek/smell_detectors/runtime_speed_spec.rb
+++ b/spec/performance/reek/smell_detectors/runtime_speed_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe 'Runtime speed' do
 
   it 'runs on our smelly sources in less than 5 seconds' do
     expect do
-      source_directory.each_entry do |entry|
-        next if %w(. ..).include?(entry.to_s)
-
-        examiner = Reek::Examiner.new entry.to_path
+      Dir[source_directory.join('**/*.rb')].each do |entry|
+        examiner = Reek::Examiner.new Pathname.new(entry)
         examiner.smells.size
       end
     end.to perform_under(5).sec

--- a/spec/quality/documentation_spec.rb
+++ b/spec/quality/documentation_spec.rb
@@ -4,6 +4,7 @@ require 'kramdown'
 RSpec.describe 'Documentation' do
   root = File.expand_path('../..', __dir__)
   files = Dir.glob(File.join(root, '*.md')) + Dir.glob(File.join(root, 'docs', '*.md'))
+  code_types = [:codeblock, :codespan]
 
   files.each do |file|
     describe "from #{file}" do
@@ -13,7 +14,7 @@ RSpec.describe 'Documentation' do
 
       blocks.each do |block|
         # Only consider code blocks with language 'ruby'.
-        next unless [:codeblock, :codespan].include?(block.type)
+        next unless code_types.include?(block.type)
         next unless block.attr['class'] == 'language-ruby'
 
         it "has a valid sample at #{block.options[:location] + 1}" do

--- a/tasks/configuration.rake
+++ b/tasks/configuration.rake
@@ -5,14 +5,15 @@ require_relative '../lib/reek/configuration/app_configuration'
 
 require 'yaml'
 
+Reek::DEFAULT_SMELL_CONFIGURATION = 'docs/defaults.reek.yml'.freeze
+
 namespace :configuration do
   desc 'Updates the default configuration file when smell defaults change'
   task :update_default_configuration do
-    DEFAULT_SMELL_CONFIGURATION = 'docs/defaults.reek.yml'.freeze
     content = Reek::DetectorRepository.smell_types.each_with_object({}) do |klass, hash|
       hash[klass.smell_type] = Reek::Configuration::RakeTaskConverter.convert klass.default_config
     end
-    File.open(DEFAULT_SMELL_CONFIGURATION, 'w') do |file|
+    File.open(Reek::DEFAULT_SMELL_CONFIGURATION, 'w') do |file|
       YAML.dump({ Reek::DETECTORS_KEY => content }, file)
     end
   end

--- a/tasks/configuration.rake
+++ b/tasks/configuration.rake
@@ -5,8 +5,6 @@ require_relative '../lib/reek/configuration/app_configuration'
 
 require 'yaml'
 
-Reek::DEFAULT_SMELL_CONFIGURATION = 'docs/defaults.reek.yml'.freeze
-
 namespace :configuration do
   desc 'Updates the default configuration file when smell defaults change'
   task :update_default_configuration do


### PR DESCRIPTION
## Update RuboCop dependencies
  - Updates rubocop to 0.91.0
  - Updates rubocop-performance to 1.8.0
## Fix several offenses
## Fix performance specs

  The existing implementation would pass a string to Reek::Examiner, causing the number of reported smells to be zero. It also needlessly iterated over non-source entries. This is fixed by:

  - Passing a Pathname object to Reek::Examiner
  - Using globbing to generate a list of Ruby files to examine

##  Fix references to default configuration file

- Ensure yml extension is used everywhere
- Fix wording in README

## Make default smell configuration file name available everywhere

This moves `DEFAULT_SMELL_CONFIGURATION` into `lib/reek.rb` so we can use it in the cucumber scenario.

