### PR TITLE
Reduce gem package size

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -12,7 +12,10 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.email = ['timo.roessner@googlemail.com']
   s.extra_rdoc_files = ['CHANGELOG.md', 'License.txt']
-  s.files = `git ls-files -z`.split("\0")
+  s.files = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|samples|docs|tasks)/}) }
+  end
+
   s.executables = s.files.grep(%r{^bin/}).map { |path| File.basename(path) }
   s.homepage = 'https://github.com/troessner/reek'
   s.rdoc_options = %w(--main README.md -x assets/|bin/|config/|features/|spec/|tasks/)


### PR DESCRIPTION
Problem
===

Reek's gem package is a bit of large.
It is 278KB on RubyGems.org. I guess it's compressed size. https://rubygems.org/gems/reek
And it is 2.2MB on local. It is unzipped size. We can check the size with `du reek-6.0.1/ --summarize -h`.

Cause
===

Because the gem package includes all files that are managed by git.

Solution
===

Remove some files from the gem package, such as tests, examples, and documentation.
These files are not used via package usually.

It reduces package size from 2.2MB to 940KB, which is calculated by `du` command.

---

This code is based on code created by `bundle gem` command.
`bundle gem` generates the following code.

```ruby
spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
  `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
end
```