### PR TITLE
Do not run RuboCop in the GitHub Action test job

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,8 +26,16 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Run tests
-      run: bundle exec rake
+    - name: Run specs
+      run: bundle exec rake test:spec
+    - name: Run performance tests
+      run: bundle exec rake test:performance
+    - name: Update default configuration
+      run: bundle exec rake configuration:update_default_configuration
+    - name: Run cucumber features
+      run: bundle exec rake test:features
+    - name: Run code quality specs
+      run: bundle exec rake test:quality
 
   rubocop:
 


### PR DESCRIPTION
RuboCop is run in a separate job so don't duplicate this effort.