### PR TITLE
Loosen dependency on simplecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development do
   gem 'rubocop',               '~> 1.5.2'
   gem 'rubocop-performance',   '~> 1.9.1'
   gem 'rubocop-rspec',         '~> 2.0.0'
-  gem 'simplecov',             ['>= 0.18.0', '< 0.20.0']
+  gem 'simplecov',             ['>= 0.18.0', '< 0.21.0']
   gem 'yard',                  '~> 0.9.5'
 
   platforms :mri do


### PR DESCRIPTION
Our simplecov dependency specification seems to be too complex for dependabot to update.