### PR TITLE
Require parser 3.0

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_runtime_dependency 'kwalify', '~> 0.7.0'
-  s.add_runtime_dependency 'parser',  '< 2.8', '>= 2.5.0.0', '!= 2.5.1.1'
+  s.add_runtime_dependency 'parser',  '~> 3.0.0'
   s.add_runtime_dependency 'psych',   '~> 3.1'
   s.add_runtime_dependency 'rainbow', '>= 2.0', '< 4.0'
 end


### PR DESCRIPTION
This updates the dependency on parser to ~> 3.0.0.

Allowing parser 3.0 is necessary to allow concurrent installation with RuboCop 1.8.0.

Versions below 3.0 are disallowed because:

- On Ruby 3.0, users should not install Parser versions below 3.0, since they do not officially support 3.0's syntax.
- Parser 3.0 supports all versions of Ruby that Reek supports.

Fixes #1576 