### PR TITLE
Do not raise Utilityfunction for methods defined in a class_method block

### DIFF
--- a/lib/reek/context/method_context.rb
+++ b/lib/reek/context/method_context.rb
@@ -85,6 +85,17 @@ module Reek
         ''
       end
 
+      def class_method_block?
+        return false unless @parent_exp
+
+        result = @parent_exp.each_node(:send).select do |node|
+          node_args = *node
+          node_args.include?(:class_methods)
+        end
+
+        !result.empty?
+      end
+
       private
 
       attr_reader :parent_exp

--- a/lib/reek/smell_detectors/utility_function.rb
+++ b/lib/reek/smell_detectors/utility_function.rb
@@ -57,8 +57,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def sniff
-        return [] if context.singleton_method? || context.module_function?
-        return [] if context.references_self?
+        return [] if context.singleton_method? || static_method_context?
         return [] if num_helper_methods.zero?
         return [] if ignore_method?
 
@@ -68,6 +67,12 @@ module Reek
       end
 
       private
+
+      def static_method_context?
+        context.module_function? ||
+          context.references_self? ||
+          context.class_method_block?
+      end
 
       def num_helper_methods
         context.local_nodes(:send).to_a.length

--- a/spec/reek/smell_detectors/utility_function_spec.rb
+++ b/spec/reek/smell_detectors/utility_function_spec.rb
@@ -177,6 +177,27 @@ RSpec.describe Reek::SmellDetectors::UtilityFunction do
     end
   end
 
+  context 'when examining class_methods block' do
+    it 'reports on the refined class' do
+      src = <<-RUBY
+        module Alpha
+          extend ActiveSupport::Concern
+
+          class_methods do
+            def bravo(arg1, arg2)
+              return 1 if arg1.something?
+              return 2 if arg2.something_else?
+
+              3
+            end
+          end
+        end
+      RUBY
+
+      expect(src).not_to reek_of(:UtilityFunction, context: 'Alpha#bravo')
+    end
+  end
+
   describe 'method visibility' do
     it 'reports private methods' do
       src = <<-RUBY


### PR DESCRIPTION
Addresses https://github.com/troessner/reek/issues/1538

This PR implements a way to not raise `UtilityFunction` warning for methods defined in `class_methods` block 