### PR TITLE
Widen range of allowed cucumber versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby RUBY_VERSION
 group :development do
   gem 'aruba',                 '~> 1.0'
   gem 'codeclimate-engine-rb', '~> 0.4.0'
-  gem 'cucumber',              ['>= 4.0', '< 6.0']
+  gem 'cucumber',              ['>= 4.0', '< 7.0']
   gem 'kramdown',              '~> 2.1'
   gem 'kramdown-parser-gfm',   '~> 1.0'
   gem 'rake',                  '~> 13.0'


### PR DESCRIPTION
Version 4.0 is still needed for Ruby 2.4.