### PR TITLE
Add build-base to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV code_dir /code
 ENV app_dir /usr/src/app
 ENV user app
 
-RUN apk --update add git
+RUN apk --update add git build-base
 ADD . ${app_dir}
 
 RUN adduser -u 9000 -D ${user}


### PR DESCRIPTION
There was an issue when was trying to build the docker image. This fix adds the developer tools to the image.

`#12 3.786 You have to install development tools first.`

Complete error:

[Docker build error.txt](https://github.com/troessner/reek/files/6384623/Docker.build.error.txt)
