### PR TITLE
Fix bugs when is used by codeclimate

### DIFF
--- a/bin/code_climate_reek
+++ b/bin/code_climate_reek
@@ -14,15 +14,14 @@ class CodeClimateToReek
   # we have to exit with a zero for both failure and success.
   ENGINE_CONFIGURATION = [
     '--failure-exit-code', '0',
-    '--success-exit-code', '0',
-    '.'
+    '--success-exit-code', '0'
   ].freeze
 
   attr_reader :configuration_file_path, :include_paths_key, :include_paths_default
 
   def initialize(configuration_file_path: '/config.json',
                  include_paths_key: 'include_paths',
-                 include_paths_default: [])
+                 include_paths_default: ['.'])
     @configuration_file_path = configuration_file_path
     @include_paths_key       = include_paths_key
     @include_paths_default   = include_paths_default


### PR DESCRIPTION
# Description
This change fix 2 bugs when we analyze the code using `codeclimate`.

1. Ignored paths were analyzed ex: `bd/` `test/` 
2. There are duplicated results

**Results before remove the line**

```
== app/channels/application_cable/channel.rb (2 issues) ==
2: ApplicationCable::Channel has no descriptive comment [reek-test]
2: ApplicationCable::Channel has no descriptive comment [reek-test]

== app/channels/application_cable/connection.rb (2 issues) ==
2: ApplicationCable::Connection has no descriptive comment [reek-test]
2: ApplicationCable::Connection has no descriptive comment [reek-test]

== app/controllers/application_controller.rb (2 issues) ==
1: ApplicationController has no descriptive comment [reek-test]
1: ApplicationController has no descriptive comment [reek-test]

== app/controllers/products_controller.rb (18 issues) ==
1: ProductsController assumes too much for instance variable '@product' [reek-test]
1: ProductsController assumes too much for instance variable '@product' [reek-test]
1: ProductsController has no descriptive comment [reek-test]
1: ProductsController has no descriptive comment [reek-test]
23: ProductsController#create has approx 10 statements [reek-test]
23: ProductsController#create has approx 10 statements [reek-test]
28-31: ProductsController#create calls 'format.html' 2 times [reek-test]
28-31: ProductsController#create calls 'format.html' 2 times [reek-test]
29-32: ProductsController#create calls 'format.json' 2 times [reek-test]
29-32: ProductsController#create calls 'format.json' 2 times [reek-test]
38: ProductsController#update has approx 9 statements [reek-test]
38: ProductsController#update has approx 9 statements [reek-test]
41-44: ProductsController#update calls 'format.html' 2 times [reek-test]
41-44: ProductsController#update calls 'format.html' 2 times [reek-test]
42-45: ProductsController#update calls 'format.json' 2 times [reek-test]
42-45: ProductsController#update calls 'format.json' 2 times [reek-test]
51: ProductsController#destroy has approx 6 statements [reek-test]
51: ProductsController#destroy has approx 6 statements [reek-test]

== app/helpers/application_helper.rb (2 issues) ==
1: ApplicationHelper has no descriptive comment [reek-test]
1: ApplicationHelper has no descriptive comment [reek-test]

== app/helpers/products_helper.rb (2 issues) ==
1: ProductsHelper has no descriptive comment [reek-test]
1: ProductsHelper has no descriptive comment [reek-test]

== app/jobs/application_job.rb (2 issues) ==
1: ApplicationJob has no descriptive comment [reek-test]
1: ApplicationJob has no descriptive comment [reek-test]

== app/mailers/application_mailer.rb (2 issues) ==
1: ApplicationMailer has no descriptive comment [reek-test]
1: ApplicationMailer has no descriptive comment [reek-test]

== app/models/application_record.rb (2 issues) ==
1: ApplicationRecord has no descriptive comment [reek-test]
1: ApplicationRecord has no descriptive comment [reek-test]

== app/models/product.rb (2 issues) ==
1: Product has no descriptive comment [reek-test]
1: Product has no descriptive comment [reek-test]

== config/application.rb (1 issue) ==
10: Depot::Application has no descriptive comment [reek-test]

== db/migrate/20210620192651_create_products.rb (4 issues) ==
1: CreateProducts has no descriptive comment [reek-test]
2: CreateProducts#change has approx 6 statements [reek-test]
3: CreateProducts#change has the variable name 't' [reek-test]
4-9: CreateProducts#change refers to 't' more than self (maybe move it to another class?) [reek-test]

== test/application_system_test_case.rb (1 issue) ==
3: ApplicationSystemTestCase has no descriptive comment [reek-test]

== test/channels/application_cable/connection_test.rb (1 issue) ==
3: ApplicationCable::ConnectionTest has no descriptive comment [reek-test]

== test/controllers/products_controller_test.rb (1 issue) ==
3: ProductsControllerTest has no descriptive comment [reek-test]

== test/models/product_test.rb (1 issue) ==
3: ProductTest has no descriptive comment [reek-test]

== test/system/products_test.rb (1 issue) ==
3: ProductsTest has no descriptive comment [reek-test]

== test/test_helper.rb (1 issue) ==
5: ActiveSupport::TestCase has no descriptive comment [reek-test]
```

**Results after remove the line**

```
== app/channels/application_cable/channel.rb (1 issue) ==
2: ApplicationCable::Channel has no descriptive comment [reek-test]

== app/channels/application_cable/connection.rb (1 issue) ==
2: ApplicationCable::Connection has no descriptive comment [reek-test]

== app/controllers/application_controller.rb (1 issue) ==
1: ApplicationController has no descriptive comment [reek-test]

== app/controllers/products_controller.rb (9 issues) ==
1: ProductsController assumes too much for instance variable '@product' [reek-test]
1: ProductsController has no descriptive comment [reek-test]
23: ProductsController#create has approx 10 statements [reek-test]
28-31: ProductsController#create calls 'format.html' 2 times [reek-test]
29-32: ProductsController#create calls 'format.json' 2 times [reek-test]
38: ProductsController#update has approx 9 statements [reek-test]
41-44: ProductsController#update calls 'format.html' 2 times [reek-test]
42-45: ProductsController#update calls 'format.json' 2 times [reek-test]
51: ProductsController#destroy has approx 6 statements [reek-test]

== app/helpers/application_helper.rb (1 issue) ==
1: ApplicationHelper has no descriptive comment [reek-test]

== app/helpers/products_helper.rb (1 issue) ==
1: ProductsHelper has no descriptive comment [reek-test]

== app/jobs/application_job.rb (1 issue) ==
1: ApplicationJob has no descriptive comment [reek-test]

== app/mailers/application_mailer.rb (1 issue) ==
1: ApplicationMailer has no descriptive comment [reek-test]

== app/models/application_record.rb (1 issue) ==
1: ApplicationRecord has no descriptive comment [reek-test]

== app/models/product.rb (1 issue) ==
1: Product has no descriptive comment [reek-test]
```

# Problem detail

When is doing the map over all included paths takes the `.` as one of the included paths
https://github.com/troessner/reek/blob/master/lib/reek/source/source_locator.rb#L17
