### PR TITLE
Remove explicit psych dependency

### DIFF
--- a/lib/reek/code_comment.rb
+++ b/lib/reek/code_comment.rb
@@ -116,8 +116,13 @@ module Reek
       end
 
       def parsed_options
-        @parsed_options ||= YAML.safe_load(options || CodeComment::DISABLE_DETECTOR_CONFIGURATION,
-                                           permitted_classes: [Regexp])
+        @parsed_options ||=
+          if Psych::VERSION < '3.1.0'
+            YAML.safe_load(options || CodeComment::DISABLE_DETECTOR_CONFIGURATION, [Regexp])
+          else
+            YAML.safe_load(options || CodeComment::DISABLE_DETECTOR_CONFIGURATION,
+                           permitted_classes: [Regexp])
+          end
       rescue Psych::SyntaxError
         raise Errors::GarbageDetectorConfigurationInCommentError.new(detector_name: detector_name,
                                                                      original_comment: original_comment,

--- a/lib/reek/code_comment.rb
+++ b/lib/reek/code_comment.rb
@@ -39,13 +39,13 @@ module Reek
 
       @original_comment.scan(CONFIGURATION_REGEX) do |detector_name, separator, options|
         escalate_legacy_separator separator
-        CodeCommentValidator.new(detector_name:    detector_name,
-                                 original_comment: original_comment,
-                                 line:             line,
-                                 source:           source,
-                                 options:          options).validate
-        @config.merge! detector_name => YAML.safe_load(options || DISABLE_DETECTOR_CONFIGURATION,
-                                                       permitted_classes: [Regexp])
+        validator = CodeCommentValidator.new(detector_name:    detector_name,
+                                             original_comment: original_comment,
+                                             line:             line,
+                                             source:           source,
+                                             options:          options)
+        validator.validate
+        @config.merge! detector_name => validator.parsed_options
       end
     end
 
@@ -115,15 +115,6 @@ module Reek
         escalate_unknown_configuration_key
       end
 
-      private
-
-      attr_reader :detector_name,
-                  :original_comment,
-                  :line,
-                  :source,
-                  :separator,
-                  :options
-
       def parsed_options
         @parsed_options ||= YAML.safe_load(options || CodeComment::DISABLE_DETECTOR_CONFIGURATION,
                                            permitted_classes: [Regexp])
@@ -133,6 +124,15 @@ module Reek
                                                                      source: source,
                                                                      line: line)
       end
+
+      private
+
+      attr_reader :detector_name,
+                  :original_comment,
+                  :line,
+                  :source,
+                  :separator,
+                  :options
 
       def escalate_unknown_configuration_key
         return if given_keys_legit?

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -32,6 +32,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'kwalify', '~> 0.7.0'
   s.add_runtime_dependency 'parser',  '~> 3.0.0'
-  s.add_runtime_dependency 'psych',   '>= 3.1', '< 5.0'
   s.add_runtime_dependency 'rainbow', '>= 2.0', '< 4.0'
 end


### PR DESCRIPTION
The psych gem is included by default in all Ruby versions supported by Reek. Remove it as an explicit dependency, to stop Reek from pulling in Psych 4, which has incompatible changes.

Fixes #1606.
