### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, jruby-9.2]
+        ruby: [2.5, 2.6, 2.7, jruby-9.2]
 
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
     - 'tmp/**/*'
     - 'vendor/**/*'
   NewCops: enable
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 # Tables are nice
 Layout/HashAlignment:

--- a/lib/reek/smell_warning.rb
+++ b/lib/reek/smell_warning.rb
@@ -59,7 +59,7 @@ module Reek
 
     # @public
     def to_hash
-      stringified_params = parameters.map { |key, val| [key.to_s, val] }.to_h
+      stringified_params = parameters.transform_keys(&:to_s)
       base_hash.merge(stringified_params)
     end
 

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^bin/}).map { |path| File.basename(path) }
   s.homepage = 'https://github.com/troessner/reek'
   s.rdoc_options = %w(--main README.md -x assets/|bin/|config/|features/|spec/|tasks/)
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
   s.summary = 'Code smell detector for Ruby'
 
   s.metadata = {

--- a/spec/reek/rake/task_spec.rb
+++ b/spec/reek/rake/task_spec.rb
@@ -9,13 +9,11 @@ RSpec.describe Reek::Rake::Task do
     end
 
     it 'is set to ENV["REEK_SRC"]' do
-      begin
         ENV['REEK_SRC'] = '*.rb'
         task = described_class.new
         expect(task.source_files).to eq FileList['*.rb']
-      ensure
-        ENV['REEK_SRC'] = nil
-      end
+    ensure
+      ENV['REEK_SRC'] = nil
     end
   end
 
@@ -28,15 +26,13 @@ RSpec.describe Reek::Rake::Task do
     end
 
     it 'has no effect when ENV["REEK_SRC"] is set' do
-      begin
         ENV['REEK_SRC'] = '*.rb'
         task = described_class.new do |it|
           it.source_files = 'lib/*.rb'
         end
         expect(task.source_files).to eq FileList['*.rb']
-      ensure
-        ENV['REEK_SRC'] = nil
-      end
+    ensure
+      ENV['REEK_SRC'] = nil
     end
   end
 


### PR DESCRIPTION
- Bump minimum Ruby version in gemspec
- Bump target Ruby version in RuboCop configuration
- Drop Ruby 2.4 from the matrix in the GitHub Action
- Autocorrect new RuboCop offenses
