### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0", "3.1", jruby-9.2, jruby-9.3]
+        ruby: [2.6, 2.7, "3.0", "3.1", jruby-9.3]
 
     steps:
       - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
   Exclude:
     - 'samples/**/*'
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 # Tables are nice
 Layout/HashAlignment:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ demo.rb -- 2 warnings:
 
 ## Supported Ruby versions
 
-Reek is officially supported for CRuby 2.4 to 2.7 and for JRuby 9.2.
+Reek is officially supported for CRuby 2.6 through 3.1 and for JRuby 9.3.
 Other Ruby implementations (like Rubinius) are not officially supported but
 should work as well.
 

--- a/lib/reek/ast/sexp_extensions/case.rb
+++ b/lib/reek/ast/sexp_extensions/case.rb
@@ -10,7 +10,7 @@ module Reek
         end
 
         def body_nodes(type, ignoring = [])
-          children[1..-1].compact.flat_map do |child|
+          children[1..].compact.flat_map do |child|
             child.each_node(type, ignoring | type).to_a
           end
         end

--- a/lib/reek/ast/sexp_extensions/if.rb
+++ b/lib/reek/ast/sexp_extensions/if.rb
@@ -31,7 +31,7 @@ module Reek
 
         # @quality :reek:FeatureEnvy
         def body_nodes(type, ignoring = [])
-          children[1..-1].compact.flat_map do |child|
+          children[1..].compact.flat_map do |child|
             if ignoring.include? child.type
               []
             else

--- a/lib/reek/ast/sexp_extensions/send.rb
+++ b/lib/reek/ast/sexp_extensions/send.rb
@@ -16,7 +16,7 @@ module Reek
         end
 
         def args
-          children[2..-1]
+          children[2..]
         end
 
         def participants

--- a/lib/reek/context_builder.rb
+++ b/lib/reek/context_builder.rb
@@ -422,7 +422,7 @@ module Reek
     # See `process_rescue` for additional reference.
     #
     def process_resbody(exp, _parent)
-      increase_statement_count_by(exp.children[1..-1].compact)
+      increase_statement_count_by(exp.children[1..].compact)
       process(exp)
     end
 

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.executables = spec.files.grep(%r{^bin/}).map { |path| File.basename(path) }
   spec.rdoc_options = %w(--main README.md -x assets/|bin/|config/|features/|spec/|tasks/)
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
   spec.metadata = {
     'homepage_uri'          => 'https://github.com/troessner/reek',


### PR DESCRIPTION
With the release of JRuby 9.3.0.0, we can drop compatibility with Ruby 2.5.

- Require Ruby 2.6 or higher in the gemspec
- Update RuboCop configuration and fix new offenses
- Update set of Rubies in CI
