### PR TITLE
Fix spelling errors for some words

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,7 +48,7 @@ Layout/MultilineOperationIndentation:
 Lint/AmbiguousBlockAssociation:
   Enabled: false
 
-# Some of our source examples include interpolation explicitely.
+# Some of our source examples include interpolation explicitly.
 Lint/InterpolationCheck:
   Exclude:
     - 'spec/**/*'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Once you’re happy with your feature / fix – or want to
 share it as a work-in-progress and request comments – once
 again make sure all of the tests pass. This will also run
 [RuboCop](https://github.com/bbatsov/rubocop) – fix any
-offences RuboCop finds (or discuss them in the pull request):
+offenses RuboCop finds (or discuss them in the pull request):
 
 ```
 bundle exec rake

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ def smelly_method foo
 end
 ```
 
-This is an incredibly powerful feature and further explained under [Smell Suppresion](docs/Smell-Suppression.md).
+This is an incredibly powerful feature and further explained under [Smell Suppression](docs/Smell-Suppression.md).
 
 #### Debugging trouble with the configuration
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -98,7 +98,7 @@ IrresponsibleModule:
 ```
 
 Reek will load this file automatically by default. If you want to load the
-configuration explicitely, you can use one of the methods below.
+configuration explicitly, you can use one of the methods below.
 
 You can now use either
 

--- a/docs/How-To-Write-New-Detectors.md
+++ b/docs/How-To-Write-New-Detectors.md
@@ -4,7 +4,7 @@
 
 Before starting to code you should discuss the overall idea for your new smell detector with
 us in a corresponding github issue.
-We all should have a solid understanding of what this detector actually reports, the edgecases
+We all should have a solid understanding of what this detector actually reports, the edge cases
 it covers and the overall rationale behind it.
 
 ### Structure
@@ -105,7 +105,7 @@ it 'reports the right values' do
                          name:    'bravo')
 end
 
-it 'does count all occurences' do
+it 'does count all occurrences' do
   src = <<-RUBY
     def alfa
       bravo = 3

--- a/docs/RSpec-matchers.md
+++ b/docs/RSpec-matchers.md
@@ -119,7 +119,7 @@ With smell_details:
 
 ### reek_only_of
 
-See the documentaton for `reek_of`.
+See the documentation for `reek_of`.
 
 **Notable differences to `reek_of`:**
 

--- a/docs/Too-Many-Statements.md
+++ b/docs/Too-Many-Statements.md
@@ -30,7 +30,7 @@ def parse(arg, argv, &error)
 end
 ```
 
-(You might argue that the two assigments within the first @if@ should count as statements, and that perhaps the nested assignment should count as +2.)
+(You might argue that the two assignments within the first @if@ should count as statements, and that perhaps the nested assignment should count as +2.)
 
 ## Configuration
 

--- a/docs/Versioning-Policy.md
+++ b/docs/Versioning-Policy.md
@@ -1,6 +1,6 @@
 # Versioning Policy
 
-* CLI interface: Adding options is a non-breaking change, and would warrant an update of the minor version. Removing options is a breaking change and requires a major version update (we did this going to Reek 2). Adding a report format probably also warrents a minor version upgrade.
+* CLI interface: Adding options is a non-breaking change, and would warrant an update of the minor version. Removing options is a breaking change and requires a major version update (we did this going to Reek 2). Adding a report format probably also warrants a minor version upgrade.
 * API: We haven't really defined a 'public' API for using Reek programmatically, and we've only just started testing it. So, this is basically a blank slate at the moment. We will work on this as a part of the Reek 3 release.
 * List of detected smells: Adding a smell warrants a minor release, removing a smell is a breaking change. This makes sense if you consider that the CLI allows running a single smell detector.
 * Consistency of detected smells: This is very hard to guarantee. If we fix a bug in one of the detectors, some fragrant code may become smelly, or vice versa. Right now we don't bother with this.

--- a/features/command_line_interface/show_progress.feature
+++ b/features/command_line_interface/show_progress.feature
@@ -3,7 +3,7 @@ Feature: Show progress
   As a developer
   I want to be able to selectively activate progress reporting
 
-  # Note that --progress is the default on TTYs, but needs to be explicitely
+  # Note that --progress is the default on TTYs, but needs to be explicitly
   # enabled here because output in the cucumber scenarios does not go to a TTY.
   Scenario: shows progress output on mixed files by default
     Given a directory called 'mixed_files' containing some clean and smelly files

--- a/features/todo_list.feature
+++ b/features/todo_list.feature
@@ -37,7 +37,7 @@ Feature: Auto-generate a todo file
     When I run reek smelly.rb
     Then it succeeds
 
-  Scenario: Reacts appropiately when there are no smells
+  Scenario: Reacts appropriately when there are no smells
     Given the clean file "clean.rb"
     When I run reek --todo clean.rb
     Then a file named ".reek.yml" should not exist

--- a/lib/reek/report/code_climate/code_climate_configuration.yml
+++ b/lib/reek/report/code_climate/code_climate_configuration.yml
@@ -63,7 +63,7 @@ BooleanParameter:
 
     * Move everything in the `if` branch into a separate method
     * Move everything in the `else` branch into a separate method
-    * Get rid of the `hit_the_switch` method alltogether
+    * Get rid of the `hit_the_switch` method altogether
     * Make the decision what method to call in the initial caller of `hit_the_switch`
 ClassVariable:
   remediation_points: 350_000
@@ -119,7 +119,7 @@ ControlParameter:
     end
     ```
 
-    Fixing those problems is out of the scope of this document but an easy solution could be to remove the "write" method alltogether and to move the calls to "write_quoted" / "write_unquoted" in the initial caller of "write".
+    Fixing those problems is out of the scope of this document but an easy solution could be to remove the "write" method altogether and to move the calls to "write_quoted" / "write_unquoted" in the initial caller of "write".
 DataClump:
   remediation_points: 250_000
   content: |

--- a/lib/reek/report/code_climate/code_climate_configuration.yml
+++ b/lib/reek/report/code_climate/code_climate_configuration.yml
@@ -768,7 +768,7 @@ TooManyStatements:
     end
     ```
 
-    (You might argue that the two assigments within the first @if@ should count as statements, and that perhaps the nested assignment should count as +2.)
+    (You might argue that the two assignments within the first @if@ should count as statements, and that perhaps the nested assignment should count as +2.)
 UncommunicativeMethodName:
   remediation_points: 150_000
   content: |

--- a/lib/reek/smell_detectors/class_variable.rb
+++ b/lib/reek/smell_detectors/class_variable.rb
@@ -25,8 +25,8 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def sniff
-        class_variables_in_context.map do |variable, occurences|
-          lines = occurences.map(&:line)
+        class_variables_in_context.map do |variable, occurrences|
+          lines = occurrences.map(&:line)
           smell_warning(
             lines: lines,
             message: "declares the class variable '#{variable}'",

--- a/lib/reek/smell_detectors/control_parameter_helpers/candidate.rb
+++ b/lib/reek/smell_detectors/control_parameter_helpers/candidate.rb
@@ -9,20 +9,20 @@ module Reek
       class Candidate
         #
         # @param parameter [Symbol] the parameter name
-        # @param occurences [Array<Reek::AST::Node>] the occurences of the ControlParameter smell
+        # @param occurrences [Array<Reek::AST::Node>] the occurrences of the ControlParameter smell
         #   e.g. [s(:lvar, :bravo), s(:lvar, :bravo)]
         #
-        def initialize(parameter, occurences)
+        def initialize(parameter, occurrences)
           @parameter = parameter
-          @occurences = occurences
+          @occurrences = occurrences
         end
 
         def smells?
-          occurences.any?
+          occurrences.any?
         end
 
         def lines
-          occurences.map(&:line)
+          occurrences.map(&:line)
         end
 
         def name
@@ -31,7 +31,7 @@ module Reek
 
         private
 
-        attr_reader :occurences, :parameter
+        attr_reader :occurrences, :parameter
       end
     end
   end

--- a/lib/reek/smell_detectors/duplicate_method_call.rb
+++ b/lib/reek/smell_detectors/duplicate_method_call.rb
@@ -67,11 +67,11 @@ module Reek
       class FoundCall
         def initialize(call_node)
           @call_node = call_node
-          @occurences = []
+          @occurrences = []
         end
 
         def record(occurence)
-          occurences.push occurence
+          occurrences.push occurence
         end
 
         def call
@@ -79,16 +79,16 @@ module Reek
         end
 
         def occurs
-          occurences.length
+          occurrences.length
         end
 
         def lines
-          occurences.map(&:line)
+          occurrences.map(&:line)
         end
 
         private
 
-        attr_reader :call_node, :occurences
+        attr_reader :call_node, :occurrences
       end
 
       private_constant :FoundCall

--- a/lib/reek/spec.rb
+++ b/lib/reek/spec.rb
@@ -92,7 +92,7 @@ module Reek
     end
 
     #
-    # See the documentaton for "reek_of".
+    # See the documentation for "reek_of".
     #
     # Notable differences to reek_of:
     #   1.) "reek_of" doesn't mind if there are other smells of a different type.

--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Reek::Configuration::ConfigurationFileFinder do
     let(:regular_configuration_dir) { CONFIGURATION_DIR.join('regular_configuration') }
     let(:regular_configuration_file) { regular_configuration_dir.join('.reek.yml') }
 
-    it 'returns any explicitely passed path' do
+    it 'returns any explicitly passed path' do
       path = Pathname.new 'foo/bar'
       found = described_class.find(path: path)
       expect(found).to eq(path)
     end
 
-    it 'prefers an explicitely passed path over a file in current dir' do
+    it 'prefers an explicitly passed path over a file in current dir' do
       path = Pathname.new 'foo/bar'
       found = described_class.find(path: path, current: regular_configuration_dir)
       expect(found).to eq(path)

--- a/spec/reek/smell_detectors/attribute_spec.rb
+++ b/spec/reek/smell_detectors/attribute_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Reek::SmellDetectors::Attribute do
                            message: 'is a writable attribute')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         attr_writer :bravo

--- a/spec/reek/smell_detectors/boolean_parameter_spec.rb
+++ b/spec/reek/smell_detectors/boolean_parameter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Reek::SmellDetectors::BooleanParameter do
                            parameter: 'bravo')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       def alfa(bravo = true, charlie = true)
       end

--- a/spec/reek/smell_detectors/control_parameter_spec.rb
+++ b/spec/reek/smell_detectors/control_parameter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Reek::SmellDetectors::ControlParameter do
                            argument: 'bravo')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       def alfa(bravo, charlie)
         bravo ? true : false
@@ -30,7 +30,7 @@ RSpec.describe Reek::SmellDetectors::ControlParameter do
       and reek_of(:ControlParameter, lines: [3], argument: 'charlie')
   end
 
-  it 'does count multiple occurences of the same parameter' do
+  it 'does count multiple occurrences of the same parameter' do
     src = <<-RUBY
       def alfa(bravo, charlie)
         if bravo

--- a/spec/reek/smell_detectors/data_clump_spec.rb
+++ b/spec/reek/smell_detectors/data_clump_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Reek::SmellDetectors::DataClump do
                            count:      3)
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         def bravo  (echo, foxtrot); end

--- a/spec/reek/smell_detectors/duplicate_method_call_spec.rb
+++ b/spec/reek/smell_detectors/duplicate_method_call_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Reek::SmellDetectors::DuplicateMethodCall do
                            count:   2)
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         def bravo(charlie)

--- a/spec/reek/smell_detectors/feature_envy_spec.rb
+++ b/spec/reek/smell_detectors/feature_envy_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Reek::SmellDetectors::FeatureEnvy do
                            name:    'charlie')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         def bravo(charlie)

--- a/spec/reek/smell_detectors/instance_variable_assumption_spec.rb
+++ b/spec/reek/smell_detectors/instance_variable_assumption_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Reek::SmellDetectors::InstanceVariableAssumption do
                            assumption: '@charlie')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         def bravo

--- a/spec/reek/smell_detectors/irresponsible_module_spec.rb
+++ b/spec/reek/smell_detectors/irresponsible_module_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Reek::SmellDetectors::IrresponsibleModule do
                            source:  'string')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         # Method is necessary because we don't count namespace classes.

--- a/spec/reek/smell_detectors/long_parameter_list_spec.rb
+++ b/spec/reek/smell_detectors/long_parameter_list_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Reek::SmellDetectors::LongParameterList do
                            count:   4)
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         def bravo(charlie, delta, echo, foxtrot)

--- a/spec/reek/smell_detectors/long_yield_list_spec.rb
+++ b/spec/reek/smell_detectors/long_yield_list_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Reek::SmellDetectors::LongYieldList do
                            count:   4)
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         def bravo(charlie, delta, echo, foxtrot)

--- a/spec/reek/smell_detectors/manual_dispatch_spec.rb
+++ b/spec/reek/smell_detectors/manual_dispatch_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Reek::SmellDetectors::ManualDispatch do
                            source:  'string')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         def bravo(charlie)
@@ -60,7 +60,7 @@ RSpec.describe Reek::SmellDetectors::ManualDispatch do
     expect(src).to reek_of(:ManualDispatch)
   end
 
-  it 'reports occurences in a single method as one smell warning' do
+  it 'reports occurrences in a single method as one smell warning' do
     src = <<-RUBY
       class Alfa
         def bravo(charlie, delta)

--- a/spec/reek/smell_detectors/missing_safe_method_spec.rb
+++ b/spec/reek/smell_detectors/missing_safe_method_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Reek::SmellDetectors::MissingSafeMethod do
                            name:    'bravo!')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         def bravo!

--- a/spec/reek/smell_detectors/nested_iterators_spec.rb
+++ b/spec/reek/smell_detectors/nested_iterators_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Reek::SmellDetectors::NestedIterators do
                            depth:   2)
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       def alfa
         bravo.each do |charlie|

--- a/spec/reek/smell_detectors/nil_check_spec.rb
+++ b/spec/reek/smell_detectors/nil_check_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Reek::SmellDetectors::NilCheck do
                            source:  'string')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       def alfa(bravo, charlie)
         bravo.nil?

--- a/spec/reek/smell_detectors/repeated_conditional_spec.rb
+++ b/spec/reek/smell_detectors/repeated_conditional_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Reek::SmellDetectors::RepeatedConditional do
                            count:   3)
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         attr_accessor :bravo

--- a/spec/reek/smell_detectors/too_many_statements_spec.rb
+++ b/spec/reek/smell_detectors/too_many_statements_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Reek::SmellDetectors::TooManyStatements do
                            count:   3).with_config(config)
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         def bravo

--- a/spec/reek/smell_detectors/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smell_detectors/uncommunicative_parameter_name_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Reek::SmellDetectors::UncommunicativeParameterName do
                            name:    'x')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       def alfa(x, y)
         [x, y]

--- a/spec/reek/smell_detectors/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smell_detectors/uncommunicative_variable_name_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Reek::SmellDetectors::UncommunicativeVariableName do
                            name:    'x')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       def alfa
         x = 3

--- a/spec/reek/smell_detectors/unused_parameters_spec.rb
+++ b/spec/reek/smell_detectors/unused_parameters_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Reek::SmellDetectors::UnusedParameters do
                            name:    'bravo')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       def alfa(bravo, charlie)
       end

--- a/spec/reek/smell_detectors/unused_parameters_spec.rb
+++ b/spec/reek/smell_detectors/unused_parameters_spec.rb
@@ -67,12 +67,12 @@ RSpec.describe Reek::SmellDetectors::UnusedParameters do
       expect(src).not_to reek_of(:UnusedParameters)
     end
 
-    it 'reports something when explicitely passing no arguments' do
+    it 'reports something when explicitly passing no arguments' do
       src = 'def alfa(*bravo); super(); end'
       expect(src).to reek_of(:UnusedParameters)
     end
 
-    it 'reports nothing when explicitely passing all arguments' do
+    it 'reports nothing when explicitly passing all arguments' do
       src = 'def alfa(*bravo); super(*bravo); end'
       expect(src).not_to reek_of(:UnusedParameters)
     end

--- a/spec/reek/smell_detectors/unused_private_method_spec.rb
+++ b/spec/reek/smell_detectors/unused_private_method_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Reek::SmellDetectors::UnusedPrivateMethod do
                            name:    'charlie')
   end
 
-  it 'does count all occurences' do
+  it 'does count all occurrences' do
     src = <<-RUBY
       class Alfa
         private


### PR DESCRIPTION
This PR has implemented improved representation.

- Use "offenses" instead of "offences
- Use "Suppression" instead of "Suppresion"
- Use "explicitly" instead of "explicitely"
- Use "edge cases" instead of "edgecases"
- Use "appropriately" instead of "appropiately"
- Use "occurrences" instead of "occurences"
- Use "documentation" instead of "documentaton"
- Use "assignments" instead of "assigments"
- Use "warrants" instead of "warrents"
- Use "altogether" instead of "alltogether"