### PR TITLE
Check all Ruby blocks in documentation specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ UtilityFunction:
 
 For a basic overview, run
 
-```ruby
+```bash
 reek --help
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -143,7 +143,7 @@ string -- 2 warnings:
 Of course, directory specific configuration and excluded paths are supported as
 well:
 
-```
+```ruby
 config_hash = {
   'IrresponsibleModule' => { 'enabled' => false }
   'spec/samples/three_clean_files/' =>

--- a/spec/quality/documentation_spec.rb
+++ b/spec/quality/documentation_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Documentation' do
       blocks.each do |block|
         # Only consider code blocks with language 'ruby'.
         next unless code_types.include?(block.type)
-        next unless block.attr['class'] == 'language-ruby'
+        next unless block.attr['class']&.downcase == 'language-ruby'
 
         it "has a valid sample at #{block.options[:location] + 1}" do
           code = block.value.strip


### PR DESCRIPTION
We were missing most Ruby blocks in this check. This change will show that a lot of the Ruby blocks in the documentation cannot be executed.

We need to decide whether to skip this check altogether (we don't seem to use the `# =>` syntax a lot), or to fix the code documentation so this works.