### PR TITLE
Add support for keyword nil arguments

### DIFF
--- a/lib/reek/ast/sexp_extensions/arguments.rb
+++ b/lib/reek/ast/sexp_extensions/arguments.rb
@@ -115,6 +115,15 @@ module Reek
         end
       end
       # rubocop:enable Naming/ClassAndModuleCamelCase
+
+      # Utility methods for :kwnilarg nodes.
+      module KwnilargNode
+        include ArgNodeBase
+
+        def anonymous_splat?
+          true
+        end
+      end
     end
   end
 end

--- a/spec/reek/smell_detectors/unused_parameters_spec.rb
+++ b/spec/reek/smell_detectors/unused_parameters_spec.rb
@@ -93,6 +93,17 @@ RSpec.describe Reek::SmellDetectors::UnusedParameters do
       src = 'def alfa(*); end'
       expect(src).not_to reek_of(:UnusedParameters)
     end
+
+    it 'reports nothing for unused anonymous splatted keyword parameter' do
+      src = 'def alfa(**); end'
+      expect(src).not_to reek_of(:UnusedParameters)
+    end
+
+    it 'reports nothing for unused nil keyword parameter' do
+      skip 'Not valid syntax for this Ruby version' unless RUBY_VERSION >= '2.7'
+      src = 'def alfa(**nil); end'
+      expect(src).not_to reek_of(:UnusedParameters)
+    end
   end
 
   context 'with splatted parameters' do


### PR DESCRIPTION
This adds support for the :kwnilarg AST node.

Keyword nil arguments indicate only empty lists of keyword arguments will be accepted, so by definition such an argument can never be used.

Fixes #1666.
