### PR TITLE
Allow failing safely when trying to recursively find a configuration …

### DIFF
--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -88,6 +88,8 @@ module Reek
         # @quality :reek:FeatureEnvy
         def find_in_dir(dir)
           dir.children.detect { |item| item.file? && item.basename.to_s == DEFAULT_FILE_NAME }
+        rescue Errno::EACCES
+          nil
         end
       end
     end

--- a/lib/reek/configuration/configuration_file_finder.rb
+++ b/lib/reek/configuration/configuration_file_finder.rb
@@ -87,9 +87,8 @@ module Reek
         #
         # @quality :reek:FeatureEnvy
         def find_in_dir(dir)
-          dir.children.detect { |item| item.file? && item.basename.to_s == DEFAULT_FILE_NAME }
-        rescue Errno::EACCES
-          nil
+          file = dir + DEFAULT_FILE_NAME
+          file if file.file?
         end
       end
     end


### PR DESCRIPTION
…file

instead of triggering 'Permission denied @ dir_initialize - (Errno::EACCES)' by attempting to list an ancestor directory for which we don't have sufficient permissions.

```ruby
# Will never raise 'Errno::EACCES'.
Pathname.pwd.ascend { |d| p d }

# Can raise 'Errno::EACCES' as nothing guarantees that we have enough
# permissions to list every ancestor directory of our working directort.
Pathname.pwd.ascend { |d| p d.children }
```