### PR TITLE
Add missing dependency rexml

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'kwalify', '~> 0.7.0'
   spec.add_runtime_dependency 'parser',  '~> 3.2.0'
   spec.add_runtime_dependency 'rainbow', '>= 2.0', '< 4.0'
+  spec.add_runtime_dependency 'rexml',   '~> 3.1'
 end


### PR DESCRIPTION
rexml has been removed from default gems since Ruby 3.0. https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

To use rexml, it should be added as runtime dependency. https://github.com/troessner/reek/blob/v6.1.4/lib/reek/report/xml_report.rb#L13

Since rexml is depended from rubocop and kramdown that are only development dependencies, all tests are passed on CI.