### PR TITLE
Treat Data.define as a class definition

### DIFF
--- a/lib/reek/ast/sexp_extensions/send.rb
+++ b/lib/reek/ast/sexp_extensions/send.rb
@@ -24,7 +24,10 @@ module Reek
         end
 
         def module_creation_call?
-          object_creation_call? && module_creation_receiver?
+          return true if object_creation_call? && module_creation_receiver?
+          return true if data_definition_call? && data_definition_receiver?
+
+          false
         end
 
         def object_creation_call?
@@ -45,9 +48,19 @@ module Reek
         private
 
         def module_creation_receiver?
-          receiver &&
-            receiver.type == :const &&
-            [:Class, :Struct].include?(receiver.simple_name)
+          const_receiver? && [:Class, :Struct].include?(receiver.simple_name)
+        end
+
+        def data_definition_call?
+          name == :define
+        end
+
+        def data_definition_receiver?
+          const_receiver? && receiver.simple_name == :Data
+        end
+
+        def const_receiver?
+          receiver && receiver.type == :const
         end
       end
 

--- a/lib/reek/ast/sexp_extensions/send.rb
+++ b/lib/reek/ast/sexp_extensions/send.rb
@@ -27,12 +27,6 @@ module Reek
           object_creation_call? && module_creation_receiver?
         end
 
-        def module_creation_receiver?
-          receiver &&
-            receiver.type == :const &&
-            [:Class, :Struct].include?(receiver.simple_name)
-        end
-
         def object_creation_call?
           name == :new
         end
@@ -46,6 +40,14 @@ module Reek
         # attr :foo, true
         def attr_with_writable_flag?
           name == :attr && args.any? && args.last.type == :true
+        end
+
+        private
+
+        def module_creation_receiver?
+          receiver &&
+            receiver.type == :const &&
+            [:Class, :Struct].include?(receiver.simple_name)
         end
       end
 

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -363,10 +363,6 @@ RSpec.describe Reek::AST::SexpExtensions::SendNode do
       expect(bare_new).not_to be_module_creation_call
     end
 
-    it 'is not considered to have a module creation receiver' do
-      expect(bare_new).not_to be_module_creation_receiver
-    end
-
     it 'is considered to be an object creation call' do
       expect(bare_new).to be_object_creation_call
     end
@@ -377,10 +373,6 @@ RSpec.describe Reek::AST::SexpExtensions::SendNode do
 
     it 'is not considered to be a module creation call' do
       expect(node).not_to be_module_creation_call
-    end
-
-    it 'is not considered to have a module creation receiver' do
-      expect(node).not_to be_module_creation_receiver
     end
 
     it 'is considered to be an object creation call' do

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -368,6 +368,66 @@ RSpec.describe Reek::AST::SexpExtensions::SendNode do
     end
   end
 
+  context 'when it’s ‘define’ with no parameters and no receiver' do
+    let(:bare_new) { sexp(:send, nil, :define) }
+
+    it 'is not considered to be a module creation call' do
+      expect(bare_new).not_to be_module_creation_call
+    end
+
+    it 'is considered to be an object creation call' do
+      expect(bare_new).not_to be_object_creation_call
+    end
+  end
+
+  context 'when it’s ‘new’ with receiver ‘Class‘' do
+    let(:bare_new) { sexp(:send, sexp(:const, nil, :Class), :new) }
+
+    it 'is considered to be a module creation call' do
+      expect(bare_new).to be_module_creation_call
+    end
+
+    it 'is considered to be an object creation call' do
+      expect(bare_new).to be_object_creation_call
+    end
+  end
+
+  context 'when it’s ‘new’ with receiver ‘Struct‘' do
+    let(:bare_new) { sexp(:send, sexp(:const, nil, :Struct), :new) }
+
+    it 'is considered to be a module creation call' do
+      expect(bare_new).to be_module_creation_call
+    end
+
+    it 'is considered to be an object creation call' do
+      expect(bare_new).to be_object_creation_call
+    end
+  end
+
+  context 'when it’s ‘new’ with receiver ‘Data‘' do
+    let(:bare_new) { sexp(:send, sexp(:const, nil, :Data), :new) }
+
+    it 'is not considered to be a module creation call' do
+      expect(bare_new).not_to be_module_creation_call
+    end
+
+    it 'is considered to be an object creation call' do
+      expect(bare_new).to be_object_creation_call
+    end
+  end
+
+  context 'when it’s ‘define’ with receiver ‘Data‘' do
+    let(:bare_new) { sexp(:send, sexp(:const, nil, :Data), :define) }
+
+    it 'is considered to be a module creation call' do
+      expect(bare_new).to be_module_creation_call
+    end
+
+    it 'is not considered to be an object creation call' do
+      expect(bare_new).not_to be_object_creation_call
+    end
+  end
+
   context 'when it’s ‘new’ with a complex receiver' do
     let(:node) { Reek::Source::SourceCode.from('(foo ? bar : baz).new').syntax_tree }
 

--- a/spec/reek/smell_detectors/module_initialize_spec.rb
+++ b/spec/reek/smell_detectors/module_initialize_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Reek::SmellDetectors::ModuleInitialize do
     expect(src).not_to reek_of(:ModuleInitialize)
   end
 
-  it 'reports nothing for a method named initialize in a nested struct' do
+  it 'reports nothing for a method named initialize in a nested Struct class' do
     src = <<-RUBY
       module Alfa
         Bravo = Struct.new(:charlie) do
@@ -57,6 +57,18 @@ RSpec.describe Reek::SmellDetectors::ModuleInitialize do
           Class.new do
             def initialize; end
           end
+        end
+      end
+    RUBY
+
+    expect(src).not_to reek_of(:ModuleInitialize)
+  end
+
+  it 'reports nothing for a method named initialize in a nested Data class' do
+    src = <<-RUBY
+      module Alfa
+        Bravo = Data.define(:charlie) do
+          def initialize; end
         end
       end
     RUBY


### PR DESCRIPTION
Fixes #1682

- Make `Reek::AST::SexpExtensions::SendNode.module_creation_receiver?` private
- Recognize that `Data.define` creates a new class
