### PR TITLE
Fix cucumber_opts warning

### DIFF
--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -18,7 +18,7 @@ namespace 'test' do
   end
 
   Cucumber::Rake::Task.new(:features) do |t|
-    t.cucumber_opts = 'features --format progress --color'
+    t.cucumber_opts = ['features --format', 'progress --color']
   end
 
   desc 'Runs all unit tests and acceptance tests'


### PR DESCRIPTION
I was reading the [Developing Reek Contributing](https://github.com/JuanVqz/reek?tab=readme-ov-file#developing-reek--contributing)
to understand how `reek` works, then run the `rake console` and saw the `warning` message.

```ruby
➜  reek git:(master) be rake console
WARNING: consider using an array rather than a space-delimited string with cucumber_opts to avoid undesired behavior.
```

after making it an array the `warning` was gone, let's see if that works for you.