### PR TITLE
Fix Instance Variable Assumption false positive

### DIFF
--- a/lib/reek/smell_detectors/instance_variable_assumption.rb
+++ b/lib/reek/smell_detectors/instance_variable_assumption.rb
@@ -20,7 +20,7 @@ module Reek
       # @return [Array<SmellWarning>]
       #
       def sniff
-        assumptions = (variables_from_context - variables_from_initialize).uniq
+        assumptions = (variables_from_context - variables_from_initializers).uniq
 
         assumptions.map do |assumption|
           build_smell_warning(assumption)
@@ -42,14 +42,14 @@ module Reek
           parameters: { assumption: assumption.to_s })
       end
 
+      def variables_from_initializers
+        variables_from_initialize.map do |method|
+          method.each_node(:ivasgn).map(&:name)
+        end.flatten
+      end
+
       def variables_from_initialize
-        initialize_exp = method_expressions.detect do |method|
-          method.name == :initialize
-        end
-
-        return [] unless initialize_exp
-
-        initialize_exp.each_node(:ivasgn).map(&:name)
+        method_expressions.select { |method| method.name == :initialize }
       end
 
       def variables_from_context

--- a/spec/reek/smell_detectors/instance_variable_assumption_spec.rb
+++ b/spec/reek/smell_detectors/instance_variable_assumption_spec.rb
@@ -93,4 +93,27 @@ RSpec.describe Reek::SmellDetectors::InstanceVariableAssumption do
 
     expect(src).to reek_of(:InstanceVariableAssumption, context: 'Alfa::Charlie')
   end
+
+  it 'does not report when the initialize is in a nested Struct class' do
+    src = <<-RUBY
+      class Foo
+        Bar = Struct.new(:status) do
+          def initialize(status)
+            super
+            p 'bar created'
+          end
+        end
+
+        def initialize
+          @foo = :foo
+        end
+
+        def foo?
+          @foo == :foo
+        end
+      end
+    RUBY
+
+    expect(src).not_to reek_of(:InstanceVariableAssumption)
+  end
 end


### PR DESCRIPTION
Can you please have a look?

I hope this fixes #1492

What this basically does is look up through all the initializers if it matches the `ivasgn` to consider it instance variable assumption.
