### PR TITLE
ISSUE-1734 Add missing configuration warning

### DIFF
--- a/lib/reek/configuration/configuration_converter.rb
+++ b/lib/reek/configuration/configuration_converter.rb
@@ -80,6 +80,8 @@ module Reek
                 to_regex item
               end
             end
+          rescue NoMethodError
+            warn_about_missing_configuration(detector) if detectors[detector].nil?
           end
         end
       end
@@ -101,9 +103,24 @@ module Reek
                   to_regex item
                 end
               end
+            rescue NoMethodError
+              warn_about_missing_configuration(detector) if configuration.nil?
             end
           end
         end
+      end
+
+      def warn_about_missing_configuration(detector)
+        msg = <<~ERROR
+          ###############################
+
+          Please review the configuration file (e.g. .reek.yml in your project directory).
+          It looks like the configuration for #{detector} is missing.
+          You can find the configuration options documentation over here: https://github.com/troessner/reek#configuration-options.
+
+          ###############################
+        ERROR
+        warn msg
       end
     end
   end

--- a/lib/reek/configuration/default_directive.rb
+++ b/lib/reek/configuration/default_directive.rb
@@ -21,8 +21,10 @@ module Reek
       # @return [self]
       def add(detectors_configuration)
         detectors_configuration.each do |name, configuration|
-          detector = key_to_smell_detector(name)
-          self[detector] = (self[detector] || {}).merge configuration
+          if configuration
+            detector = key_to_smell_detector(name)
+            self[detector] = (self[detector] || {}).merge configuration
+          end
         end
         self
       end


### PR DESCRIPTION
This PR adds a more descriptive error message when users add a detector without configuration. Before this change a NoMethodError exception was raised with an unclear error message. Now we catch this exception and provide a more helpful error message.

A better future option might be add [dry-schema](https://dry-rb.org/gems/dry-schema/1.13/). 
The [current yaml schema validator](https://github.com/sunaku/kwalify) is outdated and does not seem to have good documentation.

See: https://github.com/troessner/reek/issues/1734