### PR TITLE
Add max_allowed calls to FeatureEnvy smell detector

### DIFF
--- a/docs/Feature-Envy.md
+++ b/docs/Feature-Envy.md
@@ -61,7 +61,7 @@ Reek cannot reliably detect that each call's receiver is a different arg and wil
 ```
   [4, 5, 6]:FeatureEnvy: Foo#initialize refers to 'arg' more than self (maybe move it to another class?)
 ```
-  
+
 If you're running into this problem you can disable this smell detector for this method either via
 configuration:
 
@@ -91,3 +91,48 @@ _Feature Envy_ is only triggered if there are some references to self and _[Util
 ## Configuration
 
 _Feature Envy_ supports the [Basic Smell Options](Basic-Smell-Options.md).
+
+Option | Value | Effect
+-------|-------|-------
+`max_calls` |  integer | The maximum number of duplicate calls allowed within a method. Defaults to 2.
+
+
+## Example configuration
+
+### Adjusting `max_calls`
+
+Imagine code like this:
+
+```ruby
+class Alfa
+  def bravo(charlie)
+    (charlie.delta - charlie.echo) * foxtrot
+  end
+end
+```
+
+This would report:
+
+>>
+src.rb -- 1 warnings:
+  [3, 3]:FeatureEnvy: Alfa#bravo refers to 'charlie' more than self (maybe move it to another class?)
+
+If you want to allow those double calls here you can disable it in 2 different ways:
+
+1.) Via source code comment:
+
+```ruby
+class Alfa
+  # :reek:FeatureEnvy { max_calls: 3 }
+  def bravo(charlie)
+    (charlie.delta - charlie.echo) * foxtrot
+  end
+end
+```
+
+2.) Via configuration file:
+
+```yaml
+FeatureEnvy:
+  max_calls: 3
+```

--- a/docs/defaults.reek.yml
+++ b/docs/defaults.reek.yml
@@ -25,6 +25,7 @@ detectors:
   FeatureEnvy:
     enabled: true
     exclude: []
+    max_calls: 2
   InstanceVariableAssumption:
     enabled: true
     exclude: []

--- a/lib/reek/configuration/schema.yml
+++ b/lib/reek/configuration/schema.yml
@@ -47,6 +47,8 @@ mapping:
         type: map
         mapping:
           <<: *detector_base
+          max_calls:
+            type: number
       InstanceVariableAssumption:
         type: map
         mapping:
@@ -203,7 +205,7 @@ mapping:
       =:
         type: map
         mapping: *all_detectors
-        
+
   "exclude_paths":
     type: seq
     sequence:

--- a/spec/reek/smell_detectors/feature_envy_spec.rb
+++ b/spec/reek/smell_detectors/feature_envy_spec.rb
@@ -292,4 +292,48 @@ RSpec.describe Reek::SmellDetectors::FeatureEnvy do
 
     expect(src).not_to reek_of(:FeatureEnvy)
   end
+
+  it 'does not reports if supressed with a preceding code comment' do
+    src = <<-RUBY
+      class Alfa
+        # :reek:FeatureEnvy
+        def bravo(charlie)
+          (charlie.delta - charlie.echo) * foxtrot
+        end
+      end
+    RUBY
+
+    expect(src).not_to reek_of(:FeatureEnvy)
+  end
+
+  it 'does not reports when increasing max_calls value with a comment' do
+    src = <<-RUBY
+      class Alfa
+        # :reek:FeatureEnvy { max_calls: 3 }
+        def bravo(charlie)
+          (charlie.delta - charlie.echo) * foxtrot
+        end
+      end
+    RUBY
+
+    expect(src).not_to reek_of(:FeatureEnvy)
+  end
+
+  context 'when allowing up to 3 calls' do
+    let(:config) do
+      { Reek::SmellDetectors::FeatureEnvy::MAX_ALLOWED_CALLS_KEY => 3 }
+    end
+
+    it 'does not report double calls' do
+      src = <<-RUBY
+        class Alfa
+          def bravo(charlie)
+            (charlie.delta - charlie.echo) * foxtrot
+          end
+        end
+      RUBY
+
+      expect(src).not_to reek_of(:FeatureEnvy).with_config(config)
+    end
+  end
 end


### PR DESCRIPTION
This is adding a configuration `max_calls` key for the FeatureEnvy smell detector

Fixes #1535

I know @mvz is assigned to the issue, sorry in advance for having worked on it, just wanted to learn more about Reek.
