### PR TITLE
Add `Tempfile.create` to ignored iterators list

### DIFF
--- a/docs/defaults.reek.yml
+++ b/docs/defaults.reek.yml
@@ -57,6 +57,7 @@ detectors:
     max_allowed_nesting: 1
     ignore_iterators:
     - tap
+    - Tempfile.create
   NilCheck:
     enabled: true
     exclude: []

--- a/lib/reek/smell_detectors/nested_iterators.rb
+++ b/lib/reek/smell_detectors/nested_iterators.rb
@@ -26,7 +26,7 @@ module Reek
       # The name of the config field that sets the names of any
       # methods for which nesting should not be considered
       IGNORE_ITERATORS_KEY = 'ignore_iterators'
-      DEFAULT_IGNORE_ITERATORS = ['tap'].freeze
+      DEFAULT_IGNORE_ITERATORS = ['tap', 'Tempfile.create'].freeze
 
       def self.default_config
         super.merge(
@@ -128,8 +128,9 @@ module Reek
 
       # @quality :reek:FeatureEnvy
       def ignored_iterator?(exp)
-        ignore_iterators.any? { |pattern| /#{pattern}/ =~ exp.call.name } ||
-          exp.without_block_arguments?
+        ignore_iterators.any? do |pattern|
+          /#{pattern}/ =~ exp.call.format_to_ruby
+        end || exp.without_block_arguments?
       end
     end
   end

--- a/spec/reek/smell_detectors/nested_iterators_spec.rb
+++ b/spec/reek/smell_detectors/nested_iterators_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe Reek::SmellDetectors::NestedIterators do
     expect(src).not_to reek_of(:NestedIterators)
   end
 
+  it 'does not report nested iterators for Tempfile#create' do
+    src = <<-RUBY
+      def alfa(bravo)
+        Tempfile.create('bravo', '.') do |charlie|
+          charlie.each { |delta| delta }
+        end
+      end
+    RUBY
+
+    expect(src).not_to reek_of(:NestedIterators)
+  end
+
   it 'does not report method with successive iterators' do
     src = <<-RUBY
       def alfa


### PR DESCRIPTION
Fixes #1490

I've added `Tempfile.create` to the list of ignored iterators and added a spec for it.

I'm submitting the PR to also get some feedback on the implementation. The specs all pass but it fails on the manual method dispatch code smell.

I tried searching for alternative ways to implement this without using `respond_to?` but didn't really find anything satisfactory, and if I don't test for that beforehand, many specs fail on exceptions because the `exp` object lacks the `receiver` method. Feedback on how to fix this would be most welcome!

Otherwise, I hope this is useful!