### PR TITLE
Add --exclude-smell CLI option

### DIFF
--- a/docs/Command-Line-Options.md
+++ b/docs/Command-Line-Options.md
@@ -73,6 +73,23 @@ You can select several smells by repeating the `--smell` option like so:
 reek --smell UtilityFunction --smell UncommunicativeMethodName
 ```
 
+## Telling Reek Which Smells to Exclude
+
+You can tell Reek to exclude specific smells by using the `--exclude-smell`
+option and passing in the smell name.
+
+For example, to exclude checking for [Utility Function](Utility-Function.md), you would use:
+
+```bash
+reek --exclude-smell UtilityFunction
+```
+
+You can select several smells to exclude by repeating the `--exclude-smell` option like so:
+
+```bash
+reek --exclude-smell UtilityFunction --exclude-smell IrresponsibleModule
+```
+
 ## Output options
 
 ### Output smell's line number

--- a/features/command_line_interface/exclude_smells.feature
+++ b/features/command_line_interface/exclude_smells.feature
@@ -1,0 +1,12 @@
+Feature: Exclude smells
+  In order to exclude specific code smells
+  As a developer
+  I want to be able to selectively exclude smell detectors
+
+  Scenario: --exclude-smell selects smells to exclude
+    Given the smelly file 'smelly.rb'
+    When I run reek --no-line-numbers --exclude-smell UncommunicativeMethodName --exclude-smell UncommunicativeVariableName smelly.rb
+    Then the exit status is 0
+    And it reports:
+      """
+      """

--- a/features/command_line_interface/options.feature
+++ b/features/command_line_interface/options.feature
@@ -44,6 +44,9 @@ Feature: Reek can be controlled using command-line options
               --smell SMELL                Only look for a specific smell.
                                            Call it like this: reek --smell MissingSafeMethod source.rb
                                            Check out https://github.com/troessner/reek/blob/v6.1.4/docs/Code-Smells.md for a list of smells
+              --exclude-smell SMELL        Exclude a specific smell.
+                                           Call it like this: reek --exclude-smell MissingSafeMethod source.rb
+                                           Check out https://github.com/troessner/reek/blob/v6.1.4/docs/Code-Smells.md for a list of smells
               --stdin-filename FILE        When passing code in via pipe, assume this filename when checking file or directory rules in the config.
 
       Generate a todo list:

--- a/lib/reek/cli/options.rb
+++ b/lib/reek/cli/options.rb
@@ -15,7 +15,7 @@ module Reek
     # See {file:docs/Command-Line-Options.md} for details.
     #
     # @quality :reek:TooManyInstanceVariables { max_instance_variables: 13 }
-    # @quality :reek:TooManyMethods { max_methods: 18 }
+    # @quality :reek:TooManyMethods { max_methods: 20 }
     # @quality :reek:Attribute { enabled: false }
     #
     class Options
@@ -101,8 +101,8 @@ module Reek
         BANNER
       end
 
-      # @quality :reek:TooManyStatements { max_statements: 7 }
-      def set_configuration_options
+      # @quality :reek:TooManyStatements { max_statements: 10 }
+      def set_configuration_options # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
         parser.separator 'Configuration:'
         parser.on('-c', '--config FILE', 'Read configuration options from FILE') do |file|
           self.config_file = Pathname.new(file)
@@ -110,15 +110,31 @@ module Reek
         parser.on('--smell SMELL',
                   'Only look for a specific smell.',
                   'Call it like this: reek --smell MissingSafeMethod source.rb',
-                  "Check out #{DocumentationLink.build('Code Smells')} " \
+                  "Check out #{code_smell_documentation_link} " \
                   'for a list of smells') do |smell|
           smells_to_detect << smell
+        end
+        parser.on('--exclude-smell SMELL',
+                  'Exclude a specific smell.',
+                  'Call it like this: reek --exclude-smell MissingSafeMethod source.rb',
+                  "Check out #{code_smell_documentation_link} " \
+                  'for a list of smells') do |smell|
+          smells_to_detect.append(*smell_detectors) if smells_to_detect.empty?
+          smells_to_detect.delete(smell)
         end
         parser.on('--stdin-filename FILE',
                   'When passing code in via pipe, assume this filename when ' \
                   'checking file or directory rules in the config.') do |file|
           self.stdin_filename = file
         end
+      end
+
+      def code_smell_documentation_link
+        @code_smell_documentation_link ||= DocumentationLink.build('Code Smells')
+      end
+
+      def smell_detectors
+        @smell_detectors ||= Reek::SmellDetectors.constants.map(&:to_s)
       end
 
       def set_generate_todo_list_options


### PR DESCRIPTION
Add `exclude-smell` CLI option:

Example without the new option:

```shell
$ reek app/controllers/users_controller.rb 
Inspecting 1 file(s):
S

app/controllers/users_controller.rb -- 6 warnings:
  [82, 82]:DuplicateMethodCall: UsersController#session_id calls 'params[:user_id]' 2 times [https://github.com/troessner/reek/blob/v6.1.4/docs/Duplicate-Method-Call.md]
  [72, 72]:DuplicateMethodCall: UsersController#email calls 'email_params[:p]' 2 times [https://github.com/troessner/reek/blob/v6.1.4/docs/Duplicate-Method-Call.md]
  [1]:IrresponsibleModule: UsersController has no descriptive comment [https://github.com/troessner/reek/blob/v6.1.4/docs/Irresponsible-Module.md]
  [82]:NilCheck: UsersController#session_id performs a nil-check [https://github.com/troessner/reek/blob/v6.1.4/docs/Nil-Check.md]
  [99]:NilCheck: UsersController#email_params performs a nil-check [https://github.com/troessner/reek/blob/v6.1.4/docs/Nil-Check.md]
  [1]:TooManyMethods: UsersController has at least 18 methods [https://github.com/troessner/reek/blob/v6.1.4/docs/Too-Many-Methods.md]
```

Example with the new option:

```
$ reek --exclude-smell IrresponsibleModule --exclude-smell DuplicateMethodCall app/controllers/users_controller.rb 
Inspecting 1 file(s):
S

app/controllers/users_controller.rb -- 3 warnings:
  [82]:NilCheck: UsersController#session_id performs a nil-check [https://github.com/troessner/reek/blob/v6.1.4/docs/Nil-Check.md]
  [99]:NilCheck: UsersController#email_params performs a nil-check [https://github.com/troessner/reek/blob/v6.1.4/docs/Nil-Check.md]
  [1]:TooManyMethods: UsersController has at least 18 methods [https://github.com/troessner/reek/blob/v6.1.4/docs/Too-Many-Methods.md]
```
