### PR TITLE
Add support for Ruby 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "jruby-9.4"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "jruby-9.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby RUBY_VERSION
 
 group :development do
   gem 'aruba',                 '~> 2.1'
+  gem 'bigdecimal',            '>= 2.0.0', '< 4.0'
   gem 'codeclimate-engine-rb', '~> 0.4.0'
   gem 'cucumber',              '~> 9.0'
   gem 'kramdown',              '~> 2.1'

--- a/lib/reek/documentation_link.rb
+++ b/lib/reek/documentation_link.rb
@@ -17,12 +17,10 @@ module Reek
       Kernel.format(HELP_LINK_TEMPLATE, version: Version::STRING, item: name_to_param(subject))
     end
 
-    # Convert the given subject name to a form that is acceptable in a URL.
+    # Convert the given subject name to a form that is acceptable in a URL, by
+    # dasherizeing it at the start of capitalized words. Spaces are discared.
     def name_to_param(name)
-      # Splits the subject on the start of capitalized words, optionally
-      # preceded by a space. The space is discarded, the start of the word is
-      # not.
-      name.split(/ *(?=[A-Z][a-z])/).join('-')
+      name.split(/([A-Z][a-z][a-z]*)/).map(&:strip).reject(&:empty?).join('-')
     end
   end
 end

--- a/spec/reek/documentation_link_spec.rb
+++ b/spec/reek/documentation_link_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Reek::DocumentationLink do
         to eq "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Feature-Envy.md"
     end
 
+    it 'returns the correct link for a smell type with another name' do
+      expect(described_class.build('UncommunicativeMethodName')).
+        to eq "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}" \
+              '/docs/Uncommunicative-Method-Name.md'
+    end
+
     it 'returns the correct link for general documentation' do
       expect(described_class.build('Rake Task')).
         to eq "https://github.com/troessner/reek/blob/v#{Reek::Version::STRING}/docs/Rake-Task.md"


### PR DESCRIPTION
- Fix subject URL generation on Ruby 3.3
- Add bigdecimal gem to silence warnings
- Build on Ruby 3.3 in CI