### PR TITLE
fix broken example link in docs

### DIFF
--- a/docs/Instance-Variable-Assumption.md
+++ b/docs/Instance-Variable-Assumption.md
@@ -98,7 +98,7 @@ class Child < Parent
 end
 ```
 
-Directly accessing instance variables is considered a smell because it [breaks encapsulation](http://designisrefactoring.com/2015/03/29/organizing-data-self-encapsulation/) and makes it harder to reason about code.
+Directly accessing instance variables is considered a smell because it [breaks encapsulation](https://www.designisrefactoring.com/2015/03/30/organizing-data-self-encapsulation/) and makes it harder to reason about code.
 
 If you don't want to expose those methods as public API just make them private like this:
 


### PR DESCRIPTION
Was browsing the documentation and clicked on a link for an example which was linked to 
`http://designisrefactoring.com/2015/03/29/organizing-data-self-encapsulation/` 
which lead to a 404, but upon browsing the site, saw that that the article was still there, but with a different URL.
`https://www.designisrefactoring.com/2015/03/30/organizing-data-self-encapsulation/`