### PR TITLE
Fix Reek installation issue when Yard is installed

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|samples|docs|tasks)/}) }
   end
+  spec.files << Dir['docs/yard_plugin.rb']
 
   spec.executables = spec.files.grep(%r{^bin/}).map { |path| File.basename(path) }
   spec.rdoc_options = %w(--main README.md -x assets/|bin/|config/|features/|spec/|tasks/)


### PR DESCRIPTION
As per #1627, Yard can't process Reek because `docs/yarn_plugin.rb` is missing. It's not included in the Gem, so this PR adds it to correct this error.

This was reported upstream in
https://github.com/lsegal/yard/issues/1462, but it seems that it either wasn't, or people were happy enough with the workaround (touching the missing file in the Gem's installed location). The workaround doesn't work when using `asdf`/`mise` with [default
Gems](https://mise.jdx.dev/lang/ruby.html#default-gems). If Yard's automatic documentation is enabled (`yard config --gem-install-yri`) then the Ruby build fails.