### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_runtime_dependency 'dry-schema', '~> 1.13.0'
-  spec.add_runtime_dependency 'parser',  '~> 3.3.0'
-  spec.add_runtime_dependency 'rainbow', '>= 2.0', '< 4.0'
-  spec.add_runtime_dependency 'rexml',   '~> 3.1'
+  spec.add_dependency 'dry-schema', '~> 1.13.0'
+  spec.add_dependency 'parser',  '~> 3.3.0'
+  spec.add_dependency 'rainbow', '>= 2.0', '< 4.0'
+  spec.add_dependency 'rexml',   '~> 3.1'
 end


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
