### PR TITLE
Add explicity dependency on logger

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'dry-schema', '~> 1.13.0'
+  spec.add_dependency 'logger',  '~> 1.6'
   spec.add_dependency 'parser',  '~> 3.3.0'
   spec.add_dependency 'rainbow', '>= 2.0', '< 4.0'
   spec.add_dependency 'rexml',   '~> 3.1'


### PR DESCRIPTION
This will be needed with Ruby 3.5 and silences a warning in the mean time. Ideally, this would be part of the dependencies of dry-schema via dry-core. Once dry-core depends on logger, the direct dependency can be removed.
