### PR TITLE
Update RuboCop dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem 'rake',                  '~> 13.0'
   gem 'rspec',                 '~> 3.0'
   gem 'rspec-benchmark',       '~> 0.6.0'
-  gem 'rubocop',               '~> 1.65.0'
+  gem 'rubocop',               '~> 1.66.1'
   gem 'rubocop-performance',   '~> 1.21.0'
   gem 'rubocop-rspec',         '~> 3.0.2'
   gem 'simplecov',             '~> 0.22.0'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development do
   gem 'rspec',                 '~> 3.0'
   gem 'rspec-benchmark',       '~> 0.6.0'
   gem 'rubocop',               '~> 1.66.1'
-  gem 'rubocop-performance',   '~> 1.21.0'
+  gem 'rubocop-performance',   '~> 1.22.1'
   gem 'rubocop-rspec',         '~> 3.0.2'
   gem 'simplecov',             '~> 0.22.0'
   gem 'yard',                  '~> 0.9.5'


### PR DESCRIPTION
Doing this semi-manually since dependebot is erroring out.

- Update rubocop to version 1.66.1
- Update rubocop-performance to version 1.22.1
