### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "jruby-9.4", "3.3"]
+        ruby: ["3.1", "3.2", "jruby-9.4", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,13 +84,6 @@ RSpec/ExampleLength:
 Style/AndOr:
   EnforcedStyle: conditionals
 
-# Require comment for files in lib and bin
-Style/FrozenStringLiteralComment:
-  Include:
-    - 'bin/*'
-    - 'lib/**/*'
-  EnforcedStyle: always
-
 # Allow multiline block chains
 Style/MultilineBlockChain:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
   Exclude:
     - 'samples/**/*'
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Tables are nice
 Layout/HashAlignment:

--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 SimpleCov.start do
   track_files 'lib/**/*.rb'
   add_filter 'lib/reek/version.rb' # version.rb is loaded too early to test

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/clean'
 

--- a/docs/templates/default/docstring/setup.rb
+++ b/docs/templates/default/docstring/setup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def init
   super
   return unless show_api_marker_section?

--- a/docs/yard_plugin.rb
+++ b/docs/yard_plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yard'
 
 # Template helper to modify processing of links in HTML generated from our

--- a/features/step_definitions/reek_steps.rb
+++ b/features/step_definitions/reek_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 When /^I run reek (.*)$/ do |args|
   reek(args)
 end

--- a/features/step_definitions/sample_file_steps.rb
+++ b/features/step_definitions/sample_file_steps.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../samples/paths'
 
 Given(/^the smelly file '(.+)'$/) do |filename|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../lib/reek'
 require_relative '../../lib/reek/cli/application'
 require 'aruba/cucumber'

--- a/lib/reek/context/code_context.rb
+++ b/lib/reek/context/code_context.rb
@@ -38,9 +38,9 @@ module Reek
       # @param type [Symbol] the type of the nodes we are looking for, e.g. :defs.
       # @yield block that is executed for every node.
       #
-      def local_nodes(type, ignored = [], &blk)
+      def local_nodes(type, ignored = [], &)
         ignored |= [:class, :module]
-        exp.each_node(type, ignored, &blk)
+        exp.each_node(type, ignored, &)
       end
 
       # Iterate over `self` and child contexts.

--- a/lib/reek/source/source_code.rb
+++ b/lib/reek/source/source_code.rb
@@ -75,11 +75,17 @@ module Reek
 
       def code
         @code ||=
-          case source
-          when File, Pathname then source.read
-          when IO             then source.readlines.join
-          when String         then source
-          end.force_encoding(Encoding::UTF_8)
+          begin
+            str =
+              case source
+              when File, Pathname then source.read
+              when IO             then source.readlines.join
+              when String         then source
+              end
+
+            str = str.dup if str.frozen?
+            str.force_encoding(Encoding::UTF_8)
+          end
       end
 
       attr_reader :parser, :source

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'lib/reek/version'
 
 Gem::Specification.new do |spec|

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.executables = spec.files.grep(%r{^bin/}).map { |path| File.basename(path) }
   spec.rdoc_options = %w(--main README.md -x assets/|bin/|config/|features/|spec/|tasks/)
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.metadata = {
     'homepage_uri'          => 'https://github.com/troessner/reek',

--- a/spec/performance/reek/smell_detectors/runtime_speed_spec.rb
+++ b/spec/performance/reek/smell_detectors/runtime_speed_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require_lib 'reek/examiner'
 

--- a/spec/quality/documentation_spec.rb
+++ b/spec/quality/documentation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require 'kramdown'
 

--- a/spec/quality/reek_source_spec.rb
+++ b/spec/quality/reek_source_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 RSpec.describe 'Reek source code' do

--- a/spec/reek/ast/node_spec.rb
+++ b/spec/reek/ast/node_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/ast/node'
 

--- a/spec/reek/ast/object_refs_spec.rb
+++ b/spec/reek/ast/object_refs_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/ast/object_refs'
 

--- a/spec/reek/ast/reference_collector_spec.rb
+++ b/spec/reek/ast/reference_collector_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/ast/reference_collector'
 

--- a/spec/reek/ast/sexp_extensions_spec.rb
+++ b/spec/reek/ast/sexp_extensions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/ast/sexp_extensions'
 

--- a/spec/reek/cli/application_spec.rb
+++ b/spec/reek/cli/application_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/cli/application'
 

--- a/spec/reek/cli/command/report_command_spec.rb
+++ b/spec/reek/cli/command/report_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require_lib 'reek/cli/command/report_command'
 require_lib 'reek/cli/options'

--- a/spec/reek/cli/command/todo_list_command_spec.rb
+++ b/spec/reek/cli/command/todo_list_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../../spec_helper'
 require_lib 'reek/cli/command/todo_list_command'
 require_lib 'reek/cli/options'

--- a/spec/reek/cli/options_spec.rb
+++ b/spec/reek/cli/options_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/cli/options'
 

--- a/spec/reek/cli/silencer_spec.rb
+++ b/spec/reek/cli/silencer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/cli/silencer'
 

--- a/spec/reek/code_climate/code_climate_configuration_spec.rb
+++ b/spec/reek/code_climate/code_climate_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/code_climate/code_climate_configuration'
 

--- a/spec/reek/code_climate/code_climate_fingerprint_spec.rb
+++ b/spec/reek/code_climate/code_climate_fingerprint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/code_climate/code_climate_fingerprint'
 

--- a/spec/reek/code_climate/code_climate_formatter_spec.rb
+++ b/spec/reek/code_climate/code_climate_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/code_climate/code_climate_formatter'
 

--- a/spec/reek/code_climate/code_climate_report_spec.rb
+++ b/spec/reek/code_climate/code_climate_report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/examiner'
 require_lib 'reek/code_climate'

--- a/spec/reek/code_comment_spec.rb
+++ b/spec/reek/code_comment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require_lib 'reek/code_comment'
 

--- a/spec/reek/configuration/app_configuration_spec.rb
+++ b/spec/reek/configuration/app_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require_relative '../../spec_helper'
 require_lib 'reek/configuration/app_configuration'

--- a/spec/reek/configuration/configuration_file_finder_spec.rb
+++ b/spec/reek/configuration/configuration_file_finder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'pathname'
 require 'tmpdir'

--- a/spec/reek/configuration/default_directive_spec.rb
+++ b/spec/reek/configuration/default_directive_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/configuration/default_directive'
 

--- a/spec/reek/configuration/directory_directives_spec.rb
+++ b/spec/reek/configuration/directory_directives_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/errors/config_file_error'
 require_lib 'reek/configuration/directory_directives'

--- a/spec/reek/configuration/excluded_paths_spec.rb
+++ b/spec/reek/configuration/excluded_paths_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/errors/config_file_error'
 require_lib 'reek/configuration/excluded_paths'

--- a/spec/reek/configuration/rake_task_converter_spec.rb
+++ b/spec/reek/configuration/rake_task_converter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/configuration/rake_task_converter'
 

--- a/spec/reek/configuration/schema_spec.rb
+++ b/spec/reek/configuration/schema_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/configuration/schema'
 

--- a/spec/reek/configuration/schema_validator_spec.rb
+++ b/spec/reek/configuration/schema_validator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/configuration/schema_validator'
 require_lib 'reek/errors/config_file_error'

--- a/spec/reek/context/code_context_spec.rb
+++ b/spec/reek/context/code_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/context/method_context'
 require_lib 'reek/context/module_context'

--- a/spec/reek/context/ghost_context_spec.rb
+++ b/spec/reek/context/ghost_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/context/code_context'
 require_lib 'reek/context/ghost_context'

--- a/spec/reek/context/method_context_spec.rb
+++ b/spec/reek/context/method_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/context/method_context'
 

--- a/spec/reek/context/module_context_spec.rb
+++ b/spec/reek/context/module_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/context/module_context'
 require_lib 'reek/context/root_context'

--- a/spec/reek/context/root_context_spec.rb
+++ b/spec/reek/context/root_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/context/root_context'
 

--- a/spec/reek/context/statement_counter_spec.rb
+++ b/spec/reek/context/statement_counter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/context/statement_counter'
 

--- a/spec/reek/context_builder_spec.rb
+++ b/spec/reek/context_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require_lib 'reek/context_builder'
 

--- a/spec/reek/detector_repository_spec.rb
+++ b/spec/reek/detector_repository_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require_lib 'reek/smell_detectors/base_detector'
 require_lib 'reek/detector_repository'

--- a/spec/reek/documentation_link_spec.rb
+++ b/spec/reek/documentation_link_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 
 RSpec.describe Reek::DocumentationLink do

--- a/spec/reek/errors/base_error_spec.rb
+++ b/spec/reek/errors/base_error_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 require_lib 'reek/errors/base_error'

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require_lib 'reek/examiner'
 require_lib 'reek/logging_error_handler'

--- a/spec/reek/logging_error_handler_spec.rb
+++ b/spec/reek/logging_error_handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require_lib 'reek/logging_error_handler'
 

--- a/spec/reek/rake/task_spec.rb
+++ b/spec/reek/rake/task_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/rake/task'
 

--- a/spec/reek/report/github_report_spec.rb
+++ b/spec/reek/report/github_report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/examiner'
 require_lib 'reek/report/json_report'

--- a/spec/reek/report/html_report_spec.rb
+++ b/spec/reek/report/html_report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/examiner'
 require_lib 'reek/report/html_report'

--- a/spec/reek/report/json_report_spec.rb
+++ b/spec/reek/report/json_report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/examiner'
 require_lib 'reek/report/json_report'

--- a/spec/reek/report/location_formatter_spec.rb
+++ b/spec/reek/report/location_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/report/location_formatter'
 

--- a/spec/reek/report/progress_formatter_spec.rb
+++ b/spec/reek/report/progress_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/report/progress_formatter'
 

--- a/spec/reek/report/text_report_spec.rb
+++ b/spec/reek/report/text_report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/examiner'
 require_lib 'reek/report/text_report'

--- a/spec/reek/report/xml_report_spec.rb
+++ b/spec/reek/report/xml_report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/examiner'
 require_lib 'reek/report/xml_report'

--- a/spec/reek/report/yaml_report_spec.rb
+++ b/spec/reek/report/yaml_report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/examiner'
 require_lib 'reek/report/yaml_report'

--- a/spec/reek/report_spec.rb
+++ b/spec/reek/report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require_lib 'reek/report'
 

--- a/spec/reek/smell_configuration_spec.rb
+++ b/spec/reek/smell_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require_lib 'reek/smell_configuration'
 

--- a/spec/reek/smell_detectors/attribute_spec.rb
+++ b/spec/reek/smell_detectors/attribute_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/attribute'
 

--- a/spec/reek/smell_detectors/base_detector_spec.rb
+++ b/spec/reek/smell_detectors/base_detector_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/base_detector'
 require_lib 'reek/smell_detectors/duplicate_method_call'

--- a/spec/reek/smell_detectors/boolean_parameter_spec.rb
+++ b/spec/reek/smell_detectors/boolean_parameter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/boolean_parameter'
 

--- a/spec/reek/smell_detectors/class_variable_spec.rb
+++ b/spec/reek/smell_detectors/class_variable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/class_variable'
 

--- a/spec/reek/smell_detectors/control_parameter_spec.rb
+++ b/spec/reek/smell_detectors/control_parameter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/control_parameter'
 

--- a/spec/reek/smell_detectors/data_clump_spec.rb
+++ b/spec/reek/smell_detectors/data_clump_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/data_clump'
 

--- a/spec/reek/smell_detectors/duplicate_method_call_spec.rb
+++ b/spec/reek/smell_detectors/duplicate_method_call_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/duplicate_method_call'
 

--- a/spec/reek/smell_detectors/feature_envy_spec.rb
+++ b/spec/reek/smell_detectors/feature_envy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/feature_envy'
 

--- a/spec/reek/smell_detectors/instance_variable_assumption_spec.rb
+++ b/spec/reek/smell_detectors/instance_variable_assumption_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 
 require_lib 'reek/smell_detectors/instance_variable_assumption'

--- a/spec/reek/smell_detectors/irresponsible_module_spec.rb
+++ b/spec/reek/smell_detectors/irresponsible_module_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/irresponsible_module'
 

--- a/spec/reek/smell_detectors/long_parameter_list_spec.rb
+++ b/spec/reek/smell_detectors/long_parameter_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/long_parameter_list'
 

--- a/spec/reek/smell_detectors/long_yield_list_spec.rb
+++ b/spec/reek/smell_detectors/long_yield_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/long_yield_list'
 

--- a/spec/reek/smell_detectors/manual_dispatch_spec.rb
+++ b/spec/reek/smell_detectors/manual_dispatch_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/too_many_constants'
 

--- a/spec/reek/smell_detectors/missing_safe_method_spec.rb
+++ b/spec/reek/smell_detectors/missing_safe_method_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/missing_safe_method'
 

--- a/spec/reek/smell_detectors/module_initialize_spec.rb
+++ b/spec/reek/smell_detectors/module_initialize_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/module_initialize'
 

--- a/spec/reek/smell_detectors/nested_iterators_spec.rb
+++ b/spec/reek/smell_detectors/nested_iterators_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/nested_iterators'
 

--- a/spec/reek/smell_detectors/nil_check_spec.rb
+++ b/spec/reek/smell_detectors/nil_check_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/nil_check'
 

--- a/spec/reek/smell_detectors/repeated_conditional_spec.rb
+++ b/spec/reek/smell_detectors/repeated_conditional_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/repeated_conditional'
 

--- a/spec/reek/smell_detectors/subclassed_from_core_class_spec.rb
+++ b/spec/reek/smell_detectors/subclassed_from_core_class_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/subclassed_from_core_class'
 

--- a/spec/reek/smell_detectors/too_many_constants_spec.rb
+++ b/spec/reek/smell_detectors/too_many_constants_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/too_many_constants'
 

--- a/spec/reek/smell_detectors/too_many_instance_variables_spec.rb
+++ b/spec/reek/smell_detectors/too_many_instance_variables_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/too_many_instance_variables'
 

--- a/spec/reek/smell_detectors/too_many_methods_spec.rb
+++ b/spec/reek/smell_detectors/too_many_methods_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/too_many_methods'
 

--- a/spec/reek/smell_detectors/too_many_statements_spec.rb
+++ b/spec/reek/smell_detectors/too_many_statements_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/too_many_statements'
 

--- a/spec/reek/smell_detectors/uncommunicative_method_name_spec.rb
+++ b/spec/reek/smell_detectors/uncommunicative_method_name_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/uncommunicative_method_name'
 

--- a/spec/reek/smell_detectors/uncommunicative_module_name_spec.rb
+++ b/spec/reek/smell_detectors/uncommunicative_module_name_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/uncommunicative_module_name'
 

--- a/spec/reek/smell_detectors/uncommunicative_parameter_name_spec.rb
+++ b/spec/reek/smell_detectors/uncommunicative_parameter_name_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/uncommunicative_parameter_name'
 

--- a/spec/reek/smell_detectors/uncommunicative_variable_name_spec.rb
+++ b/spec/reek/smell_detectors/uncommunicative_variable_name_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/uncommunicative_variable_name'
 

--- a/spec/reek/smell_detectors/unused_parameters_spec.rb
+++ b/spec/reek/smell_detectors/unused_parameters_spec.rb
@@ -100,7 +100,6 @@ RSpec.describe Reek::SmellDetectors::UnusedParameters do
     end
 
     it 'reports nothing for unused nil keyword parameter' do
-      skip 'Not valid syntax for this Ruby version' unless RUBY_VERSION >= '2.7'
       src = 'def alfa(**nil); end'
       expect(src).not_to reek_of(:UnusedParameters)
     end

--- a/spec/reek/smell_detectors/unused_parameters_spec.rb
+++ b/spec/reek/smell_detectors/unused_parameters_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/unused_parameters'
 

--- a/spec/reek/smell_detectors/unused_private_method_spec.rb
+++ b/spec/reek/smell_detectors/unused_private_method_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/unused_private_method'
 

--- a/spec/reek/smell_detectors/utility_function_spec.rb
+++ b/spec/reek/smell_detectors/utility_function_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/smell_detectors/utility_function'
 

--- a/spec/reek/smell_warning_spec.rb
+++ b/spec/reek/smell_warning_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 require_lib 'reek/smell_warning'
 

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -63,16 +63,12 @@ RSpec.describe Reek::Source::SourceCode do
       end
     end
 
-    if RUBY_VERSION >= '2.7'
-      context 'with ruby 2.7 syntax' do
-        context 'with forward_args (`...`)' do
-          let(:source_code) { described_class.new(source: 'def alpha(...) bravo(...); end') }
+    context 'with forward_args (`...`)' do
+      let(:source_code) { described_class.new(source: 'def alpha(...) bravo(...); end') }
 
-          it 'returns a :forward_args node' do
-            result = source_code.syntax_tree
-            expect(result.children[1].type).to eq(:forward_args)
-          end
-        end
+      it 'returns a :forward_args node' do
+        result = source_code.syntax_tree
+        expect(result.children[1].type).to eq(:forward_args)
       end
     end
   end

--- a/spec/reek/source/source_code_spec.rb
+++ b/spec/reek/source/source_code_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require 'stringio'
 require_lib 'reek/source/source_code'

--- a/spec/reek/source/source_locator_spec.rb
+++ b/spec/reek/source/source_locator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require_relative '../../spec_helper'
 require_lib 'reek/configuration/app_configuration'

--- a/spec/reek/spec/should_reek_of_spec.rb
+++ b/spec/reek/spec/should_reek_of_spec.rb
@@ -102,14 +102,26 @@ RSpec.describe Reek::Spec::ShouldReekOf do
 
       it 'sets the proper error message' do
         matcher.matches?(smelly_code)
-        expected = <<~TEXT
-          Expected string to reek of DuplicateMethodCall (which it did) with smell details {:name=>"foo", :count=>15}, which it didn't.
-          The number of smell details I had to compare with the given one was 2 and here they are:
-          1.)
-          {"context"=>"double_thing", "lines"=>[1, 1], "message"=>"calls '@other.thing' 2 times", "source"=>"string", "name"=>"@other.thing", "count"=>2}
-          2.)
-          {"context"=>"double_thing", "lines"=>[1, 1], "message"=>"calls '@other.thing.foo' 2 times", "source"=>"string", "name"=>"@other.thing.foo", "count"=>2}
-        TEXT
+        expected =
+          if RUBY_VERSION >= '3.4'
+            <<~TEXT
+              Expected string to reek of DuplicateMethodCall (which it did) with smell details {name: "foo", count: 15}, which it didn't.
+              The number of smell details I had to compare with the given one was 2 and here they are:
+              1.)
+              {"context" => "double_thing", "lines" => [1, 1], "message" => "calls '@other.thing' 2 times", "source" => "string", "name" => "@other.thing", "count" => 2}
+              2.)
+              {"context" => "double_thing", "lines" => [1, 1], "message" => "calls '@other.thing.foo' 2 times", "source" => "string", "name" => "@other.thing.foo", "count" => 2}
+            TEXT
+          else
+            <<~TEXT
+              Expected string to reek of DuplicateMethodCall (which it did) with smell details {:name=>"foo", :count=>15}, which it didn't.
+              The number of smell details I had to compare with the given one was 2 and here they are:
+              1.)
+              {"context"=>"double_thing", "lines"=>[1, 1], "message"=>"calls '@other.thing' 2 times", "source"=>"string", "name"=>"@other.thing", "count"=>2}
+              2.)
+              {"context"=>"double_thing", "lines"=>[1, 1], "message"=>"calls '@other.thing.foo' 2 times", "source"=>"string", "name"=>"@other.thing.foo", "count"=>2}
+            TEXT
+          end
 
         expect(matcher.failure_message).to eq(expected)
       end
@@ -117,9 +129,14 @@ RSpec.describe Reek::Spec::ShouldReekOf do
       it 'sets the proper error message when negated' do
         matcher.matches?(smelly_code)
 
-        expect(matcher.failure_message_when_negated).to \
-          match('Expected string not to reek of DuplicateMethodCall with smell ' \
-                'details {:name=>"foo", :count=>15}, but it did')
+        expected = if RUBY_VERSION >= '3.4'
+                     'Expected string not to reek of DuplicateMethodCall with smell ' \
+                       'details {name: "foo", count: 15}, but it did'
+                   else
+                     'Expected string not to reek of DuplicateMethodCall with smell ' \
+                       'details {:name=>"foo", :count=>15}, but it did'
+                   end
+        expect(matcher.failure_message_when_negated).to eq expected
       end
     end
   end

--- a/spec/reek/spec/should_reek_of_spec.rb
+++ b/spec/reek/spec/should_reek_of_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require_relative '../../spec_helper'
 require_lib 'reek/spec'

--- a/spec/reek/spec/should_reek_only_of_spec.rb
+++ b/spec/reek/spec/should_reek_only_of_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/spec'
 

--- a/spec/reek/spec/should_reek_spec.rb
+++ b/spec/reek/spec/should_reek_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/spec'
 

--- a/spec/reek/spec/smell_matcher_spec.rb
+++ b/spec/reek/spec/smell_matcher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../spec_helper'
 require_lib 'reek/spec/smell_matcher'
 

--- a/spec/reek/tree_dresser_spec.rb
+++ b/spec/reek/tree_dresser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../spec_helper'
 Reek::CLI::Silencer.without_warnings { require 'parser/ruby25' }
 require_lib 'reek/tree_dresser'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'timeout'
 require 'rspec-benchmark'

--- a/tasks/configuration.rake
+++ b/tasks/configuration.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../lib/reek'
 require_relative '../lib/reek/detector_repository'
 require_relative '../lib/reek/configuration/rake_task_converter'

--- a/tasks/console.rake
+++ b/tasks/console.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc 'Starts the interactive console'
 task :console do
   require 'irb'

--- a/tasks/reek.rake
+++ b/tasks/reek.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../lib/reek/rake/task'
 
 Reek::Rake::Task.new do |t|

--- a/tasks/rubocop.rake
+++ b/tasks/rubocop.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   require 'rubocop/rake_task'
 

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cucumber/rake/task'
 require 'rspec/core/rake_task'
 


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
