### PR TITLE
Le santos/fix dataclump analysis for clumps in non consecutive methods

### DIFF
--- a/lib/reek/smell_detectors/data_clump.rb
+++ b/lib/reek/smell_detectors/data_clump.rb
@@ -84,7 +84,7 @@ module Reek
       end
 
       def candidate_clumps
-        candidate_methods.each_cons(max_copies + 1).map do |methods|
+        candidate_methods.combination(max_copies + 1).map do |methods|
           common_argument_names_for(methods)
         end.select do |clump|
           clump.length >= min_clump_size

--- a/spec/reek/smell_detectors/data_clump_spec.rb
+++ b/spec/reek/smell_detectors/data_clump_spec.rb
@@ -38,6 +38,25 @@ RSpec.describe Reek::SmellDetectors::DataClump do
       and reek_of(:DataClump, lines: [6, 7, 8], parameters: ['juliett', 'kilo'])
   end
 
+  it 'detects clumps mixed among other methods' do
+    src = <<-RUBY
+      class Alfa
+        def bravo  (echo, foxtrot); end
+        def charlie(echo, foxtrot); end
+        def dummy(param); end
+        def delta  (echo, foxtrot); end
+      end
+    RUBY
+
+    expect(src).to reek_of(:DataClump,
+                           lines:      [2, 3, 5],
+                           context:    'Alfa',
+                           message:    "takes parameters ['echo', 'foxtrot'] to 3 methods",
+                           source:     'string',
+                           parameters: ['echo', 'foxtrot'],
+                           count:      3)
+  end
+
   %w(class module).each do |scope|
     it "does not report parameter sets < 2 for #{scope}" do
       src = <<-RUBY


### PR DESCRIPTION
This PR fixes issue #1798.

**What changes?**

1. `DataClump` detector now creates all combinations between methods to analyse for possible clumps, instead of grouping only the consecutive methods.

```rb
def a(x,y); end
def b(x,y); end
def c(z)  ; end
def d(x,y); end

# Before
# candidate_methods.each_cons(3)
# => [[a, b, c], [b, c, d]]

# Now
# candidate_methods.combination(3)
# => [[a, b, c], [a, b, d], [a, c, d], [b, c, d]]

```

2. After this fix, the codebase quality tests pointed a new DataClump smell in `Reek::AST::Node` class. For that reason, it was necessary to adjust some params in protected methods of this class.

<img width=700 src="https://github.com/user-attachments/assets/1084799e-9cfa-4433-89ef-8862a81e92cb">

