### PR TITLE
Loosen dependency on dry-schema

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_dependency 'dry-schema', '~> 1.13.0'
+  spec.add_dependency 'dry-schema', '~> 1.13'
   spec.add_dependency 'logger',  '~> 1.6'
   spec.add_dependency 'parser',  '~> 3.3.0'
   spec.add_dependency 'rainbow', '>= 2.0', '< 4.0'


### PR DESCRIPTION
Dry-rb follows SemVer, so there is no need to lock the version to 1.13.x. This change will allow version 1.14.0 to be used on Ruby 3.1 and up.
