### PR TITLE
Remove obsolete ruby version specification from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-ruby RUBY_VERSION
-
 group :development do
   gem 'aruba',                 '~> 2.1'
   gem 'codeclimate-engine-rb', '~> 0.4.0'


### PR DESCRIPTION
This line was needed to help Bundler pick the correct activesupport version, but Reek no longer has that dependency.
