### PR TITLE
Update rubocop dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-rspec
   - rubocop-performance
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,9 @@ group :development do
   gem 'rake',                  '~> 13.0'
   gem 'rspec',                 '~> 3.0'
   gem 'rspec-benchmark',       '~> 0.6.0'
-  gem 'rubocop',               '~> 1.69.0'
-  gem 'rubocop-performance',   '~> 1.23.0'
-  gem 'rubocop-rspec',         '~> 3.4.0'
+  gem 'rubocop',               '~> 1.72.2'
+  gem 'rubocop-performance',   '~> 1.24.0'
+  gem 'rubocop-rspec',         '~> 3.5.0'
   gem 'simplecov',             '~> 0.22.0'
   gem 'yard',                  '~> 0.9.5'
 


### PR DESCRIPTION
- Update rubocop to version 1.72.2
- Update rubocop-performance to version 1.24.0
- Update rubocop-rspec to version 3.5.0
- Use new RuboCop configuration for plugins
