### PR TITLE
Use documented form of platform syntax in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,4 @@ gem 'simplecov',             '~> 0.22.0'
 gem 'yard',                  '~> 0.9.5'
 
 # Needed for YARD to properly parse GFM code blocks in the documentation
-gem 'redcarpet', '~> 3.4', platform: :mri
+gem 'redcarpet', '~> 3.4', platforms: [:mri]


### PR DESCRIPTION
The plural form is documented, so maybe switching will finally make dependabot work. Also, it's neater to follow the docs.

See https://bundler.io/man/gemfile.5.html#PLATFORMS.
