### PR TITLE
Require Rainbow 3.x

### DIFF
--- a/reek.gemspec
+++ b/reek.gemspec
@@ -37,6 +37,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-schema', '~> 1.13'
   spec.add_dependency 'logger',  '~> 1.6'
   spec.add_dependency 'parser',  '~> 3.3.0'
-  spec.add_dependency 'rainbow', '>= 2.0', '< 4.0'
+  spec.add_dependency 'rainbow', '~> 3.0'
   spec.add_dependency 'rexml',   '~> 3.1'
 end


### PR DESCRIPTION
Version 3.0 of the rainbow gem came out in 2017. There is no need to support using Reek with version 2.x.
