### PR TITLE
Update rubocop-rspec and fix new offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'rspec',                 '~> 3.0'
 gem 'rspec-benchmark',       '~> 0.6.0'
 gem 'rubocop',               '~> 1.87.0'
 gem 'rubocop-performance',   '~> 1.26.0'
-gem 'rubocop-rspec',         '~> 3.9.0'
+gem 'rubocop-rspec',         '~> 3.10.2'
 gem 'simplecov',             '~> 0.22.0'
 gem 'yard',                  '~> 0.9.5'
 

--- a/spec/reek/examiner_spec.rb
+++ b/spec/reek/examiner_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Reek::Examiner do
 
       it 'shows the original exception class' do
         expect { examiner.smells }.
-          to raise_error { expect(_1.long_message).to match(/ArgumentError/) }
+          to raise_error { expect(_1.long_message).to include('ArgumentError') }
       end
     end
   end
@@ -222,7 +222,7 @@ RSpec.describe Reek::Examiner do
 
     it 'shows the original exception class' do
       expect { examiner.smells }.
-        to raise_error { expect(_1.long_message).to match(/Parser::SyntaxError/) }
+        to raise_error { expect(_1.long_message).to include('Parser::SyntaxError') }
     end
   end
 
@@ -250,7 +250,7 @@ RSpec.describe Reek::Examiner do
 
     it 'shows the original exception class' do
       expect { examiner.smells }.
-        to raise_error { expect(_1.long_message).to match(/InvalidByteSequenceError/) }
+        to raise_error { expect(_1.long_message).to include('InvalidByteSequenceError') }
     end
   end
 

--- a/spec/reek/report/text_report_spec.rb
+++ b/spec/reek/report/text_report_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Reek::Report::TextReport do
       end
 
       it 'mentions every smell name' do
-        matcher = match(/UncommunicativeParameterName/).and match(/UtilityFunction/)
+        matcher = include('UncommunicativeParameterName').and include('UtilityFunction')
         expect { instance.show }.to output(matcher).to_stdout
       end
 


### PR DESCRIPTION
- **Update rubocop-rspec dependency to version 3.10.2**
- **Autocorrect RSpec/MatchWithSimpleRegex offenses**
