### PR TITLE
Upgrade to simplecov 1.x

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,19 +1,14 @@
 # frozen_string_literal: true
 
-SimpleCov.start do
-  track_files 'lib/**/*.rb'
-  add_filter 'lib/reek/version.rb' # version.rb is loaded too early to test
-  add_filter 'lib/reek/cli/options.rb' # tested mostly via integration tests
-  add_filter 'spec/'
-  add_filter 'samples/'
+SimpleCov.configure do
+  cover 'lib/**/*.rb'
+  skip 'lib/reek/version.rb' # version.rb is loaded too early to test
+  skip 'lib/reek/cli/options.rb' # tested mostly via integration tests
   coverage_dir 'tmp/coverage'
   enable_coverage :branch
-end
 
-SimpleCov.at_exit do
-  SimpleCov.result.format!
   unless RUBY_ENGINE == 'jruby'
-    SimpleCov.minimum_coverage 98.88
-    SimpleCov.minimum_coverage_by_file 81.4
+    minimum_coverage 98.88
+    coverage(:line) { minimum_per_file 81.4 }
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'rspec-benchmark',       '~> 0.6.0'
 gem 'rubocop',               '~> 1.89.0'
 gem 'rubocop-performance',   '~> 1.26.0'
 gem 'rubocop-rspec',         '~> 3.10.2'
-gem 'simplecov',             '~> 0.22.0'
+gem 'simplecov',             '~> 1.0'
 gem 'yard',                  '~> 0.9.5'
 
 # Needed for YARD to properly parse GFM code blocks in the documentation

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+SimpleCov.start if defined? SimpleCov
+
 require 'pathname'
 require 'timeout'
 require 'rspec-benchmark'


### PR DESCRIPTION
In addition to bumping the dependency, this updates the simplecov setup to use simplecov's new configuration methods in a SimpleCov.configure block, and puts SimpleCov.start in the spec helper, which is the recommended and supported location.

It also places all configuration together in the configure block, dropping the custom SimpleCov.at_exit.
