### PR TITLE
Support Ruby 3.2 and up

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "jruby-9.4", "3.3", "3.4", "4.0"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
 
     steps:
       - uses: actions/checkout@v7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
   Exclude:
     - 'samples/**/*'
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 # Tables are nice
 Layout/HashAlignment:

--- a/lib/reek/context_builder.rb
+++ b/lib/reek/context_builder.rb
@@ -494,8 +494,8 @@ module Reek
     # @param args arguments for the class initializer
     # @yield block
     #
-    def inside_new_context(klass, *args)
-      new_context = append_new_context(klass, *args)
+    def inside_new_context(klass, *)
+      new_context = append_new_context(klass, *)
 
       orig, self.current_context = current_context, new_context
       yield

--- a/lib/reek/smell_detectors/base_detector.rb
+++ b/lib/reek/smell_detectors/base_detector.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
 require_relative '../smell_warning'
 require_relative '../smell_configuration'
 

--- a/lib/reek/smell_detectors/class_variable.rb
+++ b/lib/reek/smell_detectors/class_variable.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'set'
 require_relative 'base_detector'
 
 module Reek

--- a/reek.gemspec
+++ b/reek.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.executables = spec.files.grep(%r{^bin/}).map { |path| File.basename(path) }
   spec.rdoc_options = %w(--main README.md -x assets/|bin/|config/|features/|spec/|tasks/)
-  spec.required_ruby_version = '>= 3.1.0'
+  spec.required_ruby_version = '>= 3.2.0'
 
   spec.metadata = {
     'homepage_uri'          => 'https://github.com/troessner/reek',


### PR DESCRIPTION
- Require Ruby 3.2 or higher in the gemspec
- Bump RuboCop target ruby version and autocorrect new offenses
- Drop Ruby 3.1 and JRuby 9.4 from the CI configuration
