### PR TITLE
Update and loosen rubocop dependencies and autocorrect new offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,9 +10,9 @@ gem 'cucumber',              ['>= 10.0', '< 12.0']
 gem 'rake',                  '~> 13.0'
 gem 'rspec',                 '~> 3.0'
 gem 'rspec-benchmark',       '~> 0.6.0'
-gem 'rubocop',               '~> 1.89.0'
-gem 'rubocop-performance',   '~> 1.26.0'
-gem 'rubocop-rspec',         '~> 3.10.2'
+gem 'rubocop',               '~> 1.90'
+gem 'rubocop-performance',   '~> 1.27'
+gem 'rubocop-rspec',         '~> 3.10'
 gem 'simplecov',             '~> 1.0'
 gem 'yard',                  '~> 0.9.5'
 

--- a/lib/reek/ast/sexp_extensions/arguments.rb
+++ b/lib/reek/ast/sexp_extensions/arguments.rb
@@ -95,7 +95,7 @@ module Reek
       end
 
       # Utility methods for :forward_args nodes.
-      # rubocop:disable Naming/ClassAndModuleCamelCase
+      # rubocop:disable-next Naming/ClassAndModuleCamelCase
       module Forward_ArgsNode
         include ArgNodeBase
 
@@ -103,10 +103,9 @@ module Reek
           true
         end
       end
-      # rubocop:enable Naming/ClassAndModuleCamelCase
 
       # Utility methods for :forward_arg nodes.
-      # rubocop:disable Naming/ClassAndModuleCamelCase
+      # rubocop:disable-next Naming/ClassAndModuleCamelCase
       module Forward_ArgNode
         include ArgNodeBase
 
@@ -114,7 +113,6 @@ module Reek
           true
         end
       end
-      # rubocop:enable Naming/ClassAndModuleCamelCase
 
       # Utility methods for :kwnilarg nodes.
       module KwnilargNode

--- a/lib/reek/configuration/schema.rb
+++ b/lib/reek/configuration/schema.rb
@@ -12,7 +12,7 @@ module Reek
       # your keys and types
       Dry::Schema.load_extensions(:info)
 
-      # rubocop:disable Metrics/BlockLength
+      # rubocop:disable-next Metrics/BlockLength
       ALL_DETECTORS_SCHEMA = Dry::Schema.Params do
         optional(:Attribute).filled(:hash) do
           optional(:enabled).filled(:bool)
@@ -158,7 +158,6 @@ module Reek
           optional(:public_methods_only).filled(:bool)
         end
       end
-      # rubocop:enable Metrics/BlockLength
 
       # @quality :reek:TooManyStatements { max_statements: 7 }
       def self.schema(directories = [])

--- a/spec/reek/cli/silencer_spec.rb
+++ b/spec/reek/cli/silencer_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../spec_helper'
 require_lib 'reek/cli/silencer'
 
 RSpec.describe Reek::CLI::Silencer do
-  # rubocop:disable RSpec/Output
+  # rubocop:disable-next RSpec/Output
   describe '.silently' do
     it 'blocks output from the block on $stdout' do
       expect { described_class.silently { puts 'Hi!' } }.not_to output.to_stdout
@@ -28,5 +28,4 @@ RSpec.describe Reek::CLI::Silencer do
       end.to output("there!\n").to_stderr
     end
   end
-  # rubocop:enable RSpec/Output
 end


### PR DESCRIPTION
Loosening the dependencies will reduce the churn in the Gemfile, at the potential cost of more build failures in unrelated pull requests. Since the frequency of functional pull requests is currently lower than the rate of change of rubocop gems, this looks like a reasonable trade-off.
