### PR TITLE
Fix DuplicateMethodCall false positives

### DIFF
--- a/features/samples.feature
+++ b/features/samples.feature
@@ -63,7 +63,7 @@ Feature: Basic smell detection
       UncommunicativeVariableName: Inline::C#module_name has the variable name 'x'
       UncommunicativeVariableName: Inline::C#parse_signature has the variable name 'x'
       UtilityFunction: Inline::C#strip_comments doesn't depend on instance state (maybe move it to another class?)
-    optparse.rb -- 126 warnings:
+    optparse.rb -- 122 warnings:
       Attribute: OptionParser#banner is a writable attribute
       Attribute: OptionParser#default_argv is a writable attribute
       Attribute: OptionParser#program_name is a writable attribute
@@ -78,7 +78,6 @@ Feature: Basic smell detection
       ControlParameter: OptionParser#summarize is controlled by argument 'blk'
       ControlParameter: OptionParser::Arguable#options= is controlled by argument 'opt'
       ControlParameter: OptionParser::ParseError#set_option is controlled by argument 'eq'
-      DuplicateMethodCall: OptionParser#getopts calls 'result[opt] = false' 2 times
       DuplicateMethodCall: OptionParser#make_switch calls 'default_style.guess(arg = a)' 4 times
       DuplicateMethodCall: OptionParser#make_switch calls 'long << (o = q.downcase)' 2 times
       DuplicateMethodCall: OptionParser#make_switch calls 'notwice(NilClass, klass, 'type')' 2 times
@@ -95,9 +94,7 @@ Feature: Basic smell detection
       DuplicateMethodCall: OptionParser#parse_in_order calls '$!.set_option(arg, true)' 2 times
       DuplicateMethodCall: OptionParser#parse_in_order calls 'cb.call(val)' 2 times
       DuplicateMethodCall: OptionParser#parse_in_order calls 'raise $!.set_option(arg, true)' 2 times
-      DuplicateMethodCall: OptionParser#parse_in_order calls 'raise(*exc)' 2 times
       DuplicateMethodCall: OptionParser#parse_in_order calls 'setter.call(sw.switch_name, val)' 2 times
-      DuplicateMethodCall: OptionParser#parse_in_order calls 'sw.block' 2 times
       DuplicateMethodCall: OptionParser#parse_in_order calls 'sw.switch_name' 2 times
       DuplicateMethodCall: OptionParser#permute calls 'argv[0]' 2 times
       DuplicateMethodCall: OptionParser::Completion#complete calls 'candidates.size' 2 times
@@ -110,7 +107,6 @@ Feature: Basic smell detection
       DuplicateMethodCall: OptionParser::Switch#summarize calls 'left.collect' 2 times
       DuplicateMethodCall: OptionParser::Switch#summarize calls 'left.shift' 2 times
       DuplicateMethodCall: OptionParser::Switch#summarize calls 'left[-1]' 3 times
-      DuplicateMethodCall: OptionParser::Switch#summarize calls 's.length' 3 times
       FeatureEnvy: OptionParser#order refers to 'argv' more than self (maybe move it to another class?)
       FeatureEnvy: OptionParser#parse refers to 'argv' more than self (maybe move it to another class?)
       FeatureEnvy: OptionParser#permute refers to 'argv' more than self (maybe move it to another class?)
@@ -301,5 +297,5 @@ Feature: Basic smell detection
       UtilityFunction: RedCloth#lT doesn't depend on instance state (maybe move it to another class?)
       UtilityFunction: RedCloth#no_textile doesn't depend on instance state (maybe move it to another class?)
       UtilityFunction: RedCloth#v_align doesn't depend on instance state (maybe move it to another class?)
-    287 total warnings
+    283 total warnings
     """

--- a/lib/reek/smell_detectors/duplicate_method_call.rb
+++ b/lib/reek/smell_detectors/duplicate_method_call.rb
@@ -93,6 +93,70 @@ module Reek
 
       private_constant :FoundCall
 
+      # Records the block-parameter bindings referenced by each method call.
+      class BindingSignatures
+        EMPTY_SIGNATURE = [].freeze
+
+        def initialize(exp)
+          @signatures = {}.compare_by_identity
+          collect(exp, [])
+        end
+
+        def for(call_node)
+          signatures.fetch(call_node, EMPTY_SIGNATURE)
+        end
+
+        private
+
+        attr_reader :signatures
+
+        # @quality :reek:FeatureEnvy
+        # @quality :reek:TooManyStatements { max_statements: 6 }
+        def collect(node, scopes)
+          return unless node.is_a?(AST::Node)
+
+          node_type = node.type
+          signatures[node] = signature(node, scopes) if node_type == :send
+
+          if node_type == :block
+            collect_block(node, scopes)
+          else
+            node.children.each { |child| collect(child, scopes) }
+          end
+        end
+
+        def collect_block(node, scopes)
+          collect(node.call, scopes)
+          collect(node.args, scopes)
+          collect(node.block, scopes + [scope_for(node)])
+        end
+
+        # @quality :reek:UtilityFunction
+        def scope_for(block_node)
+          scope_id = block_node.object_id
+          block_node.args.components.filter_map do |argument|
+            name = argument.name
+            [name, scope_id] if name
+          end.to_h
+        end
+
+        # @quality :reek:UtilityFunction
+        def signature(call_node, scopes)
+          call_node.each_node(:lvar).filter_map do |variable|
+            binding_for(variable, scopes)
+          end.uniq.sort_by { |name, scope_id| [name.to_s, scope_id] }.freeze
+        end
+
+        # @quality :reek:UtilityFunction
+        def binding_for(variable, scopes)
+          name = variable.var_name
+          scope = scopes.reverse_each.find { |candidate| candidate.key?(name) }
+          [name, scope.fetch(name)] if scope
+        end
+      end
+
+      private_constant :BindingSignatures
+
       # Collects all calls in a given context
       class CallCollector
         attr_reader :context
@@ -104,7 +168,7 @@ module Reek
         end
 
         def calls
-          result = Hash.new { |hash, key| hash[key] = FoundCall.new(key) }
+          result = {}
           collect_calls(result)
           result.values.sort_by(&:call)
         end
@@ -117,17 +181,41 @@ module Reek
 
         attr_reader :allow_calls, :max_allowed_calls
 
-        # @quality :reek:TooManyStatements { max_statements: 6 }
+        # @quality :reek:TooManyStatements { max_statements: 8 }
         # @quality :reek:DuplicateMethodCall { max_calls: 2 }
         def collect_calls(result)
+          binding_signatures = BindingSignatures.new(context.exp)
           context.local_nodes(:send, [:mlhs]) do |call_node|
             next if call_node.object_creation_call?
             next if simple_method_call? call_node
 
-            result[call_node].record(call_node)
+            key = [call_node, binding_signatures.for(call_node), call_role(call_node)]
+            record_call(result, key, call_node)
           end
           context.local_nodes(:block) do |call_node|
-            result[call_node].record(call_node)
+            record_call(result, call_node, call_node)
+          end
+        end
+
+        # @quality :reek:UtilityFunction
+        def record_call(result, key, call_node)
+          found_call = result[key] ||= FoundCall.new(call_node)
+          found_call.record(call_node)
+        end
+
+        def call_role(call_node)
+          if compound_assignment_target_ids.include?(call_node.object_id)
+            :compound_assignment_target
+          else
+            :regular
+          end
+        end
+
+        # @quality :reek:FeatureEnvy
+        def compound_assignment_target_ids
+          @compound_assignment_target_ids ||= context.local_nodes(:op_asgn).filter_map do |node|
+            target = node.children.first
+            target.object_id if target.is_a?(AST::Node) && target.type == :send
           end
         end
 

--- a/spec/reek/smell_detectors/duplicate_method_call_spec.rb
+++ b/spec/reek/smell_detectors/duplicate_method_call_spec.rb
@@ -61,6 +61,38 @@ RSpec.describe Reek::SmellDetectors::DuplicateMethodCall do
         and reek_of(:DuplicateMethodCall, name: '@bravo.charlie.delta')
     end
 
+    it 'distinguishes same-named parameters from different blocks' do
+      src = <<-RUBY
+        def alfa
+          bravo.each { |charlie| charlie.delta }
+          echo.each { |charlie| charlie.delta }
+        end
+      RUBY
+
+      expect(src).not_to reek_of(:DuplicateMethodCall, name: 'charlie.delta')
+    end
+
+    it 'reports repeated calls on the same block parameter' do
+      src = <<-RUBY
+        def alfa
+          bravo.each { |charlie| charlie.delta + charlie.delta }
+        end
+      RUBY
+
+      expect(src).to reek_of(:DuplicateMethodCall, name: 'charlie.delta')
+    end
+
+    it 'reports repeated calls on the same outer binding across blocks' do
+      src = <<-RUBY
+        def alfa(bravo)
+          charlie.each { bravo.delta }
+          echo.each { bravo.delta }
+        end
+      RUBY
+
+      expect(src).to reek_of(:DuplicateMethodCall, name: 'bravo.delta')
+    end
+
     it 'ignores calls to new' do
       src = 'def alfa; @bravo.new + @bravo.new; end'
       expect(src).not_to reek_of(:DuplicateMethodCall)
@@ -149,6 +181,26 @@ RSpec.describe Reek::SmellDetectors::DuplicateMethodCall do
       RUBY
 
       expect(src).not_to reek_of(:DuplicateMethodCall)
+    end
+
+    it 'does not treat a compound assignment target as a repeated call' do
+      src = 'def alfa(bravo); bravo.charlie; bravo.charlie += 1; end'
+
+      expect(src).not_to reek_of(:DuplicateMethodCall, name: 'bravo.charlie')
+    end
+
+    it 'reports repeated compound assignment targets' do
+      src = 'def alfa(bravo); bravo.charlie += 1; bravo.charlie += 2; end'
+
+      expect(src).to reek_of(:DuplicateMethodCall, name: 'bravo.charlie')
+    end
+
+    it 'still reports repeated receiver calls inside a compound assignment target' do
+      src = 'def alfa(bravo); bravo.charlie.delta; bravo.charlie.delta += 1; end'
+
+      expect(src).
+        to reek_of(:DuplicateMethodCall, name: 'bravo.charlie').
+        and not_reek_of(:DuplicateMethodCall, name: 'bravo.charlie.delta')
     end
   end
 


### PR DESCRIPTION
## Summary

- distinguish identical-looking calls that refer to different block parameter bindings
- keep ordinary calls separate from compound-assignment targets while still reporting duplicated receiver prefixes
- add focused regression coverage and synchronize the sample report

## Verification

- `bundle exec rspec spec/reek/smell_detectors/duplicate_method_call_spec.rb`
- `bundle exec cucumber features/samples.feature`
- `bundle exec rake`

Closes #1813
